### PR TITLE
Numerous fixes to docs

### DIFF
--- a/app/asr/Decode.cpp
+++ b/app/asr/Decode.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/Decode.cpp
+++ b/app/asr/Decode.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/Test.cpp
+++ b/app/asr/Test.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/Test.cpp
+++ b/app/asr/Test.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/Train.cpp
+++ b/app/asr/Train.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/Train.cpp
+++ b/app/asr/Train.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/common/Defines.cpp
+++ b/app/asr/common/Defines.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/common/Defines.cpp
+++ b/app/asr/common/Defines.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/common/Defines.h
+++ b/app/asr/common/Defines.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/common/Defines.h
+++ b/app/asr/common/Defines.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/AutoSegmentationCriterion.h
+++ b/app/asr/criterion/AutoSegmentationCriterion.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/AutoSegmentationCriterion.h
+++ b/app/asr/criterion/AutoSegmentationCriterion.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/ConnectionistTemporalClassificationCriterion.cpp
+++ b/app/asr/criterion/ConnectionistTemporalClassificationCriterion.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/ConnectionistTemporalClassificationCriterion.cpp
+++ b/app/asr/criterion/ConnectionistTemporalClassificationCriterion.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/ConnectionistTemporalClassificationCriterion.h
+++ b/app/asr/criterion/ConnectionistTemporalClassificationCriterion.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/ConnectionistTemporalClassificationCriterion.h
+++ b/app/asr/criterion/ConnectionistTemporalClassificationCriterion.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/CriterionUtils.cpp
+++ b/app/asr/criterion/CriterionUtils.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/CriterionUtils.cpp
+++ b/app/asr/criterion/CriterionUtils.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/CriterionUtils.h
+++ b/app/asr/criterion/CriterionUtils.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/CriterionUtils.h
+++ b/app/asr/criterion/CriterionUtils.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/Defines.h
+++ b/app/asr/criterion/Defines.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/Defines.h
+++ b/app/asr/criterion/Defines.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/ForceAlignmentCriterion.cpp
+++ b/app/asr/criterion/ForceAlignmentCriterion.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/ForceAlignmentCriterion.cpp
+++ b/app/asr/criterion/ForceAlignmentCriterion.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/ForceAlignmentCriterion.h
+++ b/app/asr/criterion/ForceAlignmentCriterion.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/ForceAlignmentCriterion.h
+++ b/app/asr/criterion/ForceAlignmentCriterion.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/FullConnectionCriterion.cpp
+++ b/app/asr/criterion/FullConnectionCriterion.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/FullConnectionCriterion.cpp
+++ b/app/asr/criterion/FullConnectionCriterion.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/FullConnectionCriterion.h
+++ b/app/asr/criterion/FullConnectionCriterion.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/FullConnectionCriterion.h
+++ b/app/asr/criterion/FullConnectionCriterion.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/LinearSegmentationCriterion.h
+++ b/app/asr/criterion/LinearSegmentationCriterion.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/LinearSegmentationCriterion.h
+++ b/app/asr/criterion/LinearSegmentationCriterion.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/Seq2SeqCriterion.cpp
+++ b/app/asr/criterion/Seq2SeqCriterion.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/Seq2SeqCriterion.cpp
+++ b/app/asr/criterion/Seq2SeqCriterion.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/Seq2SeqCriterion.h
+++ b/app/asr/criterion/Seq2SeqCriterion.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/Seq2SeqCriterion.h
+++ b/app/asr/criterion/Seq2SeqCriterion.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/SequenceCriterion.h
+++ b/app/asr/criterion/SequenceCriterion.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/SequenceCriterion.h
+++ b/app/asr/criterion/SequenceCriterion.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/TransformerCriterion.cpp
+++ b/app/asr/criterion/TransformerCriterion.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/TransformerCriterion.cpp
+++ b/app/asr/criterion/TransformerCriterion.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/TransformerCriterion.h
+++ b/app/asr/criterion/TransformerCriterion.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/TransformerCriterion.h
+++ b/app/asr/criterion/TransformerCriterion.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/attention/AttentionBase.h
+++ b/app/asr/criterion/attention/AttentionBase.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/attention/AttentionBase.h
+++ b/app/asr/criterion/attention/AttentionBase.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/attention/ContentAttention.cpp
+++ b/app/asr/criterion/attention/ContentAttention.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/attention/ContentAttention.cpp
+++ b/app/asr/criterion/attention/ContentAttention.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/attention/ContentAttention.h
+++ b/app/asr/criterion/attention/ContentAttention.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/attention/ContentAttention.h
+++ b/app/asr/criterion/attention/ContentAttention.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/attention/Defines.h
+++ b/app/asr/criterion/attention/Defines.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/attention/Defines.h
+++ b/app/asr/criterion/attention/Defines.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/attention/LocationAttention.cpp
+++ b/app/asr/criterion/attention/LocationAttention.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/attention/LocationAttention.cpp
+++ b/app/asr/criterion/attention/LocationAttention.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/attention/LocationAttention.h
+++ b/app/asr/criterion/attention/LocationAttention.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/attention/LocationAttention.h
+++ b/app/asr/criterion/attention/LocationAttention.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/attention/MedianWindow.cpp
+++ b/app/asr/criterion/attention/MedianWindow.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/attention/MedianWindow.cpp
+++ b/app/asr/criterion/attention/MedianWindow.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/attention/MedianWindow.h
+++ b/app/asr/criterion/attention/MedianWindow.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/attention/MedianWindow.h
+++ b/app/asr/criterion/attention/MedianWindow.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/attention/MultiHeadAttention.cpp
+++ b/app/asr/criterion/attention/MultiHeadAttention.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/attention/MultiHeadAttention.cpp
+++ b/app/asr/criterion/attention/MultiHeadAttention.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/attention/MultiHeadAttention.h
+++ b/app/asr/criterion/attention/MultiHeadAttention.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/attention/MultiHeadAttention.h
+++ b/app/asr/criterion/attention/MultiHeadAttention.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/attention/SoftPretrainWindow.cpp
+++ b/app/asr/criterion/attention/SoftPretrainWindow.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/attention/SoftPretrainWindow.cpp
+++ b/app/asr/criterion/attention/SoftPretrainWindow.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/attention/SoftPretrainWindow.h
+++ b/app/asr/criterion/attention/SoftPretrainWindow.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/attention/SoftPretrainWindow.h
+++ b/app/asr/criterion/attention/SoftPretrainWindow.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/attention/SoftWindow.cpp
+++ b/app/asr/criterion/attention/SoftWindow.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/attention/SoftWindow.cpp
+++ b/app/asr/criterion/attention/SoftWindow.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/attention/SoftWindow.h
+++ b/app/asr/criterion/attention/SoftWindow.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/attention/SoftWindow.h
+++ b/app/asr/criterion/attention/SoftWindow.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/attention/StepWindow.cpp
+++ b/app/asr/criterion/attention/StepWindow.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/attention/StepWindow.cpp
+++ b/app/asr/criterion/attention/StepWindow.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/attention/StepWindow.h
+++ b/app/asr/criterion/attention/StepWindow.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/attention/StepWindow.h
+++ b/app/asr/criterion/attention/StepWindow.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/attention/WindowBase.h
+++ b/app/asr/criterion/attention/WindowBase.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/attention/WindowBase.h
+++ b/app/asr/criterion/attention/WindowBase.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/attention/attention.h
+++ b/app/asr/criterion/attention/attention.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/attention/attention.h
+++ b/app/asr/criterion/attention/attention.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/attention/window.h
+++ b/app/asr/criterion/attention/window.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/attention/window.h
+++ b/app/asr/criterion/attention/window.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/backend/cpu/ConnectionistTemporalClassificationCriterion.cpp
+++ b/app/asr/criterion/backend/cpu/ConnectionistTemporalClassificationCriterion.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/backend/cpu/ConnectionistTemporalClassificationCriterion.cpp
+++ b/app/asr/criterion/backend/cpu/ConnectionistTemporalClassificationCriterion.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/backend/cpu/CriterionUtils.cpp
+++ b/app/asr/criterion/backend/cpu/CriterionUtils.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/backend/cpu/CriterionUtils.cpp
+++ b/app/asr/criterion/backend/cpu/CriterionUtils.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/backend/cpu/ForceAlignmentCriterion.cpp
+++ b/app/asr/criterion/backend/cpu/ForceAlignmentCriterion.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/backend/cpu/ForceAlignmentCriterion.cpp
+++ b/app/asr/criterion/backend/cpu/ForceAlignmentCriterion.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/backend/cpu/FullConnectionCriterion.cpp
+++ b/app/asr/criterion/backend/cpu/FullConnectionCriterion.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/backend/cpu/FullConnectionCriterion.cpp
+++ b/app/asr/criterion/backend/cpu/FullConnectionCriterion.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/backend/cuda/ConnectionistTemporalClassificationCriterion.cpp
+++ b/app/asr/criterion/backend/cuda/ConnectionistTemporalClassificationCriterion.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/backend/cuda/ConnectionistTemporalClassificationCriterion.cpp
+++ b/app/asr/criterion/backend/cuda/ConnectionistTemporalClassificationCriterion.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/backend/cuda/CriterionUtils.cpp
+++ b/app/asr/criterion/backend/cuda/CriterionUtils.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/backend/cuda/CriterionUtils.cpp
+++ b/app/asr/criterion/backend/cuda/CriterionUtils.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/backend/cuda/ForceAlignmentCriterion.cpp
+++ b/app/asr/criterion/backend/cuda/ForceAlignmentCriterion.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/backend/cuda/ForceAlignmentCriterion.cpp
+++ b/app/asr/criterion/backend/cuda/ForceAlignmentCriterion.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/backend/cuda/FullConnectionCriterion.cpp
+++ b/app/asr/criterion/backend/cuda/FullConnectionCriterion.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/backend/cuda/FullConnectionCriterion.cpp
+++ b/app/asr/criterion/backend/cuda/FullConnectionCriterion.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/criterion/criterion.h
+++ b/app/asr/criterion/criterion.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/criterion/criterion.h
+++ b/app/asr/criterion/criterion.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/data/BlobsDataset.cpp
+++ b/app/asr/data/BlobsDataset.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/data/BlobsDataset.cpp
+++ b/app/asr/data/BlobsDataset.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/data/BlobsDataset.h
+++ b/app/asr/data/BlobsDataset.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/data/BlobsDataset.h
+++ b/app/asr/data/BlobsDataset.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/data/Dataset.cpp
+++ b/app/asr/data/Dataset.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/data/Dataset.cpp
+++ b/app/asr/data/Dataset.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/data/Dataset.h
+++ b/app/asr/data/Dataset.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/data/Dataset.h
+++ b/app/asr/data/Dataset.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/data/FeatureTransforms.cpp
+++ b/app/asr/data/FeatureTransforms.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/data/FeatureTransforms.cpp
+++ b/app/asr/data/FeatureTransforms.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/data/FeatureTransforms.h
+++ b/app/asr/data/FeatureTransforms.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/data/FeatureTransforms.h
+++ b/app/asr/data/FeatureTransforms.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/data/Featurize.cpp
+++ b/app/asr/data/Featurize.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/data/Featurize.cpp
+++ b/app/asr/data/Featurize.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/data/Featurize.h
+++ b/app/asr/data/Featurize.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/data/Featurize.h
+++ b/app/asr/data/Featurize.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/data/ListFileDataset.cpp
+++ b/app/asr/data/ListFileDataset.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/data/ListFileDataset.cpp
+++ b/app/asr/data/ListFileDataset.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/data/ListFileDataset.h
+++ b/app/asr/data/ListFileDataset.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/data/ListFileDataset.h
+++ b/app/asr/data/ListFileDataset.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/data/ListFilesDataset.cpp
+++ b/app/asr/data/ListFilesDataset.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/data/ListFilesDataset.cpp
+++ b/app/asr/data/ListFilesDataset.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/data/ListFilesDataset.h
+++ b/app/asr/data/ListFilesDataset.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/data/ListFilesDataset.h
+++ b/app/asr/data/ListFilesDataset.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/data/Sound.cpp
+++ b/app/asr/data/Sound.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/data/Sound.cpp
+++ b/app/asr/data/Sound.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/data/Sound.h
+++ b/app/asr/data/Sound.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/data/Sound.h
+++ b/app/asr/data/Sound.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/data/SpeechSample.cpp
+++ b/app/asr/data/SpeechSample.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/data/SpeechSample.cpp
+++ b/app/asr/data/SpeechSample.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/data/SpeechSample.h
+++ b/app/asr/data/SpeechSample.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/data/SpeechSample.h
+++ b/app/asr/data/SpeechSample.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/data/Utils.cpp
+++ b/app/asr/data/Utils.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/data/Utils.cpp
+++ b/app/asr/data/Utils.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/data/Utils.h
+++ b/app/asr/data/Utils.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/data/Utils.h
+++ b/app/asr/data/Utils.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/decoder/ConvLmModule.cpp
+++ b/app/asr/decoder/ConvLmModule.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/decoder/ConvLmModule.cpp
+++ b/app/asr/decoder/ConvLmModule.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/decoder/ConvLmModule.h
+++ b/app/asr/decoder/ConvLmModule.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/decoder/ConvLmModule.h
+++ b/app/asr/decoder/ConvLmModule.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/decoder/Defines.h
+++ b/app/asr/decoder/Defines.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/decoder/Defines.h
+++ b/app/asr/decoder/Defines.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/decoder/TranscriptionUtils.cpp
+++ b/app/asr/decoder/TranscriptionUtils.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/decoder/TranscriptionUtils.cpp
+++ b/app/asr/decoder/TranscriptionUtils.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/decoder/TranscriptionUtils.h
+++ b/app/asr/decoder/TranscriptionUtils.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/decoder/TranscriptionUtils.h
+++ b/app/asr/decoder/TranscriptionUtils.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/decoder/TranscriptionUtils.h
+++ b/app/asr/decoder/TranscriptionUtils.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-/**
+/*
  * Generic utilities which should not depend on ArrayFire / flashlight.
  */
 

--- a/app/asr/experimental/inference/inference/common/DataType.cpp
+++ b/app/asr/experimental/inference/inference/common/DataType.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/common/DataType.cpp
+++ b/app/asr/experimental/inference/inference/common/DataType.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/common/DataType.h
+++ b/app/asr/experimental/inference/inference/common/DataType.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/common/DataType.h
+++ b/app/asr/experimental/inference/inference/common/DataType.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/common/DefaultMemoryManager.cpp
+++ b/app/asr/experimental/inference/inference/common/DefaultMemoryManager.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/common/DefaultMemoryManager.cpp
+++ b/app/asr/experimental/inference/inference/common/DefaultMemoryManager.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/common/DefaultMemoryManager.h
+++ b/app/asr/experimental/inference/inference/common/DefaultMemoryManager.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/common/DefaultMemoryManager.h
+++ b/app/asr/experimental/inference/inference/common/DefaultMemoryManager.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/common/Functions.cpp
+++ b/app/asr/experimental/inference/inference/common/Functions.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/common/Functions.cpp
+++ b/app/asr/experimental/inference/inference/common/Functions.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/common/Functions.h
+++ b/app/asr/experimental/inference/inference/common/Functions.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/common/Functions.h
+++ b/app/asr/experimental/inference/inference/common/Functions.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/common/IOBuffer.cpp
+++ b/app/asr/experimental/inference/inference/common/IOBuffer.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/common/IOBuffer.cpp
+++ b/app/asr/experimental/inference/inference/common/IOBuffer.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/common/IOBuffer.h
+++ b/app/asr/experimental/inference/inference/common/IOBuffer.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/common/IOBuffer.h
+++ b/app/asr/experimental/inference/inference/common/IOBuffer.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/common/MemoryManager.h
+++ b/app/asr/experimental/inference/inference/common/MemoryManager.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/common/MemoryManager.h
+++ b/app/asr/experimental/inference/inference/common/MemoryManager.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/common/common.h
+++ b/app/asr/experimental/inference/inference/common/common.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/common/common.h
+++ b/app/asr/experimental/inference/inference/common/common.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/decoder/Decoder.cpp
+++ b/app/asr/experimental/inference/inference/decoder/Decoder.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) 2018-present, Facebook, Inc.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/app/asr/experimental/inference/inference/decoder/Decoder.cpp
+++ b/app/asr/experimental/inference/inference/decoder/Decoder.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2018-present, Facebook, Inc.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/decoder/Decoder.h
+++ b/app/asr/experimental/inference/inference/decoder/Decoder.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) 2018-present, Facebook, Inc.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/app/asr/experimental/inference/inference/decoder/Decoder.h
+++ b/app/asr/experimental/inference/inference/decoder/Decoder.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2018-present, Facebook, Inc.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/examples/AudioToWords.cpp
+++ b/app/asr/experimental/inference/inference/examples/AudioToWords.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/examples/AudioToWords.cpp
+++ b/app/asr/experimental/inference/inference/examples/AudioToWords.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/examples/AudioToWords.h
+++ b/app/asr/experimental/inference/inference/examples/AudioToWords.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/examples/AudioToWords.h
+++ b/app/asr/experimental/inference/inference/examples/AudioToWords.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/examples/InteractiveStreamingASRExample.cpp
+++ b/app/asr/experimental/inference/inference/examples/InteractiveStreamingASRExample.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/examples/InteractiveStreamingASRExample.cpp
+++ b/app/asr/experimental/inference/inference/examples/InteractiveStreamingASRExample.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/examples/MultithreadedStreamingASRExample.cpp
+++ b/app/asr/experimental/inference/inference/examples/MultithreadedStreamingASRExample.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/examples/MultithreadedStreamingASRExample.cpp
+++ b/app/asr/experimental/inference/inference/examples/MultithreadedStreamingASRExample.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/examples/SimpleStreamingASRExample.cpp
+++ b/app/asr/experimental/inference/inference/examples/SimpleStreamingASRExample.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/examples/SimpleStreamingASRExample.cpp
+++ b/app/asr/experimental/inference/inference/examples/SimpleStreamingASRExample.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/examples/Util.cpp
+++ b/app/asr/experimental/inference/inference/examples/Util.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/examples/Util.cpp
+++ b/app/asr/experimental/inference/inference/examples/Util.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/examples/Util.h
+++ b/app/asr/experimental/inference/inference/examples/Util.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/examples/Util.h
+++ b/app/asr/experimental/inference/inference/examples/Util.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/examples/threadpool/ThreadPool.h
+++ b/app/asr/experimental/inference/inference/examples/threadpool/ThreadPool.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/examples/threadpool/ThreadPool.h
+++ b/app/asr/experimental/inference/inference/examples/threadpool/ThreadPool.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/InferenceModule.cpp
+++ b/app/asr/experimental/inference/inference/module/InferenceModule.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/InferenceModule.cpp
+++ b/app/asr/experimental/inference/inference/module/InferenceModule.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/InferenceModule.h
+++ b/app/asr/experimental/inference/inference/module/InferenceModule.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/InferenceModule.h
+++ b/app/asr/experimental/inference/inference/module/InferenceModule.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/ModuleParameter.cpp
+++ b/app/asr/experimental/inference/inference/module/ModuleParameter.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/ModuleParameter.cpp
+++ b/app/asr/experimental/inference/inference/module/ModuleParameter.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/ModuleParameter.h
+++ b/app/asr/experimental/inference/inference/module/ModuleParameter.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/ModuleParameter.h
+++ b/app/asr/experimental/inference/inference/module/ModuleParameter.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/ModuleProcessingState.cpp
+++ b/app/asr/experimental/inference/inference/module/ModuleProcessingState.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/ModuleProcessingState.cpp
+++ b/app/asr/experimental/inference/inference/module/ModuleProcessingState.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/ModuleProcessingState.h
+++ b/app/asr/experimental/inference/inference/module/ModuleProcessingState.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/ModuleProcessingState.h
+++ b/app/asr/experimental/inference/inference/module/ModuleProcessingState.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/feature/LogMelFeature.cpp
+++ b/app/asr/experimental/inference/inference/module/feature/LogMelFeature.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/feature/LogMelFeature.cpp
+++ b/app/asr/experimental/inference/inference/module/feature/LogMelFeature.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/feature/LogMelFeature.h
+++ b/app/asr/experimental/inference/inference/module/feature/LogMelFeature.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/feature/LogMelFeature.h
+++ b/app/asr/experimental/inference/inference/module/feature/LogMelFeature.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/feature/feature.h
+++ b/app/asr/experimental/inference/inference/module/feature/feature.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/feature/feature.h
+++ b/app/asr/experimental/inference/inference/module/feature/feature.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/module.h
+++ b/app/asr/experimental/inference/inference/module/module.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/module.h
+++ b/app/asr/experimental/inference/inference/module/module.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/nn/Conv1d.cpp
+++ b/app/asr/experimental/inference/inference/module/nn/Conv1d.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/nn/Conv1d.cpp
+++ b/app/asr/experimental/inference/inference/module/nn/Conv1d.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/nn/Conv1d.h
+++ b/app/asr/experimental/inference/inference/module/nn/Conv1d.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/nn/Conv1d.h
+++ b/app/asr/experimental/inference/inference/module/nn/Conv1d.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/nn/Identity.cpp
+++ b/app/asr/experimental/inference/inference/module/nn/Identity.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/nn/Identity.cpp
+++ b/app/asr/experimental/inference/inference/module/nn/Identity.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/nn/Identity.h
+++ b/app/asr/experimental/inference/inference/module/nn/Identity.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/nn/Identity.h
+++ b/app/asr/experimental/inference/inference/module/nn/Identity.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/nn/LayerNorm.cpp
+++ b/app/asr/experimental/inference/inference/module/nn/LayerNorm.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/nn/LayerNorm.cpp
+++ b/app/asr/experimental/inference/inference/module/nn/LayerNorm.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/nn/LayerNorm.h
+++ b/app/asr/experimental/inference/inference/module/nn/LayerNorm.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/nn/LayerNorm.h
+++ b/app/asr/experimental/inference/inference/module/nn/LayerNorm.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/nn/Linear.cpp
+++ b/app/asr/experimental/inference/inference/module/nn/Linear.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/nn/Linear.cpp
+++ b/app/asr/experimental/inference/inference/module/nn/Linear.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/nn/Linear.h
+++ b/app/asr/experimental/inference/inference/module/nn/Linear.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/nn/Linear.h
+++ b/app/asr/experimental/inference/inference/module/nn/Linear.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/nn/LocalNorm.cpp
+++ b/app/asr/experimental/inference/inference/module/nn/LocalNorm.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/nn/LocalNorm.cpp
+++ b/app/asr/experimental/inference/inference/module/nn/LocalNorm.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/nn/LocalNorm.h
+++ b/app/asr/experimental/inference/inference/module/nn/LocalNorm.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/nn/LocalNorm.h
+++ b/app/asr/experimental/inference/inference/module/nn/LocalNorm.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/nn/Relu.cpp
+++ b/app/asr/experimental/inference/inference/module/nn/Relu.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/nn/Relu.cpp
+++ b/app/asr/experimental/inference/inference/module/nn/Relu.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/nn/Relu.h
+++ b/app/asr/experimental/inference/inference/module/nn/Relu.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/nn/Relu.h
+++ b/app/asr/experimental/inference/inference/module/nn/Relu.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/nn/Residual.cpp
+++ b/app/asr/experimental/inference/inference/module/nn/Residual.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/nn/Residual.cpp
+++ b/app/asr/experimental/inference/inference/module/nn/Residual.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/nn/Residual.h
+++ b/app/asr/experimental/inference/inference/module/nn/Residual.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/nn/Residual.h
+++ b/app/asr/experimental/inference/inference/module/nn/Residual.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/nn/Sequential.cpp
+++ b/app/asr/experimental/inference/inference/module/nn/Sequential.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/nn/Sequential.cpp
+++ b/app/asr/experimental/inference/inference/module/nn/Sequential.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/nn/Sequential.h
+++ b/app/asr/experimental/inference/inference/module/nn/Sequential.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/nn/Sequential.h
+++ b/app/asr/experimental/inference/inference/module/nn/Sequential.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/nn/TDSBlock.cpp
+++ b/app/asr/experimental/inference/inference/module/nn/TDSBlock.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/nn/TDSBlock.cpp
+++ b/app/asr/experimental/inference/inference/module/nn/TDSBlock.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/nn/TDSBlock.h
+++ b/app/asr/experimental/inference/inference/module/nn/TDSBlock.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/nn/TDSBlock.h
+++ b/app/asr/experimental/inference/inference/module/nn/TDSBlock.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/nn/backend/fbgemm/Conv1dFbGemm.cpp
+++ b/app/asr/experimental/inference/inference/module/nn/backend/fbgemm/Conv1dFbGemm.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/nn/backend/fbgemm/Conv1dFbGemm.cpp
+++ b/app/asr/experimental/inference/inference/module/nn/backend/fbgemm/Conv1dFbGemm.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/nn/backend/fbgemm/Conv1dFbGemm.h
+++ b/app/asr/experimental/inference/inference/module/nn/backend/fbgemm/Conv1dFbGemm.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/nn/backend/fbgemm/Conv1dFbGemm.h
+++ b/app/asr/experimental/inference/inference/module/nn/backend/fbgemm/Conv1dFbGemm.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/nn/backend/fbgemm/LinearFbGemm.cpp
+++ b/app/asr/experimental/inference/inference/module/nn/backend/fbgemm/LinearFbGemm.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/nn/backend/fbgemm/LinearFbGemm.cpp
+++ b/app/asr/experimental/inference/inference/module/nn/backend/fbgemm/LinearFbGemm.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/nn/backend/fbgemm/LinearFbGemm.h
+++ b/app/asr/experimental/inference/inference/module/nn/backend/fbgemm/LinearFbGemm.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/nn/backend/fbgemm/LinearFbGemm.h
+++ b/app/asr/experimental/inference/inference/module/nn/backend/fbgemm/LinearFbGemm.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/nn/backend/fbgemm/PackedGemmMatrixFP16.cpp
+++ b/app/asr/experimental/inference/inference/module/nn/backend/fbgemm/PackedGemmMatrixFP16.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/nn/backend/fbgemm/PackedGemmMatrixFP16.cpp
+++ b/app/asr/experimental/inference/inference/module/nn/backend/fbgemm/PackedGemmMatrixFP16.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/nn/backend/fbgemm/PackedGemmMatrixFP16.h
+++ b/app/asr/experimental/inference/inference/module/nn/backend/fbgemm/PackedGemmMatrixFP16.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/nn/backend/fbgemm/PackedGemmMatrixFP16.h
+++ b/app/asr/experimental/inference/inference/module/nn/backend/fbgemm/PackedGemmMatrixFP16.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/nn/backend/fbgemm/fbgemm.h
+++ b/app/asr/experimental/inference/inference/module/nn/backend/fbgemm/fbgemm.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/nn/backend/fbgemm/fbgemm.h
+++ b/app/asr/experimental/inference/inference/module/nn/backend/fbgemm/fbgemm.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/nn/nn.h
+++ b/app/asr/experimental/inference/inference/module/nn/nn.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/nn/nn.h
+++ b/app/asr/experimental/inference/inference/module/nn/nn.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/test/Conv1dTest.cpp
+++ b/app/asr/experimental/inference/inference/module/test/Conv1dTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/test/Conv1dTest.cpp
+++ b/app/asr/experimental/inference/inference/module/test/Conv1dTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/test/IdentityTest.cpp
+++ b/app/asr/experimental/inference/inference/module/test/IdentityTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/test/IdentityTest.cpp
+++ b/app/asr/experimental/inference/inference/module/test/IdentityTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/test/LayerNormTest.cpp
+++ b/app/asr/experimental/inference/inference/module/test/LayerNormTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/test/LayerNormTest.cpp
+++ b/app/asr/experimental/inference/inference/module/test/LayerNormTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/test/LinearTest.cpp
+++ b/app/asr/experimental/inference/inference/module/test/LinearTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/test/LinearTest.cpp
+++ b/app/asr/experimental/inference/inference/module/test/LinearTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/test/LogMelFeatureTest.cpp
+++ b/app/asr/experimental/inference/inference/module/test/LogMelFeatureTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/test/LogMelFeatureTest.cpp
+++ b/app/asr/experimental/inference/inference/module/test/LogMelFeatureTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/test/MemoryManagerTest.cpp
+++ b/app/asr/experimental/inference/inference/module/test/MemoryManagerTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/test/MemoryManagerTest.cpp
+++ b/app/asr/experimental/inference/inference/module/test/MemoryManagerTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/test/ReluTest.cpp
+++ b/app/asr/experimental/inference/inference/module/test/ReluTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/test/ReluTest.cpp
+++ b/app/asr/experimental/inference/inference/module/test/ReluTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/test/ResidualTest.cpp
+++ b/app/asr/experimental/inference/inference/module/test/ResidualTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/test/ResidualTest.cpp
+++ b/app/asr/experimental/inference/inference/module/test/ResidualTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/test/TDSBlockTest.cpp
+++ b/app/asr/experimental/inference/inference/module/test/TDSBlockTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/test/TDSBlockTest.cpp
+++ b/app/asr/experimental/inference/inference/module/test/TDSBlockTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/inference/inference/module/test/TestUtils.h
+++ b/app/asr/experimental/inference/inference/module/test/TestUtils.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/inference/inference/module/test/TestUtils.h
+++ b/app/asr/experimental/inference/inference/module/test/TestUtils.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/tools/StreamingTDSModelConverter.cpp
+++ b/app/asr/experimental/tools/StreamingTDSModelConverter.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/tools/StreamingTDSModelConverter.cpp
+++ b/app/asr/experimental/tools/StreamingTDSModelConverter.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/tools/VoiceActivityDetection-CTC.cpp
+++ b/app/asr/experimental/tools/VoiceActivityDetection-CTC.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/tools/VoiceActivityDetection-CTC.cpp
+++ b/app/asr/experimental/tools/VoiceActivityDetection-CTC.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/tools/alignment/Align.cpp
+++ b/app/asr/experimental/tools/alignment/Align.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/tools/alignment/Align.cpp
+++ b/app/asr/experimental/tools/alignment/Align.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/experimental/tools/alignment/Utils.h
+++ b/app/asr/experimental/tools/alignment/Utils.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/experimental/tools/alignment/Utils.h
+++ b/app/asr/experimental/tools/alignment/Utils.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/runtime/Helpers.cpp
+++ b/app/asr/runtime/Helpers.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/runtime/Helpers.cpp
+++ b/app/asr/runtime/Helpers.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/runtime/Helpers.h
+++ b/app/asr/runtime/Helpers.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/runtime/Helpers.h
+++ b/app/asr/runtime/Helpers.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/runtime/Logger.cpp
+++ b/app/asr/runtime/Logger.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/runtime/Logger.cpp
+++ b/app/asr/runtime/Logger.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/runtime/Logger.h
+++ b/app/asr/runtime/Logger.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/runtime/Logger.h
+++ b/app/asr/runtime/Logger.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/runtime/Optimizer.cpp
+++ b/app/asr/runtime/Optimizer.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/runtime/Optimizer.cpp
+++ b/app/asr/runtime/Optimizer.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/runtime/Optimizer.h
+++ b/app/asr/runtime/Optimizer.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/runtime/Optimizer.h
+++ b/app/asr/runtime/Optimizer.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/runtime/Serialization.h
+++ b/app/asr/runtime/Serialization.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/runtime/Serialization.h
+++ b/app/asr/runtime/Serialization.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/runtime/SpeechStatMeter.cpp
+++ b/app/asr/runtime/SpeechStatMeter.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/runtime/SpeechStatMeter.cpp
+++ b/app/asr/runtime/SpeechStatMeter.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/runtime/SpeechStatMeter.h
+++ b/app/asr/runtime/SpeechStatMeter.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/runtime/SpeechStatMeter.h
+++ b/app/asr/runtime/SpeechStatMeter.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/runtime/runtime.h
+++ b/app/asr/runtime/runtime.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/runtime/runtime.h
+++ b/app/asr/runtime/runtime.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/test/criterion/BenchmarkASG.cpp
+++ b/app/asr/test/criterion/BenchmarkASG.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/test/criterion/BenchmarkASG.cpp
+++ b/app/asr/test/criterion/BenchmarkASG.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/test/criterion/BenchmarkCTC.cpp
+++ b/app/asr/test/criterion/BenchmarkCTC.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/test/criterion/BenchmarkCTC.cpp
+++ b/app/asr/test/criterion/BenchmarkCTC.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/test/criterion/BenchmarkSeq2Seq.cpp
+++ b/app/asr/test/criterion/BenchmarkSeq2Seq.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/test/criterion/BenchmarkSeq2Seq.cpp
+++ b/app/asr/test/criterion/BenchmarkSeq2Seq.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/test/criterion/CompareASG.cpp
+++ b/app/asr/test/criterion/CompareASG.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/test/criterion/CompareASG.cpp
+++ b/app/asr/test/criterion/CompareASG.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/test/criterion/CriterionTest.cpp
+++ b/app/asr/test/criterion/CriterionTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/test/criterion/CriterionTest.cpp
+++ b/app/asr/test/criterion/CriterionTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/test/criterion/Seq2SeqTest.cpp
+++ b/app/asr/test/criterion/Seq2SeqTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/test/criterion/Seq2SeqTest.cpp
+++ b/app/asr/test/criterion/Seq2SeqTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/test/criterion/attention/AttentionTest.cpp
+++ b/app/asr/test/criterion/attention/AttentionTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/test/criterion/attention/AttentionTest.cpp
+++ b/app/asr/test/criterion/attention/AttentionTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/test/criterion/attention/WindowTest.cpp
+++ b/app/asr/test/criterion/attention/WindowTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/test/criterion/attention/WindowTest.cpp
+++ b/app/asr/test/criterion/attention/WindowTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/test/data/DataTest.cpp
+++ b/app/asr/test/data/DataTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/test/data/DataTest.cpp
+++ b/app/asr/test/data/DataTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/test/data/FeatureTest.cpp
+++ b/app/asr/test/data/FeatureTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/test/data/FeatureTest.cpp
+++ b/app/asr/test/data/FeatureTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/test/data/ListFileDatasetTest.cpp
+++ b/app/asr/test/data/ListFileDatasetTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/test/data/ListFileDatasetTest.cpp
+++ b/app/asr/test/data/ListFileDatasetTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/test/data/SoundTest.cpp
+++ b/app/asr/test/data/SoundTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/test/data/SoundTest.cpp
+++ b/app/asr/test/data/SoundTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/test/decoder/ConvLmModuleTest.cpp
+++ b/app/asr/test/decoder/ConvLmModuleTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/test/decoder/ConvLmModuleTest.cpp
+++ b/app/asr/test/decoder/ConvLmModuleTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/test/decoder/DecoderTest.cpp
+++ b/app/asr/test/decoder/DecoderTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/test/decoder/DecoderTest.cpp
+++ b/app/asr/test/decoder/DecoderTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/test/runtime/RuntimeTest.cpp
+++ b/app/asr/test/runtime/RuntimeTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/asr/test/runtime/RuntimeTest.cpp
+++ b/app/asr/test/runtime/RuntimeTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/app/asr/third_party/warpctc/include/contrib/moderngpu/include/device/ctaloadbalance.cuh
+++ b/app/asr/third_party/warpctc/include/contrib/moderngpu/include/device/ctaloadbalance.cuh
@@ -1,4 +1,4 @@
-/******************************************************************************
+/*****************************************************************************
  * Copyright (c) 2013, NVIDIA CORPORATION.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/app/asr/third_party/warpctc/include/contrib/moderngpu/include/device/ctamerge.cuh
+++ b/app/asr/third_party/warpctc/include/contrib/moderngpu/include/device/ctamerge.cuh
@@ -1,4 +1,4 @@
-/******************************************************************************
+/*****************************************************************************
  * Copyright (c) 2013, NVIDIA CORPORATION.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/app/asr/third_party/warpctc/include/contrib/moderngpu/include/device/ctascan.cuh
+++ b/app/asr/third_party/warpctc/include/contrib/moderngpu/include/device/ctascan.cuh
@@ -1,4 +1,4 @@
-/******************************************************************************
+/*****************************************************************************
  * Copyright (c) 2013, NVIDIA CORPORATION.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/app/asr/third_party/warpctc/include/contrib/moderngpu/include/device/ctasearch.cuh
+++ b/app/asr/third_party/warpctc/include/contrib/moderngpu/include/device/ctasearch.cuh
@@ -1,4 +1,4 @@
-/******************************************************************************
+/*****************************************************************************
  * Copyright (c) 2013, NVIDIA CORPORATION.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/app/asr/third_party/warpctc/include/contrib/moderngpu/include/device/ctasegreduce.cuh
+++ b/app/asr/third_party/warpctc/include/contrib/moderngpu/include/device/ctasegreduce.cuh
@@ -1,4 +1,4 @@
-/******************************************************************************
+/*****************************************************************************
  * Copyright (c) 2013, NVIDIA CORPORATION.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/app/asr/third_party/warpctc/include/contrib/moderngpu/include/device/ctasegscan.cuh
+++ b/app/asr/third_party/warpctc/include/contrib/moderngpu/include/device/ctasegscan.cuh
@@ -1,4 +1,4 @@
-/******************************************************************************
+/*****************************************************************************
  * Copyright (c) 2013, NVIDIA CORPORATION.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/app/asr/third_party/warpctc/include/contrib/moderngpu/include/device/ctasegsort.cuh
+++ b/app/asr/third_party/warpctc/include/contrib/moderngpu/include/device/ctasegsort.cuh
@@ -1,4 +1,4 @@
-/******************************************************************************
+/*****************************************************************************
  * Copyright (c) 2013, NVIDIA CORPORATION.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/app/asr/third_party/warpctc/include/contrib/moderngpu/include/device/ctasortedsearch.cuh
+++ b/app/asr/third_party/warpctc/include/contrib/moderngpu/include/device/ctasortedsearch.cuh
@@ -1,4 +1,4 @@
-/******************************************************************************
+/*****************************************************************************
  * Copyright (c) 2013, NVIDIA CORPORATION.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/app/asr/third_party/warpctc/include/contrib/moderngpu/include/device/devicetypes.cuh
+++ b/app/asr/third_party/warpctc/include/contrib/moderngpu/include/device/devicetypes.cuh
@@ -1,4 +1,4 @@
-/******************************************************************************
+/*****************************************************************************
  * Copyright (c) 2013, NVIDIA CORPORATION.  All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/app/asr/third_party/warpctc/include/contrib/moderngpu/include/device/deviceutil.cuh
+++ b/app/asr/third_party/warpctc/include/contrib/moderngpu/include/device/deviceutil.cuh
@@ -1,4 +1,4 @@
-/******************************************************************************
+/*****************************************************************************
  * Copyright (c) 2013, NVIDIA CORPORATION.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/app/asr/third_party/warpctc/include/contrib/moderngpu/include/device/intrinsics.cuh
+++ b/app/asr/third_party/warpctc/include/contrib/moderngpu/include/device/intrinsics.cuh
@@ -1,4 +1,4 @@
-/******************************************************************************
+/*****************************************************************************
  * Copyright (c) 2013, NVIDIA CORPORATION.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/app/asr/third_party/warpctc/include/contrib/moderngpu/include/device/loadstore.cuh
+++ b/app/asr/third_party/warpctc/include/contrib/moderngpu/include/device/loadstore.cuh
@@ -1,4 +1,4 @@
-/******************************************************************************
+/*****************************************************************************
  * Copyright (c) 2013, NVIDIA CORPORATION.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/app/asr/third_party/warpctc/include/contrib/moderngpu/include/device/serialsets.cuh
+++ b/app/asr/third_party/warpctc/include/contrib/moderngpu/include/device/serialsets.cuh
@@ -1,4 +1,4 @@
-/******************************************************************************
+/*****************************************************************************
  * Copyright (c) 2013, NVIDIA CORPORATION.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/app/asr/third_party/warpctc/include/contrib/moderngpu/include/device/sortnetwork.cuh
+++ b/app/asr/third_party/warpctc/include/contrib/moderngpu/include/device/sortnetwork.cuh
@@ -1,4 +1,4 @@
-/******************************************************************************
+/*****************************************************************************
  * Copyright (c) 2013, NVIDIA CORPORATION.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/app/asr/third_party/warpctc/include/contrib/moderngpu/include/mgpudevice.cuh
+++ b/app/asr/third_party/warpctc/include/contrib/moderngpu/include/mgpudevice.cuh
@@ -1,4 +1,4 @@
-/******************************************************************************
+/*****************************************************************************
  * Copyright (c) 2013, NVIDIA CORPORATION.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/app/asr/third_party/warpctc/include/contrib/moderngpu/include/mgpuenums.h
+++ b/app/asr/third_party/warpctc/include/contrib/moderngpu/include/mgpuenums.h
@@ -1,4 +1,4 @@
-/******************************************************************************
+/*****************************************************************************
  * Copyright (c) 2013, NVIDIA CORPORATION.  All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/app/asr/third_party/warpctc/include/contrib/moderngpu/include/util/static.h
+++ b/app/asr/third_party/warpctc/include/contrib/moderngpu/include/util/static.h
@@ -1,4 +1,4 @@
-/******************************************************************************
+/*****************************************************************************
  * Copyright (c) 2013, NVIDIA CORPORATION.  All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/bindings/python/flashlight/lib/audio/_feature.cpp
+++ b/bindings/python/flashlight/lib/audio/_feature.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/bindings/python/flashlight/lib/audio/_feature.cpp
+++ b/bindings/python/flashlight/lib/audio/_feature.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/bindings/python/flashlight/lib/sequence/_criterion.cpp
+++ b/bindings/python/flashlight/lib/sequence/_criterion.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/bindings/python/flashlight/lib/sequence/_criterion.cpp
+++ b/bindings/python/flashlight/lib/sequence/_criterion.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/bindings/python/flashlight/lib/text/_decoder.cpp
+++ b/bindings/python/flashlight/lib/text/_decoder.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/bindings/python/flashlight/lib/text/_decoder.cpp
+++ b/bindings/python/flashlight/lib/text/_decoder.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/bindings/python/flashlight/lib/text/_dictionary.cpp
+++ b/bindings/python/flashlight/lib/text/_dictionary.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/bindings/python/flashlight/lib/text/_dictionary.cpp
+++ b/bindings/python/flashlight/lib/text/_dictionary.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/docs/source/common.rst
+++ b/docs/source/common.rst
@@ -1,9 +1,11 @@
 Common
 ======
 
-.. doxygenfile:: Defines.h
+.. doxygengroup:: common_defines
+    :content-only:
 
-.. doxygenfile:: common/Utils.h
+.. doxygengroup:: common_utils
+    :content-only:
 
 .. doxygenclass:: fl::DevicePtr
    :members:

--- a/docs/source/data_loading.rst
+++ b/docs/source/data_loading.rst
@@ -66,4 +66,5 @@ PrefetchDataset
 
 Utils
 -----
-.. doxygenfile:: dataset/Utils.h
+.. doxygengroup:: dataset_utils
+    :content-only:

--- a/docs/source/dist.rst
+++ b/docs/source/dist.rst
@@ -1,7 +1,8 @@
 Distributed Library
 ===================
 
-.. doxygenfile:: DistributedApi.h
+.. doxygengroup:: distributed_api
+    :content-only:
 
 
 Reducer Framework

--- a/docs/source/functions.rst
+++ b/docs/source/functions.rst
@@ -3,6 +3,8 @@
 Functions
 ---------
 
-.. doxygenfile:: Functions.h
+.. doxygengroup:: autograd_functions
+    :content-only:
 
-.. doxygenfile:: autograd/Utils.h
+.. doxygengroup:: autograd_utils
+    :content-only:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -31,6 +31,7 @@ A C++ library for machine learning.
    optimization
    data_loading
    dist
+   logging
    memory
    meters
    serial

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -168,12 +168,15 @@ MeanSquaredError
 
 Initialization
 --------------
-.. doxygenfile:: nn/Init.h
+
+.. doxygengroup:: nn_init_utils
 
 Utils
 --------------
-.. doxygenfile:: nn/Utils.h
+.. doxygengroup:: nn_utils
+    :content-only:
 
 DistributedUtils
 ----------------
-.. doxygenfile:: nn/DistributedUtils.h
+.. doxygengroup:: nn_distributed_utils
+    :content-only:

--- a/docs/source/serial.rst
+++ b/docs/source/serial.rst
@@ -3,14 +3,4 @@
 Serialization Library
 =====================
 
-.. doxygenfile:: common/Serialization.h
-
-.. cpp:function:: template <typename... Args> void save(const std::string& filepath, const Args&... args)
-
-.. cpp:function:: template <typename... Args> void save(std::ostream& ostr, const Args&... args)
-
-.. cpp:function:: template <typename... Args> void load(const std::string& filepath, Args&... args)
-
-.. cpp:function:: template <typename... Args> void load(std::istream& istr, Args&... args)
-
-.. cpp:function::  template <typename T> detail::Versioned<T> versioned(T&& t, uint32_t minVersion, uint32_t maxVersion = UINT32_MAX);
+.. doxygengroup:: serialization_library

--- a/ext/common/DistributedUtils.cpp
+++ b/ext/common/DistributedUtils.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/ext/common/DistributedUtils.cpp
+++ b/ext/common/DistributedUtils.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/ext/common/DistributedUtils.h
+++ b/ext/common/DistributedUtils.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/ext/common/DistributedUtils.h
+++ b/ext/common/DistributedUtils.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/ext/common/SequentialBuilder.cpp
+++ b/ext/common/SequentialBuilder.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/ext/common/SequentialBuilder.cpp
+++ b/ext/common/SequentialBuilder.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/ext/common/SequentialBuilder.h
+++ b/ext/common/SequentialBuilder.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/ext/common/SequentialBuilder.h
+++ b/ext/common/SequentialBuilder.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/ext/common/Utils-inl.h
+++ b/ext/common/Utils-inl.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/ext/common/Utils-inl.h
+++ b/ext/common/Utils-inl.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/ext/test/common/SequentialBuilderTest.cpp
+++ b/ext/test/common/SequentialBuilderTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/ext/test/common/SequentialBuilderTest.cpp
+++ b/ext/test/common/SequentialBuilderTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/autograd/Functions.cpp
+++ b/flashlight/autograd/Functions.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/autograd/Functions.cpp
+++ b/flashlight/autograd/Functions.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/autograd/Functions.h
+++ b/flashlight/autograd/Functions.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/autograd/Functions.h
+++ b/flashlight/autograd/Functions.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/autograd/Functions.h
+++ b/flashlight/autograd/Functions.h
@@ -31,6 +31,11 @@ af::array sumAs(const af::array& input, const af::dim4& rdims);
 class Variable;
 
 /**
+ * \defgroup autograd_functions Autograd Functions
+ * @{
+ */
+
+/**
  * Element-wise addition of two Variables.
  * \f[ out = var_1 + var_2 \f]
  */
@@ -824,5 +829,7 @@ Variable relu(const Variable& input);
  * element-wise to a `Variable`
  */
 Variable gelu(const Variable& input);
+
+/** @} */
 
 } // namespace fl

--- a/flashlight/autograd/Utils.cpp
+++ b/flashlight/autograd/Utils.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/autograd/Utils.cpp
+++ b/flashlight/autograd/Utils.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/autograd/Utils.h
+++ b/flashlight/autograd/Utils.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/autograd/Utils.h
+++ b/flashlight/autograd/Utils.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/autograd/Utils.h
+++ b/flashlight/autograd/Utils.h
@@ -12,6 +12,11 @@
 namespace fl {
 
 /**
+ * \defgroup autograd_utils Autograd Utils
+ * @{
+ */
+
+/**
  * Returns true if two Variable are of same type and are element-wise equal
  * within given tolerance limit.
  *
@@ -20,5 +25,7 @@ namespace fl {
  *
  */
 bool allClose(const Variable& a, const Variable& b, double absTolerance = 1e-5);
+
+/** @} */
 
 } // namespace fl

--- a/flashlight/autograd/Variable.cpp
+++ b/flashlight/autograd/Variable.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/autograd/Variable.cpp
+++ b/flashlight/autograd/Variable.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/autograd/Variable.h
+++ b/flashlight/autograd/Variable.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/autograd/Variable.h
+++ b/flashlight/autograd/Variable.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/autograd/autograd.h
+++ b/flashlight/autograd/autograd.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/autograd/autograd.h
+++ b/flashlight/autograd/autograd.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/autograd/backend/cpu/BatchNorm.cpp
+++ b/flashlight/autograd/backend/cpu/BatchNorm.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/autograd/backend/cpu/BatchNorm.cpp
+++ b/flashlight/autograd/backend/cpu/BatchNorm.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/autograd/backend/cpu/Conv2D.cpp
+++ b/flashlight/autograd/backend/cpu/Conv2D.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/autograd/backend/cpu/Conv2D.cpp
+++ b/flashlight/autograd/backend/cpu/Conv2D.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/autograd/backend/cpu/MkldnnUtils.cpp
+++ b/flashlight/autograd/backend/cpu/MkldnnUtils.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/autograd/backend/cpu/MkldnnUtils.cpp
+++ b/flashlight/autograd/backend/cpu/MkldnnUtils.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/autograd/backend/cpu/MkldnnUtils.h
+++ b/flashlight/autograd/backend/cpu/MkldnnUtils.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/autograd/backend/cpu/MkldnnUtils.h
+++ b/flashlight/autograd/backend/cpu/MkldnnUtils.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/autograd/backend/cpu/Pool2D.cpp
+++ b/flashlight/autograd/backend/cpu/Pool2D.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/autograd/backend/cpu/Pool2D.cpp
+++ b/flashlight/autograd/backend/cpu/Pool2D.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/autograd/backend/cpu/RNN.cpp
+++ b/flashlight/autograd/backend/cpu/RNN.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/autograd/backend/cpu/RNN.cpp
+++ b/flashlight/autograd/backend/cpu/RNN.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/autograd/backend/cuda/BatchNorm.cpp
+++ b/flashlight/autograd/backend/cuda/BatchNorm.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/autograd/backend/cuda/BatchNorm.cpp
+++ b/flashlight/autograd/backend/cuda/BatchNorm.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/autograd/backend/cuda/Conv2D.cpp
+++ b/flashlight/autograd/backend/cuda/Conv2D.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/autograd/backend/cuda/Conv2D.cpp
+++ b/flashlight/autograd/backend/cuda/Conv2D.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/autograd/backend/cuda/CudnnUtils.cpp
+++ b/flashlight/autograd/backend/cuda/CudnnUtils.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/autograd/backend/cuda/CudnnUtils.cpp
+++ b/flashlight/autograd/backend/cuda/CudnnUtils.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/autograd/backend/cuda/CudnnUtils.h
+++ b/flashlight/autograd/backend/cuda/CudnnUtils.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/autograd/backend/cuda/CudnnUtils.h
+++ b/flashlight/autograd/backend/cuda/CudnnUtils.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/autograd/backend/cuda/Pool2D.cpp
+++ b/flashlight/autograd/backend/cuda/Pool2D.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/autograd/backend/cuda/Pool2D.cpp
+++ b/flashlight/autograd/backend/cuda/Pool2D.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/autograd/backend/cuda/RNN.cpp
+++ b/flashlight/autograd/backend/cuda/RNN.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/autograd/backend/cuda/RNN.cpp
+++ b/flashlight/autograd/backend/cuda/RNN.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/common/CppBackports.h
+++ b/flashlight/common/CppBackports.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/common/CppBackports.h
+++ b/flashlight/common/CppBackports.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/common/CudaUtils.cpp
+++ b/flashlight/common/CudaUtils.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/common/CudaUtils.cpp
+++ b/flashlight/common/CudaUtils.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/common/CudaUtils.h
+++ b/flashlight/common/CudaUtils.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/common/CudaUtils.h
+++ b/flashlight/common/CudaUtils.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/common/Defines.cpp
+++ b/flashlight/common/Defines.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/common/Defines.cpp
+++ b/flashlight/common/Defines.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/common/Defines.h
+++ b/flashlight/common/Defines.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/common/Defines.h
+++ b/flashlight/common/Defines.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/common/Defines.h
+++ b/flashlight/common/Defines.h
@@ -12,6 +12,11 @@
 namespace fl {
 
 /**
+ * \defgroup common_defines Common constants and definitions
+ * @{
+ */
+
+/**
  * Reduction mode to used for CrossEntropy, AdaptiveSoftMax etc ...
  */
 enum class ReduceMode {
@@ -69,5 +74,7 @@ struct DistributedConstants {
   static constexpr const std::size_t kCoalesceCacheSize =
       ((size_t)(20) << 20); // 20 MB
 };
+
+/** @} */
 
 } // namespace fl

--- a/flashlight/common/DevicePtr.cpp
+++ b/flashlight/common/DevicePtr.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/common/DevicePtr.cpp
+++ b/flashlight/common/DevicePtr.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/common/DevicePtr.h
+++ b/flashlight/common/DevicePtr.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/common/DevicePtr.h
+++ b/flashlight/common/DevicePtr.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/common/Histogram.cpp
+++ b/flashlight/common/Histogram.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/common/Histogram.cpp
+++ b/flashlight/common/Histogram.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/common/Histogram.h
+++ b/flashlight/common/Histogram.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/common/Histogram.h
+++ b/flashlight/common/Histogram.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/common/Logging.cpp
+++ b/flashlight/common/Logging.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/common/Logging.cpp
+++ b/flashlight/common/Logging.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/common/Logging.h
+++ b/flashlight/common/Logging.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/common/Logging.h
+++ b/flashlight/common/Logging.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/common/Logging.h
+++ b/flashlight/common/Logging.h
@@ -6,37 +6,6 @@
  *
  */
 
-/**
- * Logging is a light, multi-level, compile time filterable, logging
- * infrastructure that is similar to glog in output format. It defines two
- * logging macros, one for any logging and the other for more verbose logging.
- * Compile time filter is applied separately to each of the two.
- *
- * Output format:
- * LMMDD HH:MM:SS.uuuuuu tid filename:##] Log message ...
- *  L: Log level (Fatal, Critical, Error, Warning, Info)
- * MMDD: month, day
- * HH:MM:SS.uuuuuu: time (24-hour format) with micro-seconds
- * tid: thread ID
- * filename:## the basename of the source file and line number of the LOG
- * message
- *
- * LOG use examples:
- *   LOG(INFO) << "foo bar n=" << 42;
- * Output example:
- *   I0206 10:42:21.047293 87072 Logging.h:15 foo bar n=42
- * Note that LOG(level) only prints when level is <= from value set to
- * Logging::setMaxLoggingLevel(level)
- *
- * VLOG use example:
- *   VLOG(1) << "foo bar n=" << 42;
- * Output example:
- *   vlog(1)0206 10:42:21.005439 87072 Logging.h:23 foo bar n=42
- * Note that VLOG(level) only prints when level is <= from value set to
- * VerboseLogging::setMaxLoggingLevel(level)
- *
- */
-
 #pragma once
 
 #include <signal.h>
@@ -46,6 +15,58 @@
 #include <utility>
 
 namespace fl {
+
+/**
+ * \defgroup logging Logging Library
+ *
+ * Logging is a light, multi-level, compile-time-filterable, logging
+ * framework that is similar to [glog](https://github.com/google/glog) in output
+ * format. It defines two logging macros, one for conventional logging and the
+ * other for verbose logging. Compile time filtering is applied separately to
+ * each of the two.
+ *
+ * Output formatsdfds:
+ * \code
+ * LMMDD HH:MM:SS.uuuuuu tid filename:##] Log message ...
+ * \endcode
+ *
+ * Where:
+ * \code
+ * L: Log level {Fatal, Critical, Error, Warning, Info}
+ * MMDD: month, day
+ * HH:MM:SS.uuuuuu: time (24-hour format) with micro-seconds
+ * tid: thread ID
+ * filename:## basename of the source file and line number of the LOG message
+ * \endcode
+ *
+ * Example:
+ * \code
+ * LOG(INFO) << "foo bar n=" << 42;
+ * \endcode
+ *
+ * Gives output:
+ * \code
+ * I0206 10:42:21.047293 87072 Logging.h:15 foo bar n=42
+ * \endcode
+ *
+ * Note that `LOG(level)` only prints when level is less than or equal to the
+ * value set via `Logging`` Example with `VLOG`:
+ * \code
+ * VLOG(1) << "foo bar n=" << 42;
+ * \endcode
+ *
+ * Gives output:
+ *
+ * \code
+ * vlog(1) 0206 10:42:21.005439 87072 Logging.h:23 foo bar n=42
+ * \endcode
+ *
+ * Note that `VLOG(level)` only prints when level is less than or equal to the
+ * value set to `VerboseLogging`
+ *
+ * @{
+ */
+
 enum LogLevel {
   DISABLE_LOGGING, // use only for when calling setMaxLoggingLevel() or
   // setting DEFUALT_MAX_LOGGING_LEVEL.
@@ -55,11 +76,11 @@ enum LogLevel {
   INFO,
 };
 
-// DEFUALT_MAX_LOGGING_LEVEL is used for globaly limit LOG(level).
+/// `DEFUALT_MAX_LOGGING_LEVEL` is used for globaly limit `LOG(level)`.
 constexpr LogLevel DEFUALT_MAX_LOGGING_LEVEL = LogLevel::INFO;
-// MAX_VERBOSE_LOGGING_LEVEL values are based on the values used in VLOG()
-// and can be any value, but expected reasonable values are: 0..10
-// for print none and print all respectively.
+/// `MAX_VERBOSE_LOGGING_LEVEL` values are based on the values used in `VLOG()`
+/// and can be any value, but expected reasonable values are: `{0..10}`
+/// for print none and print all respectively.
 constexpr int DEFUALT_MAX_VERBOSE_LOGGING_LEVEL = 1;
 
 #define LOG(level) Logging(level, __FILE__, __LINE__)
@@ -67,6 +88,8 @@ constexpr int DEFUALT_MAX_VERBOSE_LOGGING_LEVEL = 1;
 
 #define IFLOG(level) if (Logging::ifLog(level))
 #define IFVLOG(level) if (VerboseLogging::ifLog(level))
+
+/** @} */
 
 class Logging {
  public:

--- a/flashlight/common/Serialization-inl.h
+++ b/flashlight/common/Serialization-inl.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/common/Serialization-inl.h
+++ b/flashlight/common/Serialization-inl.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/common/Serialization.h
+++ b/flashlight/common/Serialization.h
@@ -1,6 +1,5 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/common/Serialization.h
+++ b/flashlight/common/Serialization.h
@@ -4,11 +4,9 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 /**
  * @file common/Serialization.h
- *
- * Serialization support using the Cereal library. Provides serialization
- * functions for `af::array` and `af::dim4` and convenience utilities.
  */
 
 #pragma once
@@ -26,6 +24,29 @@
 #include <cereal/types/vector.hpp>
 
 namespace fl {
+
+/**
+ * \defgroup serialization_library Serialization Library
+ *
+ * Serialization support using the `cereal` library. Provides serialization
+ * functions for `af::array` and `af::dim4` and convenience utilities.
+ *
+ * Note the following guidelines for serialization:
+ * - By default you should use save/load pairs and explicit versioning.
+ *   The provided macros encourage this usage.
+ * - Saving an object must not mutate it. `save()` being `const` helps, but
+ *   be careful about `Variable` which is a `shared_ptr` to non-const.
+ * - Loading an object must provide the basic exception guarantee. After an
+ *   exception, the object must be safe to destroy and no leaks can occur.
+ * - For simplicity, `load()` may assume that the initial state of the
+ *   object is default-constructed. Conversely, one must only call `load()`
+ *   on a default-constructed object.
+ * - Avoid serializing `long`, `size_t`, and ArrayFire's `dim_t` since these
+ *   types have platform-dependent sizes. Fixed-size types like `int64_t` are
+ *   always fine. `int`, `long long` should be fine on virtually all platforms.
+ *
+ * @{
+ */
 
 /**
  * Save (serialize) the specified args to a binary file (via Cereal).
@@ -58,22 +79,13 @@ void load(const std::string& filepath, Args&... args);
  */
 template <typename... Args>
 void load(std::istream& istr, Args&... args);
+
+/** @} */
 } // namespace fl
 
 /**
- * Note the following guidelines for serialization:
- * - By default you should use save/load pairs and explicit versioning.
- *   The provided macros encourage this usage.
- * - Saving an object must not mutate it. `save()` being `const` helps, but
- *   be careful about `Variable` which is a `shared_ptr` to non-const.
- * - Loading an object must provide the basic exception guarantee. After an
- *   exception, the object must be safe to destroy and no leaks can occur.
- * - For simplicity, `load()` may assume that the initial state of the
- *   object is default-constructed. Conversely, one must only call `load()`
- *   on a default-constructed object.
- * - Avoid serializing `long`, `size_t`, and ArrayFire's `dim_t` since these
- *   types have platform-dependent sizes. Fixed-size types like `int64_t` are
- *   always fine. `int`, `long long` should be fine on virtually all platforms.
+ * \addtogroup serialization_library Serialization Library
+ * @{
  */
 
 /**
@@ -119,6 +131,8 @@ void load(std::istream& istr, Args&... args);
   template <class Archive>                              \
   void load(Archive& ar, const uint32_t version);
 
+/** @} */
+
 namespace fl {
 namespace detail {
 
@@ -132,6 +146,11 @@ template <typename T>
 struct CerealSave;
 
 } // namespace detail
+
+/**
+ * \addtogroup serialization_library Serialization Library
+ * @{
+ */
 
 /**
  * Serialize an expression iff the version is in the given range (inclusive).
@@ -170,6 +189,7 @@ template <typename S, typename T, typename SaveConvFn, typename LoadConvFn>
 detail::SerializeAs<S, T>
 serializeAs(T&& t, SaveConvFn saveConverter, LoadConvFn loadConverter);
 
+/** @} */
 } // namespace fl
 
 namespace cereal {

--- a/flashlight/common/Utils.cpp
+++ b/flashlight/common/Utils.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/common/Utils.cpp
+++ b/flashlight/common/Utils.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/common/Utils.h
+++ b/flashlight/common/Utils.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/common/Utils.h
+++ b/flashlight/common/Utils.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/common/Utils.h
+++ b/flashlight/common/Utils.h
@@ -11,6 +11,11 @@
 
 #include <arrayfire.h>
 
+/**
+ * \defgroup common_utils Common utilities
+ * @{
+ */
+
 #define AF_CHECK(fn)                                                          \
   do {                                                                        \
     af_err __err = fn;                                                        \
@@ -50,5 +55,7 @@ std::string prettyStringMemorySize(size_t size);
 
 // Returns a string formatted similar to: 26675644(2m+667k+5644)
 std::string prettyStringCount(size_t count);
+
+/** @} */
 
 } // namespace fl

--- a/flashlight/common/common.h
+++ b/flashlight/common/common.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/common/common.h
+++ b/flashlight/common/common.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/common/cuda.h
+++ b/flashlight/common/cuda.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/common/cuda.h
+++ b/flashlight/common/cuda.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/common/threadpool/ThreadPool.h
+++ b/flashlight/common/threadpool/ThreadPool.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/common/threadpool/ThreadPool.h
+++ b/flashlight/common/threadpool/ThreadPool.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/contrib/contrib.h
+++ b/flashlight/contrib/contrib.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/contrib/contrib.h
+++ b/flashlight/contrib/contrib.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/contrib/modules/AsymmetricConv1D.cpp
+++ b/flashlight/contrib/modules/AsymmetricConv1D.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/contrib/modules/AsymmetricConv1D.cpp
+++ b/flashlight/contrib/modules/AsymmetricConv1D.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/contrib/modules/AsymmetricConv1D.h
+++ b/flashlight/contrib/modules/AsymmetricConv1D.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/contrib/modules/AsymmetricConv1D.h
+++ b/flashlight/contrib/modules/AsymmetricConv1D.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/contrib/modules/PositionEmbedding.cpp
+++ b/flashlight/contrib/modules/PositionEmbedding.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/contrib/modules/PositionEmbedding.cpp
+++ b/flashlight/contrib/modules/PositionEmbedding.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/contrib/modules/PositionEmbedding.h
+++ b/flashlight/contrib/modules/PositionEmbedding.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/contrib/modules/PositionEmbedding.h
+++ b/flashlight/contrib/modules/PositionEmbedding.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/contrib/modules/Residual.cpp
+++ b/flashlight/contrib/modules/Residual.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/contrib/modules/Residual.cpp
+++ b/flashlight/contrib/modules/Residual.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/contrib/modules/Residual.h
+++ b/flashlight/contrib/modules/Residual.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/contrib/modules/Residual.h
+++ b/flashlight/contrib/modules/Residual.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/contrib/modules/SpecAugment.cpp
+++ b/flashlight/contrib/modules/SpecAugment.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/contrib/modules/SpecAugment.cpp
+++ b/flashlight/contrib/modules/SpecAugment.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/contrib/modules/SpecAugment.h
+++ b/flashlight/contrib/modules/SpecAugment.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/contrib/modules/SpecAugment.h
+++ b/flashlight/contrib/modules/SpecAugment.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/contrib/modules/TDSBlock.cpp
+++ b/flashlight/contrib/modules/TDSBlock.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/contrib/modules/TDSBlock.cpp
+++ b/flashlight/contrib/modules/TDSBlock.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/contrib/modules/TDSBlock.h
+++ b/flashlight/contrib/modules/TDSBlock.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/contrib/modules/TDSBlock.h
+++ b/flashlight/contrib/modules/TDSBlock.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/contrib/modules/Transformer.cpp
+++ b/flashlight/contrib/modules/Transformer.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/contrib/modules/Transformer.cpp
+++ b/flashlight/contrib/modules/Transformer.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/contrib/modules/Transformer.h
+++ b/flashlight/contrib/modules/Transformer.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/contrib/modules/Transformer.h
+++ b/flashlight/contrib/modules/Transformer.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/contrib/modules/modules.h
+++ b/flashlight/contrib/modules/modules.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/contrib/modules/modules.h
+++ b/flashlight/contrib/modules/modules.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/dataset/BatchDataset.cpp
+++ b/flashlight/dataset/BatchDataset.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/dataset/BatchDataset.cpp
+++ b/flashlight/dataset/BatchDataset.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/dataset/BatchDataset.h
+++ b/flashlight/dataset/BatchDataset.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/dataset/BatchDataset.h
+++ b/flashlight/dataset/BatchDataset.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/dataset/BlobDataset.cpp
+++ b/flashlight/dataset/BlobDataset.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/dataset/BlobDataset.cpp
+++ b/flashlight/dataset/BlobDataset.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/dataset/BlobDataset.h
+++ b/flashlight/dataset/BlobDataset.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/dataset/BlobDataset.h
+++ b/flashlight/dataset/BlobDataset.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/dataset/ConcatDataset.cpp
+++ b/flashlight/dataset/ConcatDataset.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/dataset/ConcatDataset.cpp
+++ b/flashlight/dataset/ConcatDataset.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/dataset/ConcatDataset.h
+++ b/flashlight/dataset/ConcatDataset.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/dataset/ConcatDataset.h
+++ b/flashlight/dataset/ConcatDataset.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/dataset/Dataset.h
+++ b/flashlight/dataset/Dataset.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/dataset/Dataset.h
+++ b/flashlight/dataset/Dataset.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/dataset/DatasetIterator.h
+++ b/flashlight/dataset/DatasetIterator.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/dataset/DatasetIterator.h
+++ b/flashlight/dataset/DatasetIterator.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/dataset/FileBlobDataset.cpp
+++ b/flashlight/dataset/FileBlobDataset.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/dataset/FileBlobDataset.cpp
+++ b/flashlight/dataset/FileBlobDataset.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/dataset/FileBlobDataset.h
+++ b/flashlight/dataset/FileBlobDataset.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/dataset/FileBlobDataset.h
+++ b/flashlight/dataset/FileBlobDataset.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/dataset/MergeDataset.cpp
+++ b/flashlight/dataset/MergeDataset.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/dataset/MergeDataset.cpp
+++ b/flashlight/dataset/MergeDataset.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/dataset/MergeDataset.h
+++ b/flashlight/dataset/MergeDataset.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/dataset/MergeDataset.h
+++ b/flashlight/dataset/MergeDataset.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/dataset/PrefetchDataset.cpp
+++ b/flashlight/dataset/PrefetchDataset.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/dataset/PrefetchDataset.cpp
+++ b/flashlight/dataset/PrefetchDataset.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/dataset/PrefetchDataset.h
+++ b/flashlight/dataset/PrefetchDataset.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/dataset/PrefetchDataset.h
+++ b/flashlight/dataset/PrefetchDataset.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/dataset/ResampleDataset.cpp
+++ b/flashlight/dataset/ResampleDataset.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/dataset/ResampleDataset.cpp
+++ b/flashlight/dataset/ResampleDataset.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/dataset/ResampleDataset.h
+++ b/flashlight/dataset/ResampleDataset.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/dataset/ResampleDataset.h
+++ b/flashlight/dataset/ResampleDataset.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/dataset/ShuffleDataset.cpp
+++ b/flashlight/dataset/ShuffleDataset.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/dataset/ShuffleDataset.cpp
+++ b/flashlight/dataset/ShuffleDataset.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/dataset/ShuffleDataset.h
+++ b/flashlight/dataset/ShuffleDataset.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/dataset/ShuffleDataset.h
+++ b/flashlight/dataset/ShuffleDataset.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/dataset/TensorDataset.cpp
+++ b/flashlight/dataset/TensorDataset.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/dataset/TensorDataset.cpp
+++ b/flashlight/dataset/TensorDataset.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/dataset/TensorDataset.h
+++ b/flashlight/dataset/TensorDataset.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/dataset/TensorDataset.h
+++ b/flashlight/dataset/TensorDataset.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/dataset/TransformDataset.cpp
+++ b/flashlight/dataset/TransformDataset.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/dataset/TransformDataset.cpp
+++ b/flashlight/dataset/TransformDataset.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/dataset/TransformDataset.h
+++ b/flashlight/dataset/TransformDataset.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/dataset/TransformDataset.h
+++ b/flashlight/dataset/TransformDataset.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/dataset/Utils.cpp
+++ b/flashlight/dataset/Utils.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/dataset/Utils.cpp
+++ b/flashlight/dataset/Utils.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/dataset/Utils.h
+++ b/flashlight/dataset/Utils.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/dataset/Utils.h
+++ b/flashlight/dataset/Utils.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/dataset/Utils.h
+++ b/flashlight/dataset/Utils.h
@@ -12,6 +12,11 @@
 namespace fl {
 
 /**
+ * \defgroup dataset_utils Dataset Utils
+ * @{
+ */
+
+/**
  * Partitions the samples in a round-robin manner and return ids of the samples.
  * For dealing with end effects, we include final samples iff we can fit
  * atleast one sample for last batch for all partitions
@@ -25,5 +30,7 @@ std::vector<int64_t> partitionByRoundRobin(
     int64_t partitionId,
     int64_t numPartitions,
     int64_t batchSz = 1);
+
+/** @} */
 
 } // namespace fl

--- a/flashlight/dataset/datasets.h
+++ b/flashlight/dataset/datasets.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/dataset/datasets.h
+++ b/flashlight/dataset/datasets.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/distributed/DistributedApi.cpp
+++ b/flashlight/distributed/DistributedApi.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/distributed/DistributedApi.cpp
+++ b/flashlight/distributed/DistributedApi.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/distributed/DistributedApi.h
+++ b/flashlight/distributed/DistributedApi.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/distributed/DistributedApi.h
+++ b/flashlight/distributed/DistributedApi.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/distributed/DistributedApi.h
+++ b/flashlight/distributed/DistributedApi.h
@@ -15,10 +15,14 @@
 #include "flashlight/flashlight/common/Defines.h"
 
 namespace fl {
+/**
+ * \defgroup distributed_api Distributed API
+ * @{
+ */
 
 /**
  * Initialize the distributed environment. Note that `worldSize`, `worldRank`
- * are ignored if DistributedInit::MPI is used.
+ * are ignored if `DistributedInit::MPI` is used.
  *
  * @param initMethod Initialization method used for setting up the rendezvous
  * @param worldSize Total number of processes in the communication group
@@ -121,6 +125,8 @@ void allReduceMultiple(
  * stream.
  */
 void syncDistributed();
+
+/** @} */
 
 namespace detail {
 class DistributedInfo {

--- a/flashlight/distributed/FileStore.cpp
+++ b/flashlight/distributed/FileStore.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/distributed/FileStore.cpp
+++ b/flashlight/distributed/FileStore.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/distributed/FileStore.h
+++ b/flashlight/distributed/FileStore.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/distributed/FileStore.h
+++ b/flashlight/distributed/FileStore.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/distributed/LRUCache.h
+++ b/flashlight/distributed/LRUCache.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/distributed/LRUCache.h
+++ b/flashlight/distributed/LRUCache.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/distributed/backend/cpu/DistributedBackend.cpp
+++ b/flashlight/distributed/backend/cpu/DistributedBackend.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/distributed/backend/cpu/DistributedBackend.cpp
+++ b/flashlight/distributed/backend/cpu/DistributedBackend.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/distributed/backend/cuda/DistributedBackend.cpp
+++ b/flashlight/distributed/backend/cuda/DistributedBackend.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/distributed/backend/cuda/DistributedBackend.cpp
+++ b/flashlight/distributed/backend/cuda/DistributedBackend.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/distributed/distributed.h
+++ b/flashlight/distributed/distributed.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/distributed/distributed.h
+++ b/flashlight/distributed/distributed.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/distributed/reducers/CoalescingReducer.cpp
+++ b/flashlight/distributed/reducers/CoalescingReducer.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/distributed/reducers/CoalescingReducer.cpp
+++ b/flashlight/distributed/reducers/CoalescingReducer.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/distributed/reducers/CoalescingReducer.h
+++ b/flashlight/distributed/reducers/CoalescingReducer.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/distributed/reducers/CoalescingReducer.h
+++ b/flashlight/distributed/reducers/CoalescingReducer.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/distributed/reducers/InlineReducer.cpp
+++ b/flashlight/distributed/reducers/InlineReducer.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/distributed/reducers/InlineReducer.cpp
+++ b/flashlight/distributed/reducers/InlineReducer.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/distributed/reducers/InlineReducer.h
+++ b/flashlight/distributed/reducers/InlineReducer.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/distributed/reducers/InlineReducer.h
+++ b/flashlight/distributed/reducers/InlineReducer.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/distributed/reducers/Reducer.h
+++ b/flashlight/distributed/reducers/Reducer.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/distributed/reducers/Reducer.h
+++ b/flashlight/distributed/reducers/Reducer.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/distributed/reducers/reducers.h
+++ b/flashlight/distributed/reducers/reducers.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/distributed/reducers/reducers.h
+++ b/flashlight/distributed/reducers/reducers.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/examples/AdaptiveClassification.cpp
+++ b/flashlight/examples/AdaptiveClassification.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/examples/AdaptiveClassification.cpp
+++ b/flashlight/examples/AdaptiveClassification.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/examples/Benchmark.cpp
+++ b/flashlight/examples/Benchmark.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/examples/Benchmark.cpp
+++ b/flashlight/examples/Benchmark.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/examples/Classification.cpp
+++ b/flashlight/examples/Classification.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/examples/Classification.cpp
+++ b/flashlight/examples/Classification.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/examples/DistributedTraining.cpp
+++ b/flashlight/examples/DistributedTraining.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/examples/DistributedTraining.cpp
+++ b/flashlight/examples/DistributedTraining.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/examples/LinearRegression.cpp
+++ b/flashlight/examples/LinearRegression.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/examples/LinearRegression.cpp
+++ b/flashlight/examples/LinearRegression.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/examples/Mnist.cpp
+++ b/flashlight/examples/Mnist.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/examples/Mnist.cpp
+++ b/flashlight/examples/Mnist.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/examples/Perceptron.cpp
+++ b/flashlight/examples/Perceptron.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/examples/Perceptron.cpp
+++ b/flashlight/examples/Perceptron.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/examples/RnnLm.cpp
+++ b/flashlight/examples/RnnLm.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/examples/RnnLm.cpp
+++ b/flashlight/examples/RnnLm.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/examples/Xor.cpp
+++ b/flashlight/examples/Xor.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/examples/Xor.cpp
+++ b/flashlight/examples/Xor.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/flashlight.h
+++ b/flashlight/flashlight.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/flashlight.h
+++ b/flashlight/flashlight.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/memory/MemoryManagerAdapter.cpp
+++ b/flashlight/memory/MemoryManagerAdapter.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/memory/MemoryManagerAdapter.cpp
+++ b/flashlight/memory/MemoryManagerAdapter.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/memory/MemoryManagerAdapter.h
+++ b/flashlight/memory/MemoryManagerAdapter.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/memory/MemoryManagerAdapter.h
+++ b/flashlight/memory/MemoryManagerAdapter.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/memory/MemoryManagerDeviceInterface.h
+++ b/flashlight/memory/MemoryManagerDeviceInterface.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/memory/MemoryManagerDeviceInterface.h
+++ b/flashlight/memory/MemoryManagerDeviceInterface.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/memory/MemoryManagerInstaller.cpp
+++ b/flashlight/memory/MemoryManagerInstaller.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/memory/MemoryManagerInstaller.cpp
+++ b/flashlight/memory/MemoryManagerInstaller.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/memory/MemoryManagerInstaller.h
+++ b/flashlight/memory/MemoryManagerInstaller.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/memory/MemoryManagerInstaller.h
+++ b/flashlight/memory/MemoryManagerInstaller.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/memory/managers/CachingMemoryManager.cpp
+++ b/flashlight/memory/managers/CachingMemoryManager.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/memory/managers/CachingMemoryManager.cpp
+++ b/flashlight/memory/managers/CachingMemoryManager.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/memory/managers/CachingMemoryManager.h
+++ b/flashlight/memory/managers/CachingMemoryManager.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/memory/managers/CachingMemoryManager.h
+++ b/flashlight/memory/managers/CachingMemoryManager.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/memory/managers/DefaultMemoryManager.cpp
+++ b/flashlight/memory/managers/DefaultMemoryManager.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/memory/managers/DefaultMemoryManager.cpp
+++ b/flashlight/memory/managers/DefaultMemoryManager.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/memory/managers/DefaultMemoryManager.h
+++ b/flashlight/memory/managers/DefaultMemoryManager.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/memory/managers/DefaultMemoryManager.h
+++ b/flashlight/memory/managers/DefaultMemoryManager.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/memory/memory.h
+++ b/flashlight/memory/memory.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/memory/memory.h
+++ b/flashlight/memory/memory.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/meter/AverageValueMeter.cpp
+++ b/flashlight/meter/AverageValueMeter.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/meter/AverageValueMeter.cpp
+++ b/flashlight/meter/AverageValueMeter.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/meter/AverageValueMeter.h
+++ b/flashlight/meter/AverageValueMeter.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/meter/AverageValueMeter.h
+++ b/flashlight/meter/AverageValueMeter.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/meter/CountMeter.cpp
+++ b/flashlight/meter/CountMeter.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/meter/CountMeter.cpp
+++ b/flashlight/meter/CountMeter.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/meter/CountMeter.h
+++ b/flashlight/meter/CountMeter.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/meter/CountMeter.h
+++ b/flashlight/meter/CountMeter.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/meter/EditDistanceMeter.cpp
+++ b/flashlight/meter/EditDistanceMeter.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/meter/EditDistanceMeter.cpp
+++ b/flashlight/meter/EditDistanceMeter.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/meter/EditDistanceMeter.h
+++ b/flashlight/meter/EditDistanceMeter.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/meter/EditDistanceMeter.h
+++ b/flashlight/meter/EditDistanceMeter.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/meter/FrameErrorMeter.cpp
+++ b/flashlight/meter/FrameErrorMeter.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/meter/FrameErrorMeter.cpp
+++ b/flashlight/meter/FrameErrorMeter.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/meter/FrameErrorMeter.h
+++ b/flashlight/meter/FrameErrorMeter.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/meter/FrameErrorMeter.h
+++ b/flashlight/meter/FrameErrorMeter.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/meter/MSEMeter.cpp
+++ b/flashlight/meter/MSEMeter.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/meter/MSEMeter.cpp
+++ b/flashlight/meter/MSEMeter.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/meter/MSEMeter.h
+++ b/flashlight/meter/MSEMeter.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/meter/MSEMeter.h
+++ b/flashlight/meter/MSEMeter.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/meter/TimeMeter.cpp
+++ b/flashlight/meter/TimeMeter.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/meter/TimeMeter.cpp
+++ b/flashlight/meter/TimeMeter.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/meter/TimeMeter.h
+++ b/flashlight/meter/TimeMeter.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/meter/TimeMeter.h
+++ b/flashlight/meter/TimeMeter.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/meter/meters.h
+++ b/flashlight/meter/meters.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/meter/meters.h
+++ b/flashlight/meter/meters.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/DistributedUtils.cpp
+++ b/flashlight/nn/DistributedUtils.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/DistributedUtils.cpp
+++ b/flashlight/nn/DistributedUtils.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/DistributedUtils.h
+++ b/flashlight/nn/DistributedUtils.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/DistributedUtils.h
+++ b/flashlight/nn/DistributedUtils.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/DistributedUtils.h
+++ b/flashlight/nn/DistributedUtils.h
@@ -15,6 +15,11 @@
 namespace fl {
 
 /**
+ * \defgroup nn_distributed_utils NN Distributed Functions
+ * @{
+ */
+
+/**
  * Registers a module for allreduce synchronization with a gradient hook on it
  * parameter Variables.
  *
@@ -44,5 +49,7 @@ void allReduceParameters(std::shared_ptr<const Module> module);
 void allReduceGradients(
     std::shared_ptr<const Module> module,
     double scale = 1.0);
+
+/** @} */
 
 } // namespace fl

--- a/flashlight/nn/Init.cpp
+++ b/flashlight/nn/Init.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/Init.cpp
+++ b/flashlight/nn/Init.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/Init.h
+++ b/flashlight/nn/Init.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/Init.h
+++ b/flashlight/nn/Init.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/Init.h
+++ b/flashlight/nn/Init.h
@@ -12,14 +12,17 @@
  * The complete license agreement can be obtained at:
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
+
 /**
- * @file nn/Init.h
+ * \defgroup nn_init_utils NN Initialization Functions
  *
  * Functions for initializing tensors.
  *
  * Provides facilities for creating a `fl::Variable` tensor of different types
  * and initializations vis-a-vis probability distributions, constants, and the
  * identity. Additionally wraps common tensors as integrated into modules.
+ *
+ * @{
  */
 
 #pragma once
@@ -419,5 +422,7 @@ Variable glorotNormal(
     int fanOut,
     af::dtype type = af::dtype::f32,
     bool calcGrad = true);
+
+/** @} */
 
 } // namespace fl

--- a/flashlight/nn/Utils.cpp
+++ b/flashlight/nn/Utils.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/Utils.cpp
+++ b/flashlight/nn/Utils.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/Utils.h
+++ b/flashlight/nn/Utils.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/Utils.h
+++ b/flashlight/nn/Utils.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/Utils.h
+++ b/flashlight/nn/Utils.h
@@ -4,10 +4,10 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 /**
- * @file nn/Utils.h
- *
- * Utils for modules.
+ * \defgroup nn_utils NN Utils
+ * @{
  */
 
 #pragma once
@@ -67,5 +67,7 @@ af::array join(
     const std::vector<af::array>& inputs,
     double padValue = 0.0,
     dim_t batchDim = -1);
+
+/** @} */
 
 } // namespace fl

--- a/flashlight/nn/modules/Activations.cpp
+++ b/flashlight/nn/modules/Activations.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/Activations.cpp
+++ b/flashlight/nn/modules/Activations.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/Activations.h
+++ b/flashlight/nn/modules/Activations.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/Activations.h
+++ b/flashlight/nn/modules/Activations.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/AdaptiveSoftMax.cpp
+++ b/flashlight/nn/modules/AdaptiveSoftMax.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/AdaptiveSoftMax.cpp
+++ b/flashlight/nn/modules/AdaptiveSoftMax.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/AdaptiveSoftMax.h
+++ b/flashlight/nn/modules/AdaptiveSoftMax.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/AdaptiveSoftMax.h
+++ b/flashlight/nn/modules/AdaptiveSoftMax.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/BatchNorm.cpp
+++ b/flashlight/nn/modules/BatchNorm.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/BatchNorm.cpp
+++ b/flashlight/nn/modules/BatchNorm.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/BatchNorm.h
+++ b/flashlight/nn/modules/BatchNorm.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/BatchNorm.h
+++ b/flashlight/nn/modules/BatchNorm.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/Container.cpp
+++ b/flashlight/nn/modules/Container.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/Container.cpp
+++ b/flashlight/nn/modules/Container.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/Container.h
+++ b/flashlight/nn/modules/Container.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/Container.h
+++ b/flashlight/nn/modules/Container.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/Conv2D.cpp
+++ b/flashlight/nn/modules/Conv2D.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/Conv2D.cpp
+++ b/flashlight/nn/modules/Conv2D.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/Conv2D.h
+++ b/flashlight/nn/modules/Conv2D.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/Conv2D.h
+++ b/flashlight/nn/modules/Conv2D.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/Dropout.cpp
+++ b/flashlight/nn/modules/Dropout.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/Dropout.cpp
+++ b/flashlight/nn/modules/Dropout.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/Dropout.h
+++ b/flashlight/nn/modules/Dropout.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/Dropout.h
+++ b/flashlight/nn/modules/Dropout.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/Embedding.cpp
+++ b/flashlight/nn/modules/Embedding.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/Embedding.cpp
+++ b/flashlight/nn/modules/Embedding.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/Embedding.h
+++ b/flashlight/nn/modules/Embedding.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/Embedding.h
+++ b/flashlight/nn/modules/Embedding.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/Identity.cpp
+++ b/flashlight/nn/modules/Identity.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/Identity.cpp
+++ b/flashlight/nn/modules/Identity.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/Identity.h
+++ b/flashlight/nn/modules/Identity.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/Identity.h
+++ b/flashlight/nn/modules/Identity.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/LayerNorm.cpp
+++ b/flashlight/nn/modules/LayerNorm.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/LayerNorm.cpp
+++ b/flashlight/nn/modules/LayerNorm.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/LayerNorm.h
+++ b/flashlight/nn/modules/LayerNorm.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/LayerNorm.h
+++ b/flashlight/nn/modules/LayerNorm.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/Linear.cpp
+++ b/flashlight/nn/modules/Linear.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/Linear.cpp
+++ b/flashlight/nn/modules/Linear.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/Linear.h
+++ b/flashlight/nn/modules/Linear.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/Linear.h
+++ b/flashlight/nn/modules/Linear.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/Loss.cpp
+++ b/flashlight/nn/modules/Loss.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/Loss.cpp
+++ b/flashlight/nn/modules/Loss.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/Loss.h
+++ b/flashlight/nn/modules/Loss.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/Loss.h
+++ b/flashlight/nn/modules/Loss.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/Module.cpp
+++ b/flashlight/nn/modules/Module.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/Module.cpp
+++ b/flashlight/nn/modules/Module.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/Module.h
+++ b/flashlight/nn/modules/Module.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/Module.h
+++ b/flashlight/nn/modules/Module.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/Normalize.cpp
+++ b/flashlight/nn/modules/Normalize.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/Normalize.cpp
+++ b/flashlight/nn/modules/Normalize.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/Normalize.h
+++ b/flashlight/nn/modules/Normalize.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/Normalize.h
+++ b/flashlight/nn/modules/Normalize.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/Padding.cpp
+++ b/flashlight/nn/modules/Padding.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/Padding.cpp
+++ b/flashlight/nn/modules/Padding.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/Padding.h
+++ b/flashlight/nn/modules/Padding.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/Padding.h
+++ b/flashlight/nn/modules/Padding.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/Pool2D.cpp
+++ b/flashlight/nn/modules/Pool2D.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/Pool2D.cpp
+++ b/flashlight/nn/modules/Pool2D.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/Pool2D.h
+++ b/flashlight/nn/modules/Pool2D.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/Pool2D.h
+++ b/flashlight/nn/modules/Pool2D.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/RNN.cpp
+++ b/flashlight/nn/modules/RNN.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/RNN.cpp
+++ b/flashlight/nn/modules/RNN.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/RNN.h
+++ b/flashlight/nn/modules/RNN.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/RNN.h
+++ b/flashlight/nn/modules/RNN.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/Reorder.cpp
+++ b/flashlight/nn/modules/Reorder.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/Reorder.cpp
+++ b/flashlight/nn/modules/Reorder.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/Reorder.h
+++ b/flashlight/nn/modules/Reorder.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/Reorder.h
+++ b/flashlight/nn/modules/Reorder.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/Transform.cpp
+++ b/flashlight/nn/modules/Transform.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/Transform.cpp
+++ b/flashlight/nn/modules/Transform.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/Transform.h
+++ b/flashlight/nn/modules/Transform.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/Transform.h
+++ b/flashlight/nn/modules/Transform.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/View.cpp
+++ b/flashlight/nn/modules/View.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/View.cpp
+++ b/flashlight/nn/modules/View.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/View.h
+++ b/flashlight/nn/modules/View.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/View.h
+++ b/flashlight/nn/modules/View.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/WeightNorm.cpp
+++ b/flashlight/nn/modules/WeightNorm.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/WeightNorm.cpp
+++ b/flashlight/nn/modules/WeightNorm.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/WeightNorm.h
+++ b/flashlight/nn/modules/WeightNorm.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/WeightNorm.h
+++ b/flashlight/nn/modules/WeightNorm.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/modules/modules.h
+++ b/flashlight/nn/modules/modules.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/modules/modules.h
+++ b/flashlight/nn/modules/modules.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/nn/nn.h
+++ b/flashlight/nn/nn.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/nn/nn.h
+++ b/flashlight/nn/nn.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/optim/AMSgradOptimizer.cpp
+++ b/flashlight/optim/AMSgradOptimizer.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/optim/AMSgradOptimizer.cpp
+++ b/flashlight/optim/AMSgradOptimizer.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/optim/AMSgradOptimizer.h
+++ b/flashlight/optim/AMSgradOptimizer.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/optim/AMSgradOptimizer.h
+++ b/flashlight/optim/AMSgradOptimizer.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/optim/AdadeltaOptimizer.cpp
+++ b/flashlight/optim/AdadeltaOptimizer.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/optim/AdadeltaOptimizer.cpp
+++ b/flashlight/optim/AdadeltaOptimizer.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/optim/AdadeltaOptimizer.h
+++ b/flashlight/optim/AdadeltaOptimizer.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/optim/AdadeltaOptimizer.h
+++ b/flashlight/optim/AdadeltaOptimizer.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/optim/AdagradOptimizer.cpp
+++ b/flashlight/optim/AdagradOptimizer.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/optim/AdagradOptimizer.cpp
+++ b/flashlight/optim/AdagradOptimizer.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/optim/AdagradOptimizer.h
+++ b/flashlight/optim/AdagradOptimizer.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/optim/AdagradOptimizer.h
+++ b/flashlight/optim/AdagradOptimizer.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/optim/AdamOptimizer.cpp
+++ b/flashlight/optim/AdamOptimizer.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/optim/AdamOptimizer.cpp
+++ b/flashlight/optim/AdamOptimizer.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/optim/AdamOptimizer.h
+++ b/flashlight/optim/AdamOptimizer.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/optim/AdamOptimizer.h
+++ b/flashlight/optim/AdamOptimizer.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/optim/NovogradOptimizer.cpp
+++ b/flashlight/optim/NovogradOptimizer.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/optim/NovogradOptimizer.cpp
+++ b/flashlight/optim/NovogradOptimizer.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/optim/NovogradOptimizer.h
+++ b/flashlight/optim/NovogradOptimizer.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/optim/NovogradOptimizer.h
+++ b/flashlight/optim/NovogradOptimizer.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/optim/Optimizers.cpp
+++ b/flashlight/optim/Optimizers.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/optim/Optimizers.cpp
+++ b/flashlight/optim/Optimizers.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/optim/Optimizers.h
+++ b/flashlight/optim/Optimizers.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/optim/Optimizers.h
+++ b/flashlight/optim/Optimizers.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/optim/RMSPropOptimizer.cpp
+++ b/flashlight/optim/RMSPropOptimizer.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/optim/RMSPropOptimizer.cpp
+++ b/flashlight/optim/RMSPropOptimizer.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/optim/RMSPropOptimizer.h
+++ b/flashlight/optim/RMSPropOptimizer.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/optim/RMSPropOptimizer.h
+++ b/flashlight/optim/RMSPropOptimizer.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/optim/SGDOptimizer.cpp
+++ b/flashlight/optim/SGDOptimizer.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/optim/SGDOptimizer.cpp
+++ b/flashlight/optim/SGDOptimizer.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/optim/SGDOptimizer.h
+++ b/flashlight/optim/SGDOptimizer.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/optim/SGDOptimizer.h
+++ b/flashlight/optim/SGDOptimizer.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/optim/Utils.cpp
+++ b/flashlight/optim/Utils.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/optim/Utils.cpp
+++ b/flashlight/optim/Utils.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/optim/Utils.h
+++ b/flashlight/optim/Utils.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/optim/Utils.h
+++ b/flashlight/optim/Utils.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/optim/optim.h
+++ b/flashlight/optim/optim.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/optim/optim.h
+++ b/flashlight/optim/optim.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/test/autograd/AutogradTest.cpp
+++ b/flashlight/test/autograd/AutogradTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/test/autograd/AutogradTest.cpp
+++ b/flashlight/test/autograd/AutogradTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/test/common/DevicePtrTest.cpp
+++ b/flashlight/test/common/DevicePtrTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/test/common/DevicePtrTest.cpp
+++ b/flashlight/test/common/DevicePtrTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/test/common/HistogramTest.cpp
+++ b/flashlight/test/common/HistogramTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/test/common/HistogramTest.cpp
+++ b/flashlight/test/common/HistogramTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/test/common/LoggingTest.cpp
+++ b/flashlight/test/common/LoggingTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/test/common/LoggingTest.cpp
+++ b/flashlight/test/common/LoggingTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/test/common/SerializationTest.cpp
+++ b/flashlight/test/common/SerializationTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/test/common/SerializationTest.cpp
+++ b/flashlight/test/common/SerializationTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/test/contrib/modules/ContribModuleTest.cpp
+++ b/flashlight/test/contrib/modules/ContribModuleTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/test/contrib/modules/ContribModuleTest.cpp
+++ b/flashlight/test/contrib/modules/ContribModuleTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/test/contrib/modules/ContribSerializationTest.cpp
+++ b/flashlight/test/contrib/modules/ContribSerializationTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/test/contrib/modules/ContribSerializationTest.cpp
+++ b/flashlight/test/contrib/modules/ContribSerializationTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/test/dataset/DatasetTest.cpp
+++ b/flashlight/test/dataset/DatasetTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/test/dataset/DatasetTest.cpp
+++ b/flashlight/test/dataset/DatasetTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/test/dataset/DatasetUtilsTest.cpp
+++ b/flashlight/test/dataset/DatasetUtilsTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/test/dataset/DatasetUtilsTest.cpp
+++ b/flashlight/test/dataset/DatasetUtilsTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/test/distributed/AllReduceBenchmark.cpp
+++ b/flashlight/test/distributed/AllReduceBenchmark.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/test/distributed/AllReduceBenchmark.cpp
+++ b/flashlight/test/distributed/AllReduceBenchmark.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/test/distributed/AllReduceTest.cpp
+++ b/flashlight/test/distributed/AllReduceTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/test/distributed/AllReduceTest.cpp
+++ b/flashlight/test/distributed/AllReduceTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/test/memory/CachingMemoryManagerTest.cpp
+++ b/flashlight/test/memory/CachingMemoryManagerTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/test/memory/CachingMemoryManagerTest.cpp
+++ b/flashlight/test/memory/CachingMemoryManagerTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/test/memory/MemoryFrameworkTest.cpp
+++ b/flashlight/test/memory/MemoryFrameworkTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/test/memory/MemoryFrameworkTest.cpp
+++ b/flashlight/test/memory/MemoryFrameworkTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/test/memory/MemoryInitTest.cpp
+++ b/flashlight/test/memory/MemoryInitTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/test/memory/MemoryInitTest.cpp
+++ b/flashlight/test/memory/MemoryInitTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/test/meter/MeterTest.cpp
+++ b/flashlight/test/meter/MeterTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/test/meter/MeterTest.cpp
+++ b/flashlight/test/meter/MeterTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/test/nn/ModuleTest.cpp
+++ b/flashlight/test/nn/ModuleTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/test/nn/ModuleTest.cpp
+++ b/flashlight/test/nn/ModuleTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/test/nn/NNSerializationTest.cpp
+++ b/flashlight/test/nn/NNSerializationTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/test/nn/NNSerializationTest.cpp
+++ b/flashlight/test/nn/NNSerializationTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/test/nn/NNUtilsTest.cpp
+++ b/flashlight/test/nn/NNUtilsTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/test/nn/NNUtilsTest.cpp
+++ b/flashlight/test/nn/NNUtilsTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/test/optim/OptimBenchmark.cpp
+++ b/flashlight/test/optim/OptimBenchmark.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/test/optim/OptimBenchmark.cpp
+++ b/flashlight/test/optim/OptimBenchmark.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/flashlight/test/optim/OptimTest.cpp
+++ b/flashlight/test/optim/OptimTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/flashlight/test/optim/OptimTest.cpp
+++ b/flashlight/test/optim/OptimTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/audio/feature/Ceplifter.cpp
+++ b/lib/audio/feature/Ceplifter.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/audio/feature/Ceplifter.cpp
+++ b/lib/audio/feature/Ceplifter.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/audio/feature/Ceplifter.h
+++ b/lib/audio/feature/Ceplifter.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/audio/feature/Ceplifter.h
+++ b/lib/audio/feature/Ceplifter.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/audio/feature/Dct.cpp
+++ b/lib/audio/feature/Dct.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/audio/feature/Dct.cpp
+++ b/lib/audio/feature/Dct.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/audio/feature/Dct.h
+++ b/lib/audio/feature/Dct.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/audio/feature/Dct.h
+++ b/lib/audio/feature/Dct.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/audio/feature/Derivatives.cpp
+++ b/lib/audio/feature/Derivatives.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/audio/feature/Derivatives.cpp
+++ b/lib/audio/feature/Derivatives.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/audio/feature/Derivatives.h
+++ b/lib/audio/feature/Derivatives.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/audio/feature/Derivatives.h
+++ b/lib/audio/feature/Derivatives.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/audio/feature/Dither.cpp
+++ b/lib/audio/feature/Dither.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/audio/feature/Dither.cpp
+++ b/lib/audio/feature/Dither.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/audio/feature/Dither.h
+++ b/lib/audio/feature/Dither.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/audio/feature/Dither.h
+++ b/lib/audio/feature/Dither.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/audio/feature/FeatureParams.h
+++ b/lib/audio/feature/FeatureParams.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/audio/feature/FeatureParams.h
+++ b/lib/audio/feature/FeatureParams.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/audio/feature/Mfcc.cpp
+++ b/lib/audio/feature/Mfcc.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/audio/feature/Mfcc.cpp
+++ b/lib/audio/feature/Mfcc.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/audio/feature/Mfcc.h
+++ b/lib/audio/feature/Mfcc.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/audio/feature/Mfcc.h
+++ b/lib/audio/feature/Mfcc.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/audio/feature/Mfsc.cpp
+++ b/lib/audio/feature/Mfsc.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/audio/feature/Mfsc.cpp
+++ b/lib/audio/feature/Mfsc.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/audio/feature/Mfsc.h
+++ b/lib/audio/feature/Mfsc.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/audio/feature/Mfsc.h
+++ b/lib/audio/feature/Mfsc.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/audio/feature/PowerSpectrum.cpp
+++ b/lib/audio/feature/PowerSpectrum.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/audio/feature/PowerSpectrum.cpp
+++ b/lib/audio/feature/PowerSpectrum.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/audio/feature/PowerSpectrum.h
+++ b/lib/audio/feature/PowerSpectrum.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/audio/feature/PowerSpectrum.h
+++ b/lib/audio/feature/PowerSpectrum.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/audio/feature/PreEmphasis.cpp
+++ b/lib/audio/feature/PreEmphasis.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/audio/feature/PreEmphasis.cpp
+++ b/lib/audio/feature/PreEmphasis.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/audio/feature/PreEmphasis.h
+++ b/lib/audio/feature/PreEmphasis.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/audio/feature/PreEmphasis.h
+++ b/lib/audio/feature/PreEmphasis.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/audio/feature/SpeechUtils.cpp
+++ b/lib/audio/feature/SpeechUtils.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/audio/feature/SpeechUtils.cpp
+++ b/lib/audio/feature/SpeechUtils.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/audio/feature/SpeechUtils.h
+++ b/lib/audio/feature/SpeechUtils.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/audio/feature/SpeechUtils.h
+++ b/lib/audio/feature/SpeechUtils.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/audio/feature/TriFilterbank.cpp
+++ b/lib/audio/feature/TriFilterbank.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/audio/feature/TriFilterbank.cpp
+++ b/lib/audio/feature/TriFilterbank.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/audio/feature/TriFilterbank.h
+++ b/lib/audio/feature/TriFilterbank.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/audio/feature/TriFilterbank.h
+++ b/lib/audio/feature/TriFilterbank.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/audio/feature/Windowing.cpp
+++ b/lib/audio/feature/Windowing.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/audio/feature/Windowing.cpp
+++ b/lib/audio/feature/Windowing.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/audio/feature/Windowing.h
+++ b/lib/audio/feature/Windowing.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/audio/feature/Windowing.h
+++ b/lib/audio/feature/Windowing.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/common/ProducerConsumerQueue.h
+++ b/lib/common/ProducerConsumerQueue.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/common/ProducerConsumerQueue.h
+++ b/lib/common/ProducerConsumerQueue.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/common/String.cpp
+++ b/lib/common/String.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/common/String.cpp
+++ b/lib/common/String.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/common/String.h
+++ b/lib/common/String.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/common/String.h
+++ b/lib/common/String.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/common/System.cpp
+++ b/lib/common/System.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/common/System.cpp
+++ b/lib/common/System.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/common/System.h
+++ b/lib/common/System.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/common/System.h
+++ b/lib/common/System.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/sequence/criterion/Defines.h
+++ b/lib/sequence/criterion/Defines.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/sequence/criterion/Defines.h
+++ b/lib/sequence/criterion/Defines.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/sequence/criterion/Workspace.h
+++ b/lib/sequence/criterion/Workspace.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/sequence/criterion/Workspace.h
+++ b/lib/sequence/criterion/Workspace.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/sequence/criterion/cpu/ConnectionistTemporalClassificationCriterion.cpp
+++ b/lib/sequence/criterion/cpu/ConnectionistTemporalClassificationCriterion.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/sequence/criterion/cpu/ConnectionistTemporalClassificationCriterion.cpp
+++ b/lib/sequence/criterion/cpu/ConnectionistTemporalClassificationCriterion.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/sequence/criterion/cpu/ConnectionistTemporalClassificationCriterion.h
+++ b/lib/sequence/criterion/cpu/ConnectionistTemporalClassificationCriterion.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/sequence/criterion/cpu/ConnectionistTemporalClassificationCriterion.h
+++ b/lib/sequence/criterion/cpu/ConnectionistTemporalClassificationCriterion.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/sequence/criterion/cpu/CriterionUtils.cpp
+++ b/lib/sequence/criterion/cpu/CriterionUtils.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/sequence/criterion/cpu/CriterionUtils.cpp
+++ b/lib/sequence/criterion/cpu/CriterionUtils.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/sequence/criterion/cpu/CriterionUtils.h
+++ b/lib/sequence/criterion/cpu/CriterionUtils.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/sequence/criterion/cpu/CriterionUtils.h
+++ b/lib/sequence/criterion/cpu/CriterionUtils.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/sequence/criterion/cpu/ForceAlignmentCriterion.cpp
+++ b/lib/sequence/criterion/cpu/ForceAlignmentCriterion.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/sequence/criterion/cpu/ForceAlignmentCriterion.cpp
+++ b/lib/sequence/criterion/cpu/ForceAlignmentCriterion.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/sequence/criterion/cpu/ForceAlignmentCriterion.h
+++ b/lib/sequence/criterion/cpu/ForceAlignmentCriterion.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/sequence/criterion/cpu/ForceAlignmentCriterion.h
+++ b/lib/sequence/criterion/cpu/ForceAlignmentCriterion.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/sequence/criterion/cpu/FullConnectionCriterion.cpp
+++ b/lib/sequence/criterion/cpu/FullConnectionCriterion.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/sequence/criterion/cpu/FullConnectionCriterion.cpp
+++ b/lib/sequence/criterion/cpu/FullConnectionCriterion.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/sequence/criterion/cpu/FullConnectionCriterion.h
+++ b/lib/sequence/criterion/cpu/FullConnectionCriterion.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/sequence/criterion/cpu/FullConnectionCriterion.h
+++ b/lib/sequence/criterion/cpu/FullConnectionCriterion.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/sequence/criterion/cpu/ViterbiPath.cpp
+++ b/lib/sequence/criterion/cpu/ViterbiPath.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/sequence/criterion/cpu/ViterbiPath.cpp
+++ b/lib/sequence/criterion/cpu/ViterbiPath.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/sequence/criterion/cpu/ViterbiPath.h
+++ b/lib/sequence/criterion/cpu/ViterbiPath.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/sequence/criterion/cpu/ViterbiPath.h
+++ b/lib/sequence/criterion/cpu/ViterbiPath.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/sequence/criterion/cuda/CriterionUtils.cu
+++ b/lib/sequence/criterion/cuda/CriterionUtils.cu
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/sequence/criterion/cuda/CriterionUtils.cu
+++ b/lib/sequence/criterion/cuda/CriterionUtils.cu
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/sequence/criterion/cuda/CriterionUtils.cuh
+++ b/lib/sequence/criterion/cuda/CriterionUtils.cuh
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/sequence/criterion/cuda/CriterionUtils.cuh
+++ b/lib/sequence/criterion/cuda/CriterionUtils.cuh
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/sequence/criterion/cuda/ForceAlignmentCriterion.cu
+++ b/lib/sequence/criterion/cuda/ForceAlignmentCriterion.cu
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/sequence/criterion/cuda/ForceAlignmentCriterion.cu
+++ b/lib/sequence/criterion/cuda/ForceAlignmentCriterion.cu
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/sequence/criterion/cuda/ForceAlignmentCriterion.cuh
+++ b/lib/sequence/criterion/cuda/ForceAlignmentCriterion.cuh
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/sequence/criterion/cuda/ForceAlignmentCriterion.cuh
+++ b/lib/sequence/criterion/cuda/ForceAlignmentCriterion.cuh
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/sequence/criterion/cuda/FullConnectionCriterion.cu
+++ b/lib/sequence/criterion/cuda/FullConnectionCriterion.cu
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/sequence/criterion/cuda/FullConnectionCriterion.cu
+++ b/lib/sequence/criterion/cuda/FullConnectionCriterion.cu
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/sequence/criterion/cuda/FullConnectionCriterion.cuh
+++ b/lib/sequence/criterion/cuda/FullConnectionCriterion.cuh
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/sequence/criterion/cuda/FullConnectionCriterion.cuh
+++ b/lib/sequence/criterion/cuda/FullConnectionCriterion.cuh
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/sequence/criterion/cuda/ViterbiPath.cu
+++ b/lib/sequence/criterion/cuda/ViterbiPath.cu
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/sequence/criterion/cuda/ViterbiPath.cu
+++ b/lib/sequence/criterion/cuda/ViterbiPath.cu
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/sequence/criterion/cuda/ViterbiPath.cuh
+++ b/lib/sequence/criterion/cuda/ViterbiPath.cuh
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/sequence/criterion/cuda/ViterbiPath.cuh
+++ b/lib/sequence/criterion/cuda/ViterbiPath.cuh
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/test/audio/feature/CeplifterTest.cpp
+++ b/lib/test/audio/feature/CeplifterTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/test/audio/feature/CeplifterTest.cpp
+++ b/lib/test/audio/feature/CeplifterTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/test/audio/feature/DctTest.cpp
+++ b/lib/test/audio/feature/DctTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/test/audio/feature/DctTest.cpp
+++ b/lib/test/audio/feature/DctTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/test/audio/feature/DerivativesTest.cpp
+++ b/lib/test/audio/feature/DerivativesTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/test/audio/feature/DerivativesTest.cpp
+++ b/lib/test/audio/feature/DerivativesTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/test/audio/feature/DitherTest.cpp
+++ b/lib/test/audio/feature/DitherTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/test/audio/feature/DitherTest.cpp
+++ b/lib/test/audio/feature/DitherTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/test/audio/feature/MfccTest.cpp
+++ b/lib/test/audio/feature/MfccTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/test/audio/feature/MfccTest.cpp
+++ b/lib/test/audio/feature/MfccTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/test/audio/feature/PreEmphasisTest.cpp
+++ b/lib/test/audio/feature/PreEmphasisTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/test/audio/feature/PreEmphasisTest.cpp
+++ b/lib/test/audio/feature/PreEmphasisTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/test/audio/feature/SpeechUtilsTest.cpp
+++ b/lib/test/audio/feature/SpeechUtilsTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/test/audio/feature/SpeechUtilsTest.cpp
+++ b/lib/test/audio/feature/SpeechUtilsTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/test/audio/feature/TestUtils.h
+++ b/lib/test/audio/feature/TestUtils.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/test/audio/feature/TestUtils.h
+++ b/lib/test/audio/feature/TestUtils.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/test/audio/feature/TriFilterbankTest.cpp
+++ b/lib/test/audio/feature/TriFilterbankTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/test/audio/feature/TriFilterbankTest.cpp
+++ b/lib/test/audio/feature/TriFilterbankTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/test/audio/feature/WindowingTest.cpp
+++ b/lib/test/audio/feature/WindowingTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/test/audio/feature/WindowingTest.cpp
+++ b/lib/test/audio/feature/WindowingTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/test/common/ProducerConsumerQueueTest.cpp
+++ b/lib/test/common/ProducerConsumerQueueTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/test/common/ProducerConsumerQueueTest.cpp
+++ b/lib/test/common/ProducerConsumerQueueTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/test/common/StringTest.cpp
+++ b/lib/test/common/StringTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/test/common/StringTest.cpp
+++ b/lib/test/common/StringTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/test/common/SystemTest.cpp
+++ b/lib/test/common/SystemTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/test/common/SystemTest.cpp
+++ b/lib/test/common/SystemTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/test/text/dictionary/DictionaryTest.cpp
+++ b/lib/test/text/dictionary/DictionaryTest.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/test/text/dictionary/DictionaryTest.cpp
+++ b/lib/test/text/dictionary/DictionaryTest.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/text/decoder/Decoder.h
+++ b/lib/text/decoder/Decoder.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/text/decoder/Decoder.h
+++ b/lib/text/decoder/Decoder.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/text/decoder/LexiconDecoder.cpp
+++ b/lib/text/decoder/LexiconDecoder.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/text/decoder/LexiconDecoder.cpp
+++ b/lib/text/decoder/LexiconDecoder.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/text/decoder/LexiconDecoder.h
+++ b/lib/text/decoder/LexiconDecoder.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/text/decoder/LexiconDecoder.h
+++ b/lib/text/decoder/LexiconDecoder.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/text/decoder/LexiconFreeDecoder.cpp
+++ b/lib/text/decoder/LexiconFreeDecoder.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/text/decoder/LexiconFreeDecoder.cpp
+++ b/lib/text/decoder/LexiconFreeDecoder.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/text/decoder/LexiconFreeDecoder.h
+++ b/lib/text/decoder/LexiconFreeDecoder.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/text/decoder/LexiconFreeDecoder.h
+++ b/lib/text/decoder/LexiconFreeDecoder.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/text/decoder/LexiconFreeSeq2SeqDecoder.cpp
+++ b/lib/text/decoder/LexiconFreeSeq2SeqDecoder.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/text/decoder/LexiconFreeSeq2SeqDecoder.cpp
+++ b/lib/text/decoder/LexiconFreeSeq2SeqDecoder.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/text/decoder/LexiconFreeSeq2SeqDecoder.h
+++ b/lib/text/decoder/LexiconFreeSeq2SeqDecoder.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/text/decoder/LexiconFreeSeq2SeqDecoder.h
+++ b/lib/text/decoder/LexiconFreeSeq2SeqDecoder.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/text/decoder/LexiconSeq2SeqDecoder.cpp
+++ b/lib/text/decoder/LexiconSeq2SeqDecoder.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/text/decoder/LexiconSeq2SeqDecoder.cpp
+++ b/lib/text/decoder/LexiconSeq2SeqDecoder.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/text/decoder/LexiconSeq2SeqDecoder.h
+++ b/lib/text/decoder/LexiconSeq2SeqDecoder.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/text/decoder/LexiconSeq2SeqDecoder.h
+++ b/lib/text/decoder/LexiconSeq2SeqDecoder.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/text/decoder/Trie.cpp
+++ b/lib/text/decoder/Trie.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/text/decoder/Trie.cpp
+++ b/lib/text/decoder/Trie.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/text/decoder/Trie.h
+++ b/lib/text/decoder/Trie.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/text/decoder/Trie.h
+++ b/lib/text/decoder/Trie.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/text/decoder/Utils.cpp
+++ b/lib/text/decoder/Utils.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/text/decoder/Utils.cpp
+++ b/lib/text/decoder/Utils.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/text/decoder/Utils.h
+++ b/lib/text/decoder/Utils.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/text/decoder/Utils.h
+++ b/lib/text/decoder/Utils.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/text/decoder/lm/ConvLM.cpp
+++ b/lib/text/decoder/lm/ConvLM.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/text/decoder/lm/ConvLM.cpp
+++ b/lib/text/decoder/lm/ConvLM.cpp
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2017-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/lib/text/decoder/lm/ConvLM.h
+++ b/lib/text/decoder/lm/ConvLM.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/text/decoder/lm/ConvLM.h
+++ b/lib/text/decoder/lm/ConvLM.h
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2017-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant

--- a/lib/text/decoder/lm/KenLM.cpp
+++ b/lib/text/decoder/lm/KenLM.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/text/decoder/lm/KenLM.cpp
+++ b/lib/text/decoder/lm/KenLM.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/text/decoder/lm/KenLM.h
+++ b/lib/text/decoder/lm/KenLM.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/text/decoder/lm/KenLM.h
+++ b/lib/text/decoder/lm/KenLM.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/text/decoder/lm/LM.h
+++ b/lib/text/decoder/lm/LM.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/text/decoder/lm/LM.h
+++ b/lib/text/decoder/lm/LM.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/text/decoder/lm/ZeroLM.cpp
+++ b/lib/text/decoder/lm/ZeroLM.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/text/decoder/lm/ZeroLM.cpp
+++ b/lib/text/decoder/lm/ZeroLM.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/text/decoder/lm/ZeroLM.h
+++ b/lib/text/decoder/lm/ZeroLM.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/text/decoder/lm/ZeroLM.h
+++ b/lib/text/decoder/lm/ZeroLM.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/text/dictionary/Defines.h
+++ b/lib/text/dictionary/Defines.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/text/dictionary/Defines.h
+++ b/lib/text/dictionary/Defines.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/text/dictionary/Dictionary.cpp
+++ b/lib/text/dictionary/Dictionary.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/text/dictionary/Dictionary.cpp
+++ b/lib/text/dictionary/Dictionary.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/text/dictionary/Dictionary.h
+++ b/lib/text/dictionary/Dictionary.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/text/dictionary/Dictionary.h
+++ b/lib/text/dictionary/Dictionary.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/text/dictionary/Utils.cpp
+++ b/lib/text/dictionary/Utils.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/text/dictionary/Utils.cpp
+++ b/lib/text/dictionary/Utils.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/text/dictionary/Utils.h
+++ b/lib/text/dictionary/Utils.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/text/dictionary/Utils.h
+++ b/lib/text/dictionary/Utils.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/text/tokenizer/Tokenizer.cpp
+++ b/lib/text/tokenizer/Tokenizer.cpp
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/text/tokenizer/Tokenizer.cpp
+++ b/lib/text/tokenizer/Tokenizer.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the

--- a/lib/text/tokenizer/Tokenizer.h
+++ b/lib/text/tokenizer/Tokenizer.h
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/lib/text/tokenizer/Tokenizer.h
+++ b/lib/text/tokenizer/Tokenizer.h
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the


### PR DESCRIPTION
Summary:
Our docs were in pretty major disrepair.

Things were unreadable for a lot of reasons — outside of copyright headers, logging library documentation was polluting every doc that used `doxygenfile` because of how it was included.

Fixes include:
- Removing `doxygenfile` and adding `doxygengroup` instead
- Adding `defgroup` calls and bracketing to relevantfiles
- Moving miscellaneous comments in files to rst markdown
- Add dedicated stubs for documenting the logging library
- Ensuring serialization things

Differential Revision: D24036691

