### PR TITLE
Enhance the CachingMemoryManager to possibly handle high memory pressure

### DIFF
--- a/app/asr/CMakeLists.txt
+++ b/app/asr/CMakeLists.txt
@@ -87,9 +87,9 @@ add_executable(Train ${CMAKE_CURRENT_LIST_DIR}/Train.cpp)
 add_executable(Test ${CMAKE_CURRENT_LIST_DIR}/Test.cpp)
 add_executable(Decoder ${CMAKE_CURRENT_LIST_DIR}/Decode.cpp)
 
-target_link_libraries(Train flashlight-app-asr)
-target_link_libraries(Test flashlight-app-asr)
-target_link_libraries(Decoder flashlight-app-asr)
+target_link_libraries(Train flashlight-app-asr ${CMAKE_DL_LIBS})
+target_link_libraries(Test flashlight-app-asr ${CMAKE_DL_LIBS})
+target_link_libraries(Decoder flashlight-app-asr ${CMAKE_DL_LIBS})
 
 # --------------------------- Tests ---------------------------
 

--- a/ext/test/CMakeLists.txt
+++ b/ext/test/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.5.1)
 set(DIR ${CMAKE_CURRENT_LIST_DIR})
 set(LIBS flashlight)
 
-build_test(
-  ${DIR}/common/SequentialBuilderTest.cpp
-  ${LIBS}
-  "ARCHDIR=\"${DIR}/common/\""
+if(FL_BUILD_CONTRIB)
+  build_test(
+    ${DIR}/common/SequentialBuilderTest.cpp
+    ${LIBS}
+    "ARCHDIR=\"${DIR}/common/\""
   )
+endif()
 
 add_library(test_module_plugin MODULE
   ${DIR}/common/test_module_plugin.cpp)

--- a/flashlight/memory/managers/CachingMemoryManager.h
+++ b/flashlight/memory/managers/CachingMemoryManager.h
@@ -7,8 +7,11 @@
 
 #pragma once
 
+#include <atomic>
+#include <limits>
 #include <memory>
 #include <mutex>
+#include <numeric>
 #include <set>
 #include <unordered_map>
 #include <vector>
@@ -48,6 +51,9 @@ class CachingMemoryManager : public MemoryManagerAdapter {
   bool jitTreeExceedsMemoryPressure(size_t bytes) override;
   void addMemoryManagement(int device) override;
   void removeMemoryManagement(int device) override;
+  // Set runtime options: RecyclingSizeLimit, SplitSizeLimit, ... Warning: not thread safe
+  void setRecyclingSizeLimit(size_t);
+  void setSplitSizeLimit(size_t);
 
   // Block denotes a single allocated unit of memory.
   struct Block {
@@ -133,6 +139,15 @@ class CachingMemoryManager : public MemoryManagerAdapter {
 
   void tryMergeBlocks(Block* dst, Block* src, BlockSet& freeBlocks);
   void freeBlock(Block* block);
+
+ private:
+  // Non-const runtime options in order to fine tune the behavior of this
+  // manager. Prevents to recycle some buffers, to be set by the user if
+  // desired:
+  size_t recyclingSizeLimit_{std::numeric_limits<size_t>::max()};
+  //size_t recyclingSizeLimit;
+  // Prevents to split big buffers, to be set by the user if desired:
+  size_t splitSizeLimit_{std::numeric_limits<size_t>::max()};
 };
 
 } // namespace fl

--- a/flashlight/test/CMakeLists.txt
+++ b/flashlight/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5.1)
 
 set(DIR ${FLASHLIGHT_CORE_DIR}/test)
-set(LIBS flashlight)
+set(LIBS flashlight ${CMAKE_DL_LIBS})
 build_test(${DIR}/autograd/AutogradTest.cpp ${LIBS} "")
 build_test(${DIR}/common/DevicePtrTest.cpp ${LIBS} "")
 build_test(${DIR}/common/HistogramTest.cpp ${LIBS} "")


### PR DESCRIPTION
Enhance the CachingMemoryManager to handle high memory pressure by adding 2 options.
Note: the default behavior is unchanged.
Add a new API to MemoryManagerAdapter to setOption().
Side: remove some glog includes failing compilation if glog-dev not installed locally

**Original Issue**: 
https://github.com/facebookresearch/flashlight/issues/180
closes #180

### Summary
The CachingMemoryManager being greedy in memory. This PR adds 2 options to mitigate this.

### Test Plan (required)
Implemented a new unitest in order to show OOM with the default CachingMM and no OOM if the right option is set.
