### PR TITLE
Kill carroted include paths for internal assets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,8 +228,9 @@ target_link_libraries(flashlight PUBLIC ArrayFire::${FL_AF_BACKEND})
 set(FLASHLIGHT_CORE_DIR "${PROJECT_SOURCE_DIR}/flashlight")
 include(${FLASHLIGHT_CORE_DIR}/CMakeLists.txt)
 set(INSTALLABLE_TARGETS ${INSTALLABLE_TARGETS} flashlight)
-# Make #include "flashlight/lib" work by adding to the inner incl dir
-setup_install_headers(${FLASHLIGHT_CORE_DIR} ${FL_INSTALL_INC_DIR})
+# flashlight core components keep their relative paths with respect to project
+# root and land in ${CMAKE_INSTALL_PREFIX}/include/flashlight/flashlight/*
+setup_install_headers(${FLASHLIGHT_CORE_DIR} ${FL_INSTALL_INC_DIR}/flashlight)
 
 if (FL_BUILD_CORE_ONLY)
   message(STATUS "Core-only setup complete")

--- a/app/asr/Decode.cpp
+++ b/app/asr/Decode.cpp
@@ -14,7 +14,7 @@
 #include <string>
 #include <vector>
 
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/flashlight.h"
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 

--- a/app/asr/Test.cpp
+++ b/app/asr/Test.cpp
@@ -13,7 +13,7 @@
 #include <string>
 #include <vector>
 
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/flashlight.h"
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 

--- a/app/asr/Train.cpp
+++ b/app/asr/Train.cpp
@@ -14,8 +14,8 @@
 
 #include <cereal/archives/json.hpp>
 #include <cereal/types/unordered_map.hpp>
-#include <flashlight/contrib/contrib.h>
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/contrib/contrib.h"
+#include "flashlight/flashlight/flashlight.h"
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 

--- a/app/asr/criterion/CriterionUtils.h
+++ b/app/asr/criterion/CriterionUtils.h
@@ -12,7 +12,7 @@
 #include <stdint.h>
 #include <limits>
 
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/flashlight.h"
 
 #include "flashlight/app/asr/criterion/Defines.h"
 

--- a/app/asr/criterion/ForceAlignmentCriterion.h
+++ b/app/asr/criterion/ForceAlignmentCriterion.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/flashlight.h"
 
 #include "flashlight/app/asr/criterion/CriterionUtils.h"
 #include "flashlight/app/asr/criterion/Defines.h"

--- a/app/asr/criterion/FullConnectionCriterion.h
+++ b/app/asr/criterion/FullConnectionCriterion.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/flashlight.h"
 #include "CriterionUtils.h"
 #include "Defines.h"
 

--- a/app/asr/criterion/SequenceCriterion.h
+++ b/app/asr/criterion/SequenceCriterion.h
@@ -10,7 +10,7 @@
 
 #include <stdexcept>
 
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/flashlight.h"
 
 namespace fl {
 namespace app {

--- a/app/asr/criterion/attention/AttentionBase.h
+++ b/app/asr/criterion/attention/AttentionBase.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/flashlight.h"
 
 namespace fl {
 namespace app {

--- a/app/asr/criterion/attention/Defines.h
+++ b/app/asr/criterion/attention/Defines.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/flashlight.h"
 
 namespace fl {
 namespace app {

--- a/app/asr/criterion/attention/WindowBase.h
+++ b/app/asr/criterion/attention/WindowBase.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/flashlight.h"
 
 namespace fl {
 namespace app {

--- a/app/asr/criterion/backend/cuda/ConnectionistTemporalClassificationCriterion.cpp
+++ b/app/asr/criterion/backend/cuda/ConnectionistTemporalClassificationCriterion.cpp
@@ -8,8 +8,8 @@
 
 #include <ctc.h> // warpctc
 
-#include <flashlight/autograd/autograd.h>
-#include <flashlight/common/cuda.h>
+#include "flashlight/flashlight/autograd/autograd.h"
+#include "flashlight/flashlight/common/cuda.h"
 
 #include "flashlight/app/asr/criterion/ConnectionistTemporalClassificationCriterion.h"
 #include "flashlight/app/asr/criterion/CriterionUtils.h"

--- a/app/asr/criterion/backend/cuda/CriterionUtils.cpp
+++ b/app/asr/criterion/backend/cuda/CriterionUtils.cpp
@@ -8,7 +8,7 @@
 
 #include "flashlight/app/asr/criterion/CriterionUtils.h"
 
-#include <flashlight/common/cuda.h>
+#include "flashlight/flashlight/common/cuda.h"
 
 #include "flashlight/lib/sequence/criterion/cuda/CriterionUtils.cuh"
 #include "flashlight/lib/sequence/criterion/cuda/ViterbiPath.cuh"

--- a/app/asr/criterion/backend/cuda/ForceAlignmentCriterion.cpp
+++ b/app/asr/criterion/backend/cuda/ForceAlignmentCriterion.cpp
@@ -8,7 +8,7 @@
 
 #include "flashlight/app/asr/criterion/ForceAlignmentCriterion.h"
 
-#include <flashlight/common/cuda.h>
+#include "flashlight/flashlight/common/cuda.h"
 
 #include "flashlight/lib/sequence/criterion/cuda/ForceAlignmentCriterion.cuh"
 #include "flashlight/app/asr/criterion/CriterionUtils.h"

--- a/app/asr/criterion/backend/cuda/FullConnectionCriterion.cpp
+++ b/app/asr/criterion/backend/cuda/FullConnectionCriterion.cpp
@@ -8,7 +8,7 @@
 
 #include "flashlight/app/asr/criterion/FullConnectionCriterion.h"
 
-#include <flashlight/common/cuda.h>
+#include "flashlight/flashlight/common/cuda.h"
 
 #include "flashlight/lib/sequence/criterion/cuda/FullConnectionCriterion.cuh"
 #include "flashlight/app/asr/criterion/CriterionUtils.h"

--- a/app/asr/data/Dataset.h
+++ b/app/asr/data/Dataset.h
@@ -11,7 +11,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/flashlight.h"
 
 #include "flashlight/lib/text/dictionary/Dictionary.h"
 #include "flashlight/app/asr/data/Featurize.h"

--- a/app/asr/data/FeatureTransforms.h
+++ b/app/asr/data/FeatureTransforms.h
@@ -7,7 +7,7 @@
  */
 #pragma once
 
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/flashlight.h"
 
 #include "flashlight/lib/audio/feature/FeatureParams.h"
 #include "flashlight/lib/text/dictionary/Utils.h"

--- a/app/asr/data/ListFileDataset.h
+++ b/app/asr/data/ListFileDataset.h
@@ -11,7 +11,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/flashlight.h"
 
 #include "flashlight/lib/text/dictionary/Dictionary.h"
 

--- a/app/asr/decoder/ConvLmModule.h
+++ b/app/asr/decoder/ConvLmModule.h
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include <flashlight/contrib/contrib.h>
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/contrib/contrib.h"
+#include "flashlight/flashlight/flashlight.h"
 
 namespace fl {
 namespace app {

--- a/app/asr/decoder/Defines.h
+++ b/app/asr/decoder/Defines.h
@@ -10,7 +10,7 @@
 
 #include <unordered_map>
 
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/flashlight.h"
 
 namespace fl {
 namespace app {

--- a/app/asr/experimental/tools/StreamingTDSModelConverter.cpp
+++ b/app/asr/experimental/tools/StreamingTDSModelConverter.cpp
@@ -13,7 +13,7 @@
 #include <string>
 #include <vector>
 
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/flashlight.h"
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 

--- a/app/asr/experimental/tools/VoiceActivityDetection-CTC.cpp
+++ b/app/asr/experimental/tools/VoiceActivityDetection-CTC.cpp
@@ -31,7 +31,7 @@
 #include <string>
 #include <vector>
 
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/flashlight.h"
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 

--- a/app/asr/runtime/Helpers.h
+++ b/app/asr/runtime/Helpers.h
@@ -17,7 +17,7 @@
 
 #include <unordered_set>
 
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/flashlight.h"
 
 #include "flashlight/app/asr/common/Defines.h"
 #include "flashlight/app/asr/data/BlobsDataset.h"

--- a/app/asr/runtime/Logger.h
+++ b/app/asr/runtime/Logger.h
@@ -10,7 +10,7 @@
 
 #include <map>
 
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/flashlight.h"
 
 #include "SpeechStatMeter.h"
 

--- a/app/asr/runtime/Optimizer.h
+++ b/app/asr/runtime/Optimizer.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/flashlight.h"
 
 #include "flashlight/app/asr/common/Defines.h"
 

--- a/app/asr/runtime/Serialization.h
+++ b/app/asr/runtime/Serialization.h
@@ -10,7 +10,7 @@
 
 #include <unordered_map>
 
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/flashlight.h"
 #include <glog/logging.h>
 
 #include "flashlight/lib/common/System.h"

--- a/app/asr/runtime/SpeechStatMeter.h
+++ b/app/asr/runtime/SpeechStatMeter.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/flashlight.h"
 
 namespace fl {
 namespace app {

--- a/app/asr/test/criterion/BenchmarkASG.cpp
+++ b/app/asr/test/criterion/BenchmarkASG.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/flashlight.h"
 
 #include <iomanip>
 #include <iostream>

--- a/app/asr/test/criterion/BenchmarkCTC.cpp
+++ b/app/asr/test/criterion/BenchmarkCTC.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/flashlight.h"
 
 #include <iomanip>
 #include <iostream>

--- a/app/asr/test/criterion/BenchmarkSeq2Seq.cpp
+++ b/app/asr/test/criterion/BenchmarkSeq2Seq.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/flashlight.h"
 
 #include <iomanip>
 #include <iostream>

--- a/app/asr/test/criterion/CompareASG.cpp
+++ b/app/asr/test/criterion/CompareASG.cpp
@@ -17,7 +17,7 @@
 #include <iostream>
 #include <random>
 
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/flashlight.h"
 
 #include "flashlight/app/asr/criterion/AutoSegmentationCriterion.h"
 

--- a/app/asr/test/criterion/Seq2SeqTest.cpp
+++ b/app/asr/test/criterion/Seq2SeqTest.cpp
@@ -9,7 +9,7 @@
 #include <gtest/gtest.h>
 
 #include <arrayfire.h>
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/flashlight.h"
 
 #include "flashlight/app/asr/criterion/attention/attention.h"
 #include "flashlight/app/asr/criterion/criterion.h"

--- a/app/asr/test/criterion/attention/AttentionTest.cpp
+++ b/app/asr/test/criterion/attention/AttentionTest.cpp
@@ -9,7 +9,7 @@
 #include <gtest/gtest.h>
 
 #include <arrayfire.h>
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/flashlight.h"
 
 #include "flashlight/app/asr/criterion/attention/attention.h"
 

--- a/app/asr/test/criterion/attention/WindowTest.cpp
+++ b/app/asr/test/criterion/attention/WindowTest.cpp
@@ -9,7 +9,7 @@
 #include <gtest/gtest.h>
 
 #include <arrayfire.h>
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/flashlight.h"
 
 #include "flashlight/app/asr/criterion/attention/window.h"
 

--- a/app/asr/test/data/DataTest.cpp
+++ b/app/asr/test/data/DataTest.cpp
@@ -7,7 +7,7 @@
  */
 
 #include <arrayfire.h>
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/flashlight.h"
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/app/asr/test/data/FeatureTest.cpp
+++ b/app/asr/test/data/FeatureTest.cpp
@@ -7,7 +7,7 @@
  */
 
 #include <arrayfire.h>
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/flashlight.h"
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/app/asr/test/decoder/ConvLmModuleTest.cpp
+++ b/app/asr/test/decoder/ConvLmModuleTest.cpp
@@ -9,7 +9,7 @@
 #include <gtest/gtest.h>
 
 #include <arrayfire.h>
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/flashlight.h"
 
 #include "flashlight/ext/common/SequentialBuilder.h"
 #include "flashlight/lib/common/System.h"

--- a/app/asr/test/runtime/RuntimeTest.cpp
+++ b/app/asr/test/runtime/RuntimeTest.cpp
@@ -12,7 +12,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/flashlight.h"
 
 #include "flashlight/app/asr/runtime/runtime.h"
 

--- a/ext/common/DistributedUtils.cpp
+++ b/ext/common/DistributedUtils.cpp
@@ -8,7 +8,7 @@
 
 #include "flashlight/ext/common/DistributedUtils.h"
 
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/flashlight.h"
 
 namespace fl {
 namespace ext {

--- a/ext/common/DistributedUtils.h
+++ b/ext/common/DistributedUtils.h
@@ -11,7 +11,7 @@
 #include <string>
 #include <vector>
 
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/flashlight.h"
 
 namespace fl {
 namespace ext {

--- a/ext/common/SequentialBuilder.h
+++ b/ext/common/SequentialBuilder.h
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include <flashlight/contrib/contrib.h>
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/contrib/contrib.h"
+#include "flashlight/flashlight/flashlight.h"
 
 namespace fl {
 namespace ext {

--- a/ext/common/Utils-inl.h
+++ b/ext/common/Utils-inl.h
@@ -7,7 +7,7 @@
  */
 #pragma once
 
-#include <flashlight/flashlight.h>
+#include "flashlight/flashlight/flashlight.h"
 
 namespace fl {
 namespace ext {


### PR DESCRIPTION
Summary:
tl;dr `find . -type f \( -name "*.cpp" -o -name "*.h" -o -name "*.cuh" -o -name "*.cu"  -o -name "*.hpp" \) | xargs sed -i 's|#include <flashlight/\(.*\)>|#include "flashlight/flashlight/\1"|g'`

Having carroted includes inside `flashlight` from legacy wav2letter components that were moved but not change created a world of hurt because projects that included flashlight would implicitly have their system includes searched for similar headers, which existed if you had an existing installation of flashlight. This meant duplicate definitions could occur even past `#pragma once` guards since those are based on absolute path, and identical headers could exist in system directories rather than in the correct `CMAKE_INSTALL_PREFIX` as per the user's most recent build of flashlight.

This also modifies installed header locations of flashlight core assets (those in `flashlight/flashlight`) to be in `${CMAKE_INSTALL_PREFIX}/include/flashlight/flashlight` rather than `${CMAKE_INSTALL_PREFIX}/include/flashlight` which ensures external includes work properly if they transitively include flashlight headers that use those relative paths.

Differential Revision: D23605506

