### PR TITLE
Fix build on mac and add WeightNorm.module() getter

### DIFF
--- a/flashlight/dataset/BlobDataset.cpp
+++ b/flashlight/dataset/BlobDataset.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <array>
 #include <thread>
 
 #include "flashlight/dataset/BlobDataset.h"

--- a/flashlight/nn/Utils.cpp
+++ b/flashlight/nn/Utils.cpp
@@ -6,6 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <array>
+
 #include "flashlight/nn/Utils.h"
 
 #include "flashlight/autograd/Utils.h"

--- a/flashlight/nn/modules/WeightNorm.cpp
+++ b/flashlight/nn/modules/WeightNorm.cpp
@@ -52,6 +52,10 @@ std::vector<Variable> WeightNorm::forward(const std::vector<Variable>& inputs) {
   return module_->forward(inputs);
 }
 
+ModulePtr WeightNorm::module() const {
+  return module_;
+}
+
 void WeightNorm::train() {
   Module::train();
   module_->train();

--- a/flashlight/nn/modules/WeightNorm.h
+++ b/flashlight/nn/modules/WeightNorm.h
@@ -76,6 +76,13 @@ class WeightNorm : public Module {
     }
   }
 
+  /**
+    * Returns a pointer to the inner `Module` normalized by this `WeightNorm`.
+    *
+    * @return a module pointer.
+    */
+  ModulePtr module() const;
+
   void train() override;
 
   void eval() override;


### PR DESCRIPTION
I'm trying to export weights from my wav2letter models and WeightNorm didn't have an obvious way of getting at the underlying Conv2d module.