### PR TITLE
make initialization function to return af::array not Variable; styling for some activations and weightNorm

### DIFF
--- a/flashlight/nn/Init.cpp
+++ b/flashlight/nn/Init.cpp
@@ -38,44 +38,52 @@ Variable param(const af::array& arr) {
   return Variable(arr, true);
 }
 
-Variable kaimingUniform(
+af::array kaimingUniform(
     af::dim4 shape,
     int fanIn,
-    af::dtype type /* = af::dtype::f32 */,
-    bool calcGrad /* = true */) {
+    af::dtype type /* = af::dtype::f32 */) {
   double stdv = std::sqrt(1.0 / static_cast<double>(fanIn));
   double limit = std::sqrt(3.0) * stdv;
-  return uniform(shape, -limit, limit, type, calcGrad);
+  af::array result = af::randu(shape, type);
+  result = 2 * limit * result - limit;
+  return result;
 }
 
-Variable kaimingNormal(
+af::array kaimingNormal(
     af::dim4 shape,
     int fanIn,
-    af::dtype type /* = af::dtype::f32 */,
-    bool calcGrad /* = true */) {
+    af::dtype type /* = af::dtype::f32 */) {
   double stdv = std::sqrt(1.0 / static_cast<double>(fanIn));
-  return normal(shape, stdv, 0, type, calcGrad);
+  af::array result = af::randn(shape, type);
+  if (stdv != 1) {
+    result = stdv * result;
+  }
+  return result;
 }
 
-Variable glorotUniform(
+af::array glorotUniform(
     af::dim4 shape,
     int fanIn,
     int fanOut,
-    af::dtype type /* = af::dtype::f32 */,
-    bool calcGrad /* = true */) {
+    af::dtype type /* = af::dtype::f32 */) {
   double stdv = std::sqrt(2.0 / static_cast<double>(fanIn + fanOut));
   double limit = std::sqrt(3.0) * stdv;
-  return uniform(shape, -limit, limit, type, calcGrad);
+  af::array result = af::randu(shape, type);
+  result = 2 * limit * result - limit;
+  return result;
 }
 
-Variable glorotNormal(
+af::array glorotNormal(
     af::dim4 shape,
     int fanIn,
     int fanOut,
-    af::dtype type /* = af::dtype::f32 */,
-    bool calcGrad /* = true */) {
+    af::dtype type /* = af::dtype::f32 */) {
   double stdv = std::sqrt(2.0 / static_cast<double>(fanIn + fanOut));
-  return normal(fanIn, stdv, 0, type, calcGrad);
+  af::array result = af::randn(shape, type);
+  if (stdv != 1) {
+    result = stdv * result;
+  }
+  return result;
 }
 
 } // namespace fl

--- a/flashlight/nn/Init.h
+++ b/flashlight/nn/Init.h
@@ -70,37 +70,28 @@ Variable param(const af::array& arr);
  * @return A `Variable` containing a tensor with random values distributed
  * accordingly.
  */
-Variable kaimingUniform(
-    af::dim4 shape,
-    int fanIn,
-    af::dtype type = af::dtype::f32,
-    bool calcGrad = true);
+af::array
+kaimingUniform(af::dim4 shape, int fanIn, af::dtype type = af::dtype::f32);
 /**
- * Creates a `Variable` representing a tensor with given input dimensions where
- * elements are normally distributed according to the method
- * outlined in [He et al (2015)](https://arxiv.org/abs/1502.01852):
- * _Delving Deep into Rectifiers: Surpassing Human-Level Performance on
- * ImageNet Classification._
+ * Creates an `af::array` representing a tensor with given input dimensions
+ * where elements are normally distributed according to the method outlined in
+ * [He et al (2015)](https://arxiv.org/abs/1502.01852): _Delving Deep into
+ * Rectifiers: Surpassing Human-Level Performance on ImageNet Classification._
  *
  * @param shape the shape of output Variable
  * @param fanIn number of input units in the Variable
  * @param type the ArrayFire datatype for which to create the tensor
- * @param calcGrad flag denoting whether gradient calculation on the resulting
- * `Variable` should be enabled
  *
- * @return A `Variable` containing a tensor with random values distributed
+ * @return An `af::array` containing a tensor with random values distributed
  * accordingly.
  */
-Variable kaimingNormal(
-    af::dim4 shape,
-    int fanIn,
-    af::dtype type = af::dtype::f32,
-    bool calcGrad = true);
+af::array
+kaimingNormal(af::dim4 shape, int fanIn, af::dtype type = af::dtype::f32);
 
 /**
- * Creates a `Variable` representing a tensor with given input dimensions where
- * elements are uniformly distributed according to the
- * method outlined in [Glorot and Bengio
+ * Creates an `af::array` representing a tensor with given input dimensions
+ * where elements are uniformly distributed according to the method outlined in
+ * [Glorot and Bengio
  * (2010)](http://proceedings.mlr.press/v9/glorot10a/glorot10a.pdf):
  * _Understanding the difficulty of training deep feedforward neural networks_.
  *
@@ -108,23 +99,20 @@ Variable kaimingNormal(
  * @param fanIn number of input units in the Variable
  * @param fanOut number of output units in the Variable
  * @param type the ArrayFire datatype with which to create the tensor
- * @param calcGrad flag denoting whether gradient calculation on the resulting
- * `Variable` should be enabled
  *
- * @return A `Variable` containing a tensor with random values distributed
+ * @return An `af::array` containing a tensor with random values distributed
  * accordingly.
  */
-Variable glorotUniform(
+af::array glorotUniform(
     af::dim4 shape,
     int fanIn,
     int fanOut,
-    af::dtype type = af::dtype::f32,
-    bool calcGrad = true);
+    af::dtype type = af::dtype::f32);
 
 /**
- * Creates a `Variable` representing a tensor with given input dimensions where
- * elements are normally distributed according to the
- * method outlined in [Glorot and Bengio
+ * Creates an `af::array` representing a tensor with given input dimensions
+ * where elements are normally distributed according to the method outlined in
+ * [Glorot and Bengio
  * (2010)](http://proceedings.mlr.press/v9/glorot10a/glorot10a.pdf):
  * _Understanding the difficulty of training deep feedforward neural
  * networks._
@@ -133,17 +121,14 @@ Variable glorotUniform(
  * @param fanIn number of input units in the Variable
  * @param fanOut number of output units in the Variable
  * @param type the ArrayFire datatype for which to create the tensor
- * @param calcGrad flag denoting whether gradient calculation on the resulting
- * `Variable` should be enabled
  *
- * @return A `Variable` containing a tensor with random values distributed
+ * @return An `af::array` containing a tensor with random values distributed
  * accordingly.
  */
-Variable glorotNormal(
+af::array glorotNormal(
     af::dim4 shape,
     int fanIn,
     int fanOut,
-    af::dtype type = af::dtype::f32,
-    bool calcGrad = true);
+    af::dtype type = af::dtype::f32);
 
 } // namespace fl

--- a/flashlight/nn/modules/Activations.cpp
+++ b/flashlight/nn/modules/Activations.cpp
@@ -81,14 +81,14 @@ std::string ReLU6::prettyString() const {
   return "ReLU6";
 }
 
-LeakyReLU::LeakyReLU(double slope) : m_slope(slope) {}
+LeakyReLU::LeakyReLU(double slope) : mSlope_(slope) {}
 
 Variable LeakyReLU::forward(const Variable& input) {
-  return max(input, m_slope * input);
+  return max(input, mSlope_ * input);
 }
 
 std::string LeakyReLU::prettyString() const {
-  return ("LeakyReLU (" + std::to_string(m_slope) + ")");
+  return "LeakyReLU (" + std::to_string(mSlope_) + ")";
 }
 
 PReLU::PReLU(const Variable& w) : UnaryModule({w}) {}
@@ -107,26 +107,26 @@ std::string PReLU::prettyString() const {
   return "PReLU";
 }
 
-ELU::ELU(double alpha) : m_alpha(alpha) {}
+ELU::ELU(double alpha) : mAlpha_(alpha) {}
 
 Variable ELU::forward(const Variable& input) {
   auto mask = input >= 0.0;
-  return (mask * input) + (!mask * m_alpha * (exp(input) - 1));
+  return (mask * input) + (!mask * mAlpha_ * (exp(input) - 1));
 }
 
 std::string ELU::prettyString() const {
-  return ("ELU (" + std::to_string(m_alpha) + ")");
+  return "ELU (" + std::to_string(mAlpha_) + ")";
 }
 
-ThresholdReLU::ThresholdReLU(double threshold) : m_threshold(threshold) {}
+ThresholdReLU::ThresholdReLU(double threshold) : mThreshold_(threshold) {}
 
 Variable ThresholdReLU::forward(const Variable& input) {
-  auto mask = input >= m_threshold;
+  auto mask = input >= mThreshold_;
   return input * mask;
 }
 
 std::string ThresholdReLU::prettyString() const {
-  return "ThresholdReLU";
+  return "ThresholdReLU (" + std::to_string(mThreshold_) + ")";
 }
 
 GatedLinearUnit::GatedLinearUnit(int dim) : dim_(dim) {}
@@ -149,7 +149,7 @@ std::string LogSoftmax::prettyString() const {
   return "LogSoftmax (" + std::to_string(dim_) + ")";
 }
 
-Swish::Swish(float beta /* = 1.0 */) : beta_(beta) {}
+Swish::Swish(double beta /* = 1.0 */) : beta_(beta) {}
 
 Variable Swish::forward(const Variable& input) {
   return input * sigmoid(beta_ * input);

--- a/flashlight/nn/modules/Activations.h
+++ b/flashlight/nn/modules/Activations.h
@@ -148,9 +148,9 @@ class ReLU6 : public UnaryModule {
  */
 class LeakyReLU : public UnaryModule {
  private:
-  double m_slope;
+  double mSlope_;
 
-  FL_SAVE_LOAD_WITH_BASE(UnaryModule, m_slope)
+  FL_SAVE_LOAD_WITH_BASE(UnaryModule, mSlope_)
 
  public:
   /**
@@ -232,9 +232,9 @@ class PReLU : public UnaryModule {
  */
 class ELU : public UnaryModule {
  private:
-  double m_alpha;
+  double mAlpha_;
 
-  FL_SAVE_LOAD_WITH_BASE(UnaryModule, m_alpha)
+  FL_SAVE_LOAD_WITH_BASE(UnaryModule, mAlpha_)
 
  public:
   ELU(double alpha = 1.0);
@@ -259,9 +259,9 @@ class ELU : public UnaryModule {
  */
 class ThresholdReLU : public UnaryModule {
  private:
-  double m_threshold;
+  double mThreshold_;
 
-  FL_SAVE_LOAD_WITH_BASE(UnaryModule, m_threshold)
+  FL_SAVE_LOAD_WITH_BASE(UnaryModule, mThreshold_)
 
  public:
   /**
@@ -332,24 +332,31 @@ class LogSoftmax : public UnaryModule {
 };
 
 /**
- * Applies the [swish activation](https://arxiv.org/abs/1710.05941)
- * function to a `Variable`
+ * Applies the swish activation function from [Ramachandran et al (2013)](
+ * https://arxiv.org/abs/1710.05941), _Searching for Activation Functions_.
+ * Applied function element-wise to a `Variable`:
  * \f[ Swish(x) = x \cdot sigmoid(\beta x) \f]
+ * where \f$\beta\f$ is a constant, often is 1.
  */
 class Swish : public UnaryModule {
  public:
-  Swish(float beta = 1.0);
+  /**
+   * Creates a `Swish` with the specified beta
+   *
+   * @param beta a constant by which the input will be multiplied in the x *
+   * sigma(beta * x)
+   */
+  Swish(double beta = 1.0);
 
   Variable forward(const Variable& input) override;
 
   std::string prettyString() const override;
 
  private:
-  float beta_;
+  double beta_;
 
   FL_SAVE_LOAD_WITH_BASE(UnaryModule, beta_)
 };
-
 
 } // namespace fl
 

--- a/flashlight/nn/modules/Conv2D.cpp
+++ b/flashlight/nn/modules/Conv2D.cpp
@@ -137,8 +137,10 @@ Variable Conv2D::forward(const Variable& input) {
 
 void Conv2D::initialize() {
   int fanIn = xFilter_ * yFilter_ * nIn_ / groups_;
-  auto wt = kaimingUniform(
-      af::dim4(xFilter_, yFilter_, nIn_ / groups_, nOut_), fanIn);
+  auto wt = Variable(
+      kaimingUniform(
+          af::dim4(xFilter_, yFilter_, nIn_ / groups_, nOut_), fanIn),
+      true);
   if (bias_) {
     double bound = std::sqrt(1.0 / fanIn);
     auto bs = uniform(af::dim4(1, 1, nOut_, 1), -bound, bound);

--- a/flashlight/nn/modules/Linear.cpp
+++ b/flashlight/nn/modules/Linear.cpp
@@ -49,7 +49,7 @@ Variable Linear::forward(const Variable& input) {
 
 void Linear::initialize() {
   int fanIn = nIn_;
-  auto w = kaimingUniform(af::dim4(nOut_, nIn_), fanIn);
+  auto w = Variable(kaimingUniform(af::dim4(nOut_, nIn_), fanIn), true);
   if (bias_) {
     double bound = std::sqrt(1.0 / fanIn);
     auto b = uniform(af::dim4(nOut_), -bound, bound);

--- a/flashlight/nn/modules/WeightNorm.cpp
+++ b/flashlight/nn/modules/WeightNorm.cpp
@@ -16,11 +16,11 @@ namespace fl {
 
 void WeightNorm::transformDims() {
   normDim_.clear();
-  int v_numdims = module_->param(0).array().numdims();
-  if (dim_ < 0 || dim_ > v_numdims) {
+  int vNumdims = module_->param(0).array().numdims();
+  if (dim_ < 0 || dim_ > vNumdims) {
     throw std::invalid_argument("invalid dimension for WeightNorm");
   }
-  for (int i = 0; i < v_numdims; i++) {
+  for (int i = 0; i < vNumdims; i++) {
     if (i != dim_) {
       normDim_.push_back(i);
     }


### PR DESCRIPTION
Summary:
- remove '_' in vars in activations and weight norm
- make initialization function return af::array (for further special scalings need) not Variable
- improve Swish activation docs

Differential Revision: D21893914

