### PR TITLE
clang-format

### DIFF
--- a/examples/AdaptiveClassification.cpp
+++ b/examples/AdaptiveClassification.cpp
@@ -29,8 +29,7 @@ int main(int /* unused */, const char** /* unused */) {
   model.add(Linear(feature_dim, feature_dim));
 
   std::vector<int> cutoff = {1, categories};
-  auto asActivation =
-      std::make_shared<AdaptiveSoftMax>(feature_dim, cutoff);
+  auto asActivation = std::make_shared<AdaptiveSoftMax>(feature_dim, cutoff);
 
   AdaptiveSoftMaxLoss criterion(asActivation);
   auto sgd_m = SGDOptimizer(model.params(), 1e-2);

--- a/flashlight/autograd/Functions.cpp
+++ b/flashlight/autograd/Functions.cpp
@@ -169,12 +169,11 @@ Variable operator/(const Variable& lhs, const double& rhsVal) {
 
 Variable operator/(const double& lhsVal, const Variable& rhs) {
   auto result = lhsVal / rhs.array();
-  auto gradFunc = [lhsVal](
-                      std::vector<Variable>& inputs,
-                      const Variable& gradOutput) {
-    inputs[0].addGrad(Variable(
-        (gradOutput * (-lhsVal) / (inputs[0] * inputs[0])).array(), false));
-  };
+  auto gradFunc =
+      [lhsVal](std::vector<Variable>& inputs, const Variable& gradOutput) {
+        inputs[0].addGrad(Variable(
+            (gradOutput * (-lhsVal) / (inputs[0] * inputs[0])).array(), false));
+      };
   return Variable(result, {rhs}, gradFunc);
 }
 
@@ -390,12 +389,11 @@ Variable clamp(const Variable& input, const double lo, const double hi) {
 
 Variable sqrt(const Variable& input) {
   auto result = af::sqrt(input.array());
-  auto gradFunc = [result](
-                      std::vector<Variable>& inputs,
-                      const Variable& gradOutput) {
-    auto output = Variable(result, false);
-    inputs[0].addGrad(Variable((gradOutput / (2 * output)).array(), false));
-  };
+  auto gradFunc =
+      [result](std::vector<Variable>& inputs, const Variable& gradOutput) {
+        auto output = Variable(result, false);
+        inputs[0].addGrad(Variable((gradOutput / (2 * output)).array(), false));
+      };
   return Variable(result, {input.withoutData()}, gradFunc);
 }
 
@@ -486,18 +484,17 @@ Variable concatenate(const std::vector<Variable>& concatInputs, int dim) {
     inDims.push_back(in.dims());
   }
 
-  auto gradFunc = [dim, inDims](
-                      std::vector<Variable>& inputs,
-                      const Variable& gradOutput) {
-    std::array<af::index, 4> sx{af::span, af::span, af::span, af::span};
-    int s = 0;
-    for (size_t i = 0; i < inputs.size(); ++i) {
-      sx[dim] = af::seq(s, s + inDims[i][dim] - 1);
-      inputs[i].addGrad(
-          Variable(gradOutput.array()(sx[0], sx[1], sx[2], sx[3]), false));
-      s += inDims[i][dim];
-    }
-  };
+  auto gradFunc =
+      [dim, inDims](std::vector<Variable>& inputs, const Variable& gradOutput) {
+        std::array<af::index, 4> sx{af::span, af::span, af::span, af::span};
+        int s = 0;
+        for (size_t i = 0; i < inputs.size(); ++i) {
+          sx[dim] = af::seq(s, s + inDims[i][dim] - 1);
+          inputs[i].addGrad(
+              Variable(gradOutput.array()(sx[0], sx[1], sx[2], sx[3]), false));
+          s += inDims[i][dim];
+        }
+      };
 
   return Variable(result, inputsNoData, gradFunc);
 }
@@ -676,8 +673,7 @@ Variable matmulTN(const Variable& lhs, const Variable& rhs) {
     if (inputs[1].isCalcGrad()) {
       // matmul(inputs[0], gradOutput)
       // -- matmulNT([N, M], [M, K]) -- [N, K]
-      inputs[1].addGrad(
-          Variable(matmul(inputs[0], gradOutput).array(), false));
+      inputs[1].addGrad(Variable(matmul(inputs[0], gradOutput).array(), false));
     }
   };
   return Variable(result, {lhs, rhs}, gradFunc);
@@ -696,8 +692,7 @@ Variable matmulNT(const Variable& lhs, const Variable& rhs) {
     if (inputs[0].isCalcGrad()) {
       // matmul(gradOutput, inputs[1])
       // -- matmul([M, K], [K, N]) -- [M, N]
-      inputs[0].addGrad(
-          Variable(matmul(gradOutput, inputs[1]).array(), false));
+      inputs[0].addGrad(Variable(matmul(gradOutput, inputs[1]).array(), false));
     }
     if (inputs[1].isCalcGrad()) {
       // matmulTN(gradOutput, inputs[0])
@@ -760,11 +755,10 @@ Variable moddims(const Variable& input, const af::dim4& dims) {
   auto result = af::moddims(input.array(), inferDims);
 
   af::dim4 inDims = input.dims();
-  auto gradFunc = [inDims](
-                      std::vector<Variable>& inputs,
-                      const Variable& gradOutput) {
-    inputs[0].addGrad(Variable(moddims(gradOutput, inDims).array(), false));
-  };
+  auto gradFunc =
+      [inDims](std::vector<Variable>& inputs, const Variable& gradOutput) {
+        inputs[0].addGrad(Variable(moddims(gradOutput, inDims).array(), false));
+      };
   return Variable(result, {input.withoutData()}, gradFunc);
 }
 
@@ -1009,8 +1003,7 @@ Variable embedding(const Variable& input, const Variable& embeddings) {
   Variable result = Variable(embeddings.array()(af::span, idxs), false);
 
   auto inDims = input.dims();
-  af::dim4 resultDims = {
-      embeddings.dims(0), inDims[0], inDims[1], inDims[2]};
+  af::dim4 resultDims = {embeddings.dims(0), inDims[0], inDims[1], inDims[2]};
 
   result = moddims(result, resultDims);
 
@@ -1052,11 +1045,10 @@ Variable padding(
   af::array result = af::constant(val, opDims, input.type());
   result(inSeq[0], inSeq[1], inSeq[2], inSeq[3]) = input.array();
 
-  auto gradFunc = [inSeq](
-                      std::vector<Variable>& inputs,
-                      const Variable& gradOutput) {
-    inputs[0].addGrad(gradOutput(inSeq[0], inSeq[1], inSeq[2], inSeq[3]));
-  };
+  auto gradFunc =
+      [inSeq](std::vector<Variable>& inputs, const Variable& gradOutput) {
+        inputs[0].addGrad(gradOutput(inSeq[0], inSeq[1], inSeq[2], inSeq[3]));
+      };
 
   return Variable(result, {input.withoutData()}, gradFunc);
 }

--- a/flashlight/common/CudaUtils.h
+++ b/flashlight/common/CudaUtils.h
@@ -8,9 +8,9 @@
 
 #pragma once
 
+#include <cublas_v2.h>
 #include <cuda.h>
 #include <cuda_runtime.h>
-#include <cublas_v2.h>
 
 #include <af/cuda.h>
 

--- a/flashlight/common/Utils.cpp
+++ b/flashlight/common/Utils.cpp
@@ -9,8 +9,8 @@
 #include <chrono>
 #include <cstdio>
 #include <ctime>
-#include <stdexcept>
 #include <sstream>
+#include <stdexcept>
 
 #include "flashlight/common/Utils.h"
 
@@ -74,7 +74,6 @@ size_t divRoundUp(size_t numerator, size_t denominator) {
   }
   return (numerator + denominator - 1) / denominator;
 }
-
 
 namespace {
 std::string prettyStringMemorySizeUnits(size_t size) {
@@ -177,6 +176,5 @@ std::string prettyStringCount(size_t count) {
   }
   return ss.str();
 }
-
 
 } // namespace fl

--- a/flashlight/dataset/Utils.cpp
+++ b/flashlight/dataset/Utils.cpp
@@ -8,8 +8,8 @@
 
 #include "Utils.h"
 
-#include <stdexcept>
 #include <algorithm>
+#include <stdexcept>
 
 namespace fl {
 

--- a/flashlight/dataset/datasets.h
+++ b/flashlight/dataset/datasets.h
@@ -13,7 +13,6 @@
 #include "flashlight/dataset/ConcatDataset.h"
 #include "flashlight/dataset/Dataset.h"
 #include "flashlight/dataset/DatasetIterator.h"
-#include "flashlight/dataset/Utils.h"
 #include "flashlight/dataset/FileBlobDataset.h"
 #include "flashlight/dataset/MergeDataset.h"
 #include "flashlight/dataset/PrefetchDataset.h"
@@ -21,3 +20,4 @@
 #include "flashlight/dataset/ShuffleDataset.h"
 #include "flashlight/dataset/TensorDataset.h"
 #include "flashlight/dataset/TransformDataset.h"
+#include "flashlight/dataset/Utils.h"

--- a/flashlight/memory/managers/CachingMemoryManager.cpp
+++ b/flashlight/memory/managers/CachingMemoryManager.cpp
@@ -6,8 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <arrayfire.h> // Needed for af exception
 #include "flashlight/memory/managers/CachingMemoryManager.h"
+#include <arrayfire.h> // Needed for af exception
 
 #include <algorithm>
 #include <iostream>
@@ -254,7 +254,8 @@ void CachingMemoryManager::mallocWithRetry(size_t size, void** ptr) {
       std::cerr << "Unable to allocate memory with native alloc for size " +
               std::to_string(size) + " bytes with error '" + ex.what()
                 << "'";
-      // note: converting here an af exception to std exception prevents to catch the af error code at the user level. Rethrowing.
+      // note: converting here an af exception to std exception prevents to
+      // catch the af error code at the user level. Rethrowing.
       throw;
     }
   }

--- a/flashlight/memory/memory.h
+++ b/flashlight/memory/memory.h
@@ -12,5 +12,5 @@
 #include "flashlight/memory/MemoryManagerDeviceInterface.h"
 #include "flashlight/memory/MemoryManagerInstaller.h"
 
-#include "flashlight/memory/managers/DefaultMemoryManager.h"
 #include "flashlight/memory/managers/CachingMemoryManager.h"
+#include "flashlight/memory/managers/DefaultMemoryManager.h"

--- a/flashlight/nn/Init.cpp
+++ b/flashlight/nn/Init.cpp
@@ -135,12 +135,8 @@ Variable normal(
   return normal(af::dim4(outputSize, inputSize), stdv, mean, type, calcGrad);
 }
 
-Variable normal(
-    af::dim4 dims,
-    double stdv,
-    double mean,
-    af::dtype type,
-    bool calcGrad) {
+Variable
+normal(af::dim4 dims, double stdv, double mean, af::dtype type, bool calcGrad) {
   return Variable(af::normal(dims, stdv, mean, type), calcGrad);
 }
 

--- a/flashlight/nn/Init.h
+++ b/flashlight/nn/Init.h
@@ -43,11 +43,8 @@ namespace af {
  * @return An `af::array` containing a tensor with random values distributed
  * accordingly.
  */
-af::array uniform(
-    af::dim4 dims,
-    double min = 0,
-    double max = 1,
-    af::dtype type = f32);
+af::array
+uniform(af::dim4 dims, double min = 0, double max = 1, af::dtype type = f32);
 
 /**
  * Creates an `af::array` representing a tensor of up to rank 4 with arbitrary
@@ -63,11 +60,8 @@ af::array uniform(
  * @return An `af::array` containing a tensor with random values distributed
  * accordingly.
  */
-af::array normal(
-    af::dim4 dims,
-    double stdv = 1,
-    double mean = 0,
-    af::dtype type = f32);
+af::array
+normal(af::dim4 dims, double stdv = 1, double mean = 0, af::dtype type = f32);
 
 /**
  * Creates a `af::array` representing a tensor with given input dimensions where
@@ -206,11 +200,8 @@ Variable constant(
  *
  * @return A `Variable` containing a tensor with constant values.
  */
-Variable constant(
-    double val,
-    af::dim4 dims,
-    af::dtype type = f32,
-    bool calcGrad = true);
+Variable
+constant(double val, af::dim4 dims, af::dtype type = f32, bool calcGrad = true);
 
 /**
  * Creates a `Variable` representing an identity tensor with dimensions

--- a/flashlight/nn/modules/Conv2D.h
+++ b/flashlight/nn/modules/Conv2D.h
@@ -9,8 +9,8 @@
 #pragma once
 
 #include "flashlight/common/Defines.h"
-#include "flashlight/nn/modules/Module.h"
 #include "flashlight/nn/Utils.h"
+#include "flashlight/nn/modules/Module.h"
 
 namespace fl {
 

--- a/flashlight/nn/modules/Loss.cpp
+++ b/flashlight/nn/modules/Loss.cpp
@@ -94,12 +94,13 @@ Variable AdaptiveSoftMaxLoss::cast(
   output(indices) = af::flat(input.array());
   auto inputDims = input.dims();
 
-  auto gradFunc =
-      [indices, inputDims](std::vector<Variable>& inputs, const Variable& grad_output) {
-        af::array gradArray = grad_output.array()(indices);
-        auto grad = Variable(af::moddims(gradArray, inputDims), false);
-        inputs[0].addGrad(grad);
-      };
+  auto gradFunc = [indices, inputDims](
+                      std::vector<Variable>& inputs,
+                      const Variable& grad_output) {
+    af::array gradArray = grad_output.array()(indices);
+    auto grad = Variable(af::moddims(gradArray, inputDims), false);
+    inputs[0].addGrad(grad);
+  };
   return Variable(output, {input.withoutData()}, gradFunc);
 }
 

--- a/flashlight/nn/modules/Module.cpp
+++ b/flashlight/nn/modules/Module.cpp
@@ -18,7 +18,6 @@
 
 #include "flashlight/nn/modules/Module.h"
 
-
 #include "flashlight/nn/Init.h"
 
 namespace fl {

--- a/flashlight/nn/modules/Pool2D.h
+++ b/flashlight/nn/modules/Pool2D.h
@@ -9,8 +9,8 @@
 #pragma once
 
 #include "flashlight/common/Defines.h"
-#include "flashlight/nn/modules/Module.h"
 #include "flashlight/nn/Utils.h"
+#include "flashlight/nn/modules/Module.h"
 
 namespace fl {
 

--- a/flashlight/nn/modules/WeightNorm.h
+++ b/flashlight/nn/modules/WeightNorm.h
@@ -77,10 +77,10 @@ class WeightNorm : public Module {
   }
 
   /**
-    * Returns a pointer to the inner `Module` normalized by this `WeightNorm`.
-    *
-    * @return a module pointer.
-    */
+   * Returns a pointer to the inner `Module` normalized by this `WeightNorm`.
+   *
+   * @return a module pointer.
+   */
   ModulePtr module() const;
 
   void train() override;

--- a/flashlight/nn/modules/modules.h
+++ b/flashlight/nn/modules/modules.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "flashlight/nn/Utils.h"
 #include "flashlight/nn/modules/Activations.h"
 #include "flashlight/nn/modules/AdaptiveSoftMax.h"
 #include "flashlight/nn/modules/BatchNorm.h"
@@ -24,6 +25,5 @@
 #include "flashlight/nn/modules/RNN.h"
 #include "flashlight/nn/modules/Reorder.h"
 #include "flashlight/nn/modules/Transform.h"
-#include "flashlight/nn/Utils.h"
 #include "flashlight/nn/modules/View.h"
 #include "flashlight/nn/modules/WeightNorm.h"

--- a/flashlight/optim/AdadeltaOptimizer.cpp
+++ b/flashlight/optim/AdadeltaOptimizer.cpp
@@ -18,7 +18,6 @@
 
 #include <cmath>
 
-
 namespace fl {
 
 AdadeltaOptimizer::AdadeltaOptimizer(

--- a/flashlight/optim/AdagradOptimizer.cpp
+++ b/flashlight/optim/AdagradOptimizer.cpp
@@ -18,7 +18,6 @@
 
 #include <cmath>
 
-
 namespace fl {
 
 AdagradOptimizer::AdagradOptimizer(

--- a/tests/common/LoggingTest.cpp
+++ b/tests/common/LoggingTest.cpp
@@ -23,7 +23,6 @@ using testing::Not;
 // VLOG(l) should print to stdout when VerboseLogging::setMaxLoggingLevel(i)
 // i>=l
 TEST(Logging, vlogOnOff) {
-
   LOG(INFO) << "test" << 1 << 1UL << 1L << 1.0;
   std::stringstream stdoutBuffer;
   std::stringstream stderrBuffer;
@@ -141,7 +140,7 @@ TEST(LoggingDeathTest, FatalOnOff) {
   std::cerr.rdbuf(origStderrBuffer);
 
   Logging::setMaxLoggingLevel(FATAL);
-  EXPECT_DEATH({LOG(FATAL) << "log-fatal";}, "");
+  EXPECT_DEATH({ LOG(FATAL) << "log-fatal"; }, "");
 }
 
 } // namespace

--- a/tests/memory/CachingMemoryManagerTest.cpp
+++ b/tests/memory/CachingMemoryManagerTest.cpp
@@ -18,7 +18,6 @@
 #include "flashlight/common/CppBackports.h"
 #include "flashlight/memory/memory.h"
 
-
 class CachingMemoryManagerTest : public ::testing::Test {
  protected:
   virtual void SetUp() override {
@@ -122,9 +121,9 @@ TEST_F(CachingMemoryManagerTest, OOM) {
   af_backend b;
   af_get_active_backend(&b);
   // Despite that test is trying to allocate PB of memory,
-  // depending on the drivers, afopencl does not seem to guarantee to send an OOM signal.
-  // https://github.com/arrayfire/arrayfire/issues/2650
-  // At the moment, skipping afopencl.
+  // depending on the drivers, afopencl does not seem to guarantee to send an
+  // OOM signal. https://github.com/arrayfire/arrayfire/issues/2650 At the
+  // moment, skipping afopencl.
   if (b == AF_BACKEND_OPENCL)
     GTEST_SKIP();
   af::array a;
@@ -132,9 +131,9 @@ TEST_F(CachingMemoryManagerTest, OOM) {
   const unsigned N = 99999;
   try {
     a = af::randu({N, N, N}, f32);
-  } catch(af::exception& ex) {
+  } catch (af::exception& ex) {
     ASSERT_EQ(ex.err(), AF_ERR_NO_MEM);
-  } catch(...) {
+  } catch (...) {
     EXPECT_TRUE(false) << "CachingMemoryManagerTest OOM: unexpected exception";
   }
 }


### PR DESCRIPTION
Summary:
Cleaning up both w2l and fl repo for further development and migration.

  find . -regex '.*\.\(cpp\|hpp\|cu\|cuh\|c\|h\)' -exec clang-format -style=file -assume-filename=.clang-format -i {} \;

Reviewed By: jacobkahn

Differential Revision: D22339112

