### PR TITLE
Fix LayerNorm in flashlight

### DIFF
--- a/flashlight/autograd/backend/cuda/BatchNorm.cpp
+++ b/flashlight/autograd/backend/cuda/BatchNorm.cpp
@@ -70,6 +70,15 @@ Variable batchnorm(
   const void* one = kOne(input.type());
   const void* zero = kZero(input.type());
 
+
+  if (!weight.isempty() && weight.dims()!= wt_desc_dims) {
+    throw std::invalid_argument("[BatchNorm] Invalid shape for weight.");
+  }
+
+  if (!bias.isempty() && bias.dims()!= wt_desc_dims) {
+    throw std::invalid_argument("[BatchNorm] Invalid shape for bias.");
+  }
+
   auto weight_nonempty = weight.isempty()
       ? Variable(af::constant(1.0, wt_desc_dims, input.type()), false)
       : weight;

--- a/flashlight/nn/modules/LayerNorm.cpp
+++ b/flashlight/nn/modules/LayerNorm.cpp
@@ -42,21 +42,6 @@ LayerNorm::LayerNorm(
 Variable LayerNorm::forward(const Variable& input) {
   Variable dummyInMean, dummyInVar;
 
-  auto weight = Variable();
-  auto bias = Variable();
-
-  if (affine_ && axisSize_ == kLnVariableAxisSize) {
-    af::dim4 tiledims(1, 1, 1, 1);
-    for (int ax : axisComplement_) {
-      tiledims[ax] = input.dims(ax);
-    }
-    weight = tile(params_[0], tiledims);
-    bias = tile(params_[1], tiledims);
-  } else if (affine_) {
-    weight = params_[0];
-    bias = params_[1];
-  }
-
   Variable inputToBn = input;
   std::vector<int> inNormAxes;
   // reorder is only required if axisComplement_ is not continuous
@@ -85,8 +70,8 @@ Variable LayerNorm::forward(const Variable& input) {
   }
   auto output = batchnorm(
       inputToBn,
-      weight,
-      bias,
+      Variable(),
+      Variable(),
       dummyInMean,
       dummyInVar,
       inNormAxes,
@@ -107,6 +92,24 @@ Variable LayerNorm::forward(const Variable& input) {
         restoreDims[2].second,
         restoreDims[3].second);
   }
+
+  if (affine_) {
+    Variable weight = params_[0], bias = params_[1];
+    if (axisSize_ != kLnVariableAxisSize) {
+      af::dim4 tiledims = input.dims();
+      for (int ax : axisComplement_) {
+        tiledims[ax] = 1;
+      }
+      if (tiledims.elements() != axisSize_) {
+        throw std::invalid_argument(
+            "[LayerNorm] Input size along the norm axis doesn't with axisSize.");
+      }
+      weight = moddims(params_[0], tiledims);
+      bias = moddims(params_[1], tiledims);
+    }
+    output = tileAs(weight, input) * output + tileAs(bias, input);
+  }
+
   return output;
 }
 

--- a/flashlight/nn/modules/LayerNorm.h
+++ b/flashlight/nn/modules/LayerNorm.h
@@ -36,7 +36,7 @@ class LayerNorm : public UnaryModule {
    *  and \f$\beta\f$. \f$\gamma\f$ and \f$\beta\f$ are set to 1, 0 respectively
    *  if set to `false`, or initialized as learnable parameters
    *  if set to `true`.
-   * @param axisSize size of features specified by `axis` to perform
+   * @param axisSize total size of features specified by `axis` to perform
    *  elementwise affine transform. If the feat size is variable, use
    *  `kLnVariableAxisSize` which uses singleton weight, bias and tiles them
    *  dynamically according to the given input.
@@ -57,7 +57,7 @@ class LayerNorm : public UnaryModule {
    *  and \f$\beta\f$. \f$\gamma\f$ and \f$\beta\f$ are set to 1, 0 respectively
    *  if set to `false`, or initialized as learnable parameters
    *  if set to `true`.
-   * @param featSize size of features specified by `axis` to perform
+   * @param axisSize total size of features specified by `axis` to perform
    *  elementwise affine transform. If the feat size is variable, use
    *  `kLnVariableAxisSize` which uses singleton weight, bias and tiles them
    *  dynamically according to the given input.

--- a/flashlight/test/nn/ModuleTest.cpp
+++ b/flashlight/test/nn/ModuleTest.cpp
@@ -294,7 +294,8 @@ TEST(ModuleTest, PaddingFwd) {
 TEST(ModuleTest, LayerNormFwd) {
   double eps = 1E-5;
   std::vector<int> feat_axes = {3};
-  auto input = Variable(af::randu(4, 4, 3, 10), true);
+  int F = 10;
+  auto input = Variable(af::randu(4, 4, 3, F), true);
 
   auto sample_mean = mean(input, {3});
   auto sample_var = var(input, {3}, true);
@@ -326,6 +327,13 @@ TEST(ModuleTest, LayerNormFwd) {
 
   ASSERT_TRUE(allClose(out_train.array(), out_eval.array(), eps));
   ASSERT_EQ(out_train.dims(), input.dims());
+
+   // with affine transform
+  auto module3 = LayerNorm(feat_axes, eps, true, F);
+  module3.setParams(Variable(af::constant(1.0, F), false), 0);
+  module3.setParams(Variable(af::constant(0.0, F), false), 1);
+  auto out3 = module3.forward(input);
+  ASSERT_TRUE(allClose(out_train.array(), out3.array(), eps));
 }
 
 TEST(ModuleTest, NormalizeFwd) {


### PR DESCRIPTION
Summary: Using batchnorm to perform scalar transformation is incorrect as it performs the operation on complement of axes. Fixing it by manually performing scalar operation using AF operations.

Reviewed By: tlikhomanenko

Differential Revision: D23640714

