### PR TITLE
Mitigate mysterious compiler behavior with DefaultMemoryManager

### DIFF
--- a/flashlight/memory/managers/DefaultMemoryManager.cpp
+++ b/flashlight/memory/managers/DefaultMemoryManager.cpp
@@ -260,7 +260,7 @@ void DefaultMemoryManager::unlock(void* ptr, bool userUnlock) {
         current.totalBytes -= iter->second.bytes;
       }
     } else {
-      current.freeMap[bytes].emplace_back(ptr);
+      current.freeMap.at(bytes).emplace_back(ptr);
     }
     current.lockedMap.erase(iter);
   }


### PR DESCRIPTION
Summary:
With gcc 4.8.5 only, this line - https://git.io/JfOU8 - is *not called* - the entire class is completely unused; the code path is *not run*, but somehow, compiling this line causes, with any operation that frees memory:
```
root@7791a15d8856:/flashlight/build# ./tests/DevicePtrTest
[==========] Running 3 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 3 tests from DevicePtrTest
[ RUN      ] DevicePtrTest.Null
[       OK ] DevicePtrTest.Null (51 ms)
[ RUN      ] DevicePtrTest.Locking
munmap_chunk(): invalid pointer
Aborted (core dumped)
```

and a bunch of other similar failures when freeing memory in other tests. I don't have time to dig into what must be a compiler bug, but this fixes it and results in functionally identical behavior.

Differential Revision: D21325919

