### PR TITLE
Remove support for the default ArrayFire memory manager

### DIFF
--- a/docs/source/memory.rst
+++ b/docs/source/memory.rst
@@ -3,6 +3,16 @@
 Memory Management
 =================
 
+flashlight also contains a framework to implement and use custom memory managers for devices running computation.
+
+By default, for better performance, flashlight uses a custom memory manager (``fl::CachingMemoryManager``) implemented with this framework in place of the default ArrayFire memory manager. When flashlight is linked to, ``MemoryManagerInstaller::installDefaultMemoryManager()`` is invoked, which sets the default ArrayFire memory manager to be an instance of the ``CachingMemoryManager``. This behavior can be changed by modifying the function accordingly.
+
+A custom memory manager can be set after flashlight initializes; see the documentation for ``fl::MemoryManagerInstaller`` below for setting custom memory managers.
+
+.. warning::
+  **The default ArrayFire memory manager is no longer supported in flashlight**; using it explicitly may result in significantly degraded performance.
+
+
 Defining a Custom Memory Manager
 --------------------------------
 

--- a/flashlight/memory/MemoryManagerInstaller.h
+++ b/flashlight/memory/MemoryManagerInstaller.h
@@ -17,15 +17,6 @@
 
 namespace fl {
 
-// Warpper to af::getMemStepSize(). getMemStepSize() is defined only when
-// ArrayFire is not using a custom memory manager. This function ignores the
-// call when a custom memory manager is installed.
-size_t afGetMemStepSize();
-// Warpper to af::setMemStepSize(). setMemStepSize() is defined only when
-// ArrayFire is not using a custom memory manager. This function ignores the
-// call when a custom memory manager is installed.
-void afSetMemStepSize(size_t size);
-
 /**
  * Manages memory managers and abstracts away parts of the ArrayFire C memory
  * manager API that enables setting active memory managers in ArrayFire.

--- a/tests/memory/MemoryFrameworkTest.cpp
+++ b/tests/memory/MemoryFrameworkTest.cpp
@@ -367,11 +367,6 @@ TEST(MemoryFramework, AdapterInstallerDeviceInterfaceTest) {
         .Times(Exactly(1));
     af::printMemInfo(printInfoMsg.c_str(), printInfoDeviceId);
 
-    // test step size functions (throws with a custom memory manager as per
-    // ArrayFire behavior)
-    ASSERT_THROW(af::setMemStepSize(500), af::exception);
-    ASSERT_THROW(af::getMemStepSize(), af::exception);
-
     // all allocations are either freed or out of scope - check that the map is
     // empty
     EXPECT_TRUE(memoryManager->lockedPtrToSizeMap.empty());


### PR DESCRIPTION
Summary: Pursuant to D22290644, officially deprecate supporting the ArrayFire memory manager -- document the change and remove functions (e.g. step size things) that interact only with the default memory manager.

Differential Revision: D22328393

