### PR TITLE
Correct build options names in documentation

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -59,11 +59,11 @@ Build Options
 +=========================+===================+===============+
 | FLASHLIGHT_BACKEND      | CUDA, CPU, OPENCL | CUDA          |
 +-------------------------+-------------------+---------------+
-| BUILD_DISTRIBUTED       | ON, OFF           | ON            |
+| FL_BUILD_DISTRIBUTED    | ON, OFF           | ON            |
 +-------------------------+-------------------+---------------+
-| BUILD_TESTS             | ON, OFF           | ON            |
+| FL_BUILD_TESTS          | ON, OFF           | ON            |
 +-------------------------+-------------------+---------------+
-| BUILD_EXAMPLES          | ON, OFF           | ON            |
+| FL_BUILD_EXAMPLES       | ON, OFF           | ON            |
 +-------------------------+-------------------+---------------+
 | CMAKE_BUILD_TYPE        | CMake build types | Debug         |
 +-------------------------+-------------------+---------------+


### PR DESCRIPTION
I observed some of these variables being ignored by CMake when I used their names from the docs - I've changed them to reflect the actual variables used by CMake.