### PR TITLE
support mkl installer defaults on mac

### DIFF
--- a/cmake/FindMKL.cmake
+++ b/cmake/FindMKL.cmake
@@ -88,7 +88,7 @@ IF (INTEL_MKL_DIR)
   SET(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH}
     "${INTEL_MKL_DIR}/include")
   SET(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH}
-    "${INTEL_MKL_DIR}/lib/${mklvers}")
+    "${INTEL_MKL_DIR}/lib/${mklvers};${INTEL_MKL_DIR}/lib")
   IF (MSVC)
     SET(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH}
       "${INTEL_MKL_DIR}/lib/${iccvers}")


### PR DESCRIPTION
I had the same issue as #27 after using the GUI installer for Mac provided by Intel.  There is no intel64 subdirectory in ```$MKLROOT/lib```.  The lib files are directly there:

```
$ ls /opt/intel/mkl/lib/
libmkl_avx.dylib		libmkl_core.a			libmkl_intel_lp64.dylib		libmkl_mc.dylib			libmkl_tbb_thread.a		libmkl_vml_mc.dylib
libmkl_avx2.dylib		libmkl_core.dylib		libmkl_intel_thread.a		libmkl_mc3.dylib		libmkl_tbb_thread.dylib		libmkl_vml_mc2.dylib
libmkl_avx512.dylib		libmkl_intel_ilp64.a		libmkl_intel_thread.dylib	libmkl_rt.dylib			libmkl_vml_avx.dylib		libmkl_vml_mc3.dylib
libmkl_blas95_ilp64.a		libmkl_intel_ilp64.dylib	libmkl_lapack95_ilp64.a		libmkl_sequential.a		libmkl_vml_avx2.dylib		locale
libmkl_blas95_lp64.a		libmkl_intel_lp64.a		libmkl_lapack95_lp64.a		libmkl_sequential.dylib		libmkl_vml_avx512.dylib
```