### PR TITLE
use older g++ version in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,8 +57,9 @@ jobs:
             sudo docker exec -it flashlight bash -c "mkdir /flashlight"
             sudo docker cp . flashlight:/flashlight
             sudo docker exec -it flashlight bash -c "\
+            apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends g++-4.8 \
             cd /flashlight && pwd && ls && mkdir -p build && cd build && \
-            cmake .. -DCMAKE_BUILD_TYPE=Release -DFLASHLIGHT_BACKEND=CUDA && \
+            export CXX=/usr/bin/g++-4.8 && cmake .. -DCMAKE_BUILD_TYPE=Release -DFLASHLIGHT_BACKEND=CUDA && \
             make -j$(nproc) && make install && make test"
   build-cpu:
     docker:
@@ -68,7 +69,8 @@ jobs:
       - run:
           name: Build flashlight with CPU backend
           command: |
-            export MKLROOT=/opt/intel/mkl && mkdir -p build && cd build
+            apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends g++-4.8
+            export MKLROOT=/opt/intel/mkl && export CXX=/usr/bin/g++-4.8 && mkdir -p build && cd build
             cmake .. -DCMAKE_BUILD_TYPE=Release -DFLASHLIGHT_BACKEND=CPU
             make -j1 && make install
 workflows:


### PR DESCRIPTION
Summary:
- use g++4.8 for the CI and tests (to prevent new features from newest compiler)
- the newest version of g++ will be used and tested inside docker build

Reviewed By: jacobkahn

Differential Revision: D21282538

