### PR TITLE
Declare zeroGrad as virtual

### DIFF
--- a/flashlight/optim/Optimizers.h
+++ b/flashlight/optim/Optimizers.h
@@ -73,7 +73,7 @@ class FirstOrderOptimizer {
   /** Zero the gradients for all the parameters being optimized. Typically
    * this will be called after every call to step().
    */
-  void zeroGrad();
+  virtual void zeroGrad();
 
   /**
    * Generates a stringified representation of the optimizer.


### PR DESCRIPTION
- Required change to build subclasses of ``FirstOrderOptimizer`` that
define zeroGrad in different ways than the base class
(which loops over the parameter vector)

This change should not influence the behaviour of the current downstream
code bases (such as wav2letter).