### PR TITLE
fix circlci https://circleci.com/gh/facebookresearch/flashlight/321

### DIFF
--- a/flashlight/memory/allocator/ConfigurableMemoryAllocator.cpp
+++ b/flashlight/memory/allocator/ConfigurableMemoryAllocator.cpp
@@ -13,6 +13,7 @@
 #include <stdexcept>
 #include <utility>
 #include <algorithm>
+#include <utility>
 
 #include "flashlight/common/CppBackports.h"
 #include "flashlight/common/Logging.h"
@@ -76,7 +77,7 @@ std::unique_ptr<MemoryAllocator> CreateMemoryAllocator(
         {subArenaConfig.maxAllocationSize, std::move(subAllocator)});
     subArenaAddress = static_cast<char*>(subArenaAddress) + subAreanSize;
   }
-  return compositeAllocator;
+  return std::move(compositeAllocator);
 }
 
 }; // namespace fl


### PR DESCRIPTION
Summary: Usage of std::move() while returning an object is  needed if the return type of the function differs from the type of the local variable

Differential Revision: D21291507

