### PR TITLE
Globally replace glog with FL_LOG with new command line flags that are removed before gflags see them.

### DIFF
--- a/app/asr/Decode.cpp
+++ b/app/asr/Decode.cpp
@@ -14,7 +14,6 @@
 #include <vector>
 
 #include <gflags/gflags.h>
-#include <glog/logging.h>
 #include "flashlight/flashlight/flashlight.h"
 
 #include "flashlight/app/asr/common/Defines.h"
@@ -23,7 +22,6 @@
 #include "flashlight/app/asr/decoder/Defines.h"
 #include "flashlight/app/asr/decoder/TranscriptionUtils.h"
 #include "flashlight/app/asr/runtime/runtime.h"
-
 #include "flashlight/lib/common/ProducerConsumerQueue.h"
 #include "flashlight/lib/text/decoder/LexiconDecoder.h"
 #include "flashlight/lib/text/decoder/LexiconFreeDecoder.h"
@@ -39,8 +37,6 @@ using namespace fl::lib::text;
 using namespace fl::app::asr;
 
 int main(int argc, char** argv) {
-  google::InitGoogleLogging(argv[0]);
-  google::InstallFailureSignalHandler();
   std::string exec(argv[0]);
   std::vector<std::string> argvs;
   for (int i = 0; i < argc; i++) {
@@ -48,15 +44,15 @@ int main(int argc, char** argv) {
   }
   gflags::SetUsageMessage("Usage: Please refer to https://git.io/JvJuR");
   if (argc <= 1) {
-    LOG(FATAL) << gflags::ProgramUsage();
+    FL_LOG(fl::FATAL) << gflags::ProgramUsage();
   }
 
   /* ===================== Parse Options ===================== */
-  LOG(INFO) << "Parsing command line flags";
+  FL_LOG(fl::INFO) << "Parsing command line flags";
   gflags::ParseCommandLineFlags(&argc, &argv, false);
   auto flagsfile = FLAGS_flagsfile;
   if (!flagsfile.empty()) {
-    LOG(INFO) << "Reading flags from file " << flagsfile;
+    FL_LOG(fl::INFO) << "Reading flags from file " << flagsfile;
     gflags::ReadFromFlagsFile(flagsfile, argv[0], true);
     // Re-parse command line flags to override values in the flag file.
     gflags::ParseCommandLineFlags(&argc, &argv, false);
@@ -64,7 +60,7 @@ int main(int argc, char** argv) {
 
   /* ===================== Create Network ===================== */
   if (FLAGS_emission_dir.empty() && FLAGS_am.empty()) {
-    LOG(FATAL) << "Both flags are empty: `-emission_dir` and `-am`";
+    FL_LOG(fl::FATAL) << "Both flags are empty: `-emission_dir` and `-am`";
   }
 
   std::shared_ptr<fl::Module> network;
@@ -73,22 +69,24 @@ int main(int argc, char** argv) {
 
   /* Using acoustic model */
   if (!FLAGS_am.empty()) {
-    LOG(INFO) << "[Network] Reading acoustic model from " << FLAGS_am;
+    FL_LOG(fl::INFO) << "[Network] Reading acoustic model from " << FLAGS_am;
     af::setDevice(0);
     Serializer::load(FLAGS_am, cfg, network, criterion);
     network->eval();
-    LOG(INFO) << "[Network] " << network->prettyString();
+    FL_LOG(fl::INFO) << "[Network] " << network->prettyString();
     if (criterion) {
       criterion->eval();
-      LOG(INFO) << "[Criterion] " << criterion->prettyString();
+      FL_LOG(fl::INFO) << "[Criterion] " << criterion->prettyString();
     }
-    LOG(INFO) << "[Network] Number of params: " << numTotalParams(network);
+    FL_LOG(fl::INFO) << "[Network] Number of params: "
+                     << numTotalParams(network);
 
     auto flags = cfg.find(kGflags);
     if (flags == cfg.end()) {
-      LOG(FATAL) << "[Network] Invalid config loaded from " << FLAGS_am;
+      FL_LOG(fl::FATAL) << "[Network] Invalid config loaded from " << FLAGS_am;
     }
-    LOG(INFO) << "[Network] Updating flags from config file: " << FLAGS_am;
+    FL_LOG(fl::INFO) << "[Network] Updating flags from config file: "
+                     << FLAGS_am;
     gflags::ReadFlagsFromString(flags->second, gflags::GetArgv0(), true);
   }
 
@@ -104,7 +102,7 @@ int main(int argc, char** argv) {
   // flags are present and corresponding new flags aren't
   handleDeprecatedFlags();
 
-  LOG(INFO) << "Gflags after parsing \n" << serializeGflags("; ");
+  FL_LOG(fl::INFO) << "Gflags after parsing \n" << serializeGflags("; ");
 
   /* ===================== Create Dictionary ===================== */
   auto dictPath = pathsConcat(FLAGS_tokensdir, FLAGS_tokens);
@@ -125,14 +123,14 @@ int main(int argc, char** argv) {
   }
 
   int numClasses = tokenDict.indexSize();
-  LOG(INFO) << "Number of classes (network): " << numClasses;
+  FL_LOG(fl::INFO) << "Number of classes (network): " << numClasses;
 
   Dictionary wordDict;
   LexiconMap lexicon;
   if (!FLAGS_lexicon.empty()) {
     lexicon = loadWords(FLAGS_lexicon, FLAGS_maxword);
     wordDict = createWordDict(lexicon);
-    LOG(INFO) << "Number of words: " << wordDict.indexSize();
+    FL_LOG(fl::INFO) << "Number of words: " << wordDict.indexSize();
   }
 
   DictionaryMap dicts = {{kTargetIdx, tokenDict}, {kWordIdx, wordDict}};
@@ -155,7 +153,7 @@ int main(int argc, char** argv) {
       FLAGS_criterion == kTransformerCriterion) {
     criterionType = CriterionType::S2S;
   } else if (FLAGS_criterion != kAsgCriterion) {
-    LOG(FATAL) << "[Decoder] Invalid model type: " << FLAGS_criterion;
+    FL_LOG(fl::FATAL) << "[Decoder] Invalid model type: " << FLAGS_criterion;
   }
 
   std::vector<float> transition;
@@ -188,13 +186,13 @@ int main(int argc, char** argv) {
     refStream.open(refPath);
     logStream.open(logPath);
     if (!hypStream.is_open() || !hypStream.good()) {
-      LOG(FATAL) << "Error opening hypothesis file: " << hypPath;
+      FL_LOG(fl::FATAL) << "Error opening hypothesis file: " << hypPath;
     }
     if (!refStream.is_open() || !refStream.good()) {
-      LOG(FATAL) << "Error opening reference file: " << refPath;
+      FL_LOG(fl::FATAL) << "Error opening reference file: " << refPath;
     }
     if (!logStream.is_open() || !logStream.good()) {
-      LOG(FATAL) << "Error opening log file: " << logPath;
+      FL_LOG(fl::FATAL) << "Error opening log file: " << logPath;
     }
   }
 
@@ -225,11 +223,12 @@ int main(int argc, char** argv) {
     if (FLAGS_lmtype == "kenlm") {
       lm = std::make_shared<KenLM>(FLAGS_lm, usrDict);
       if (!lm) {
-        LOG(FATAL) << "[LM constructing] Failed to load LM: " << FLAGS_lm;
+        FL_LOG(fl::FATAL) << "[LM constructing] Failed to load LM: "
+                          << FLAGS_lm;
       }
     } else if (FLAGS_lmtype == "convlm") {
       af::setDevice(0);
-      LOG(INFO) << "[ConvLM]: Loading LM from " << FLAGS_lm;
+      FL_LOG(fl::INFO) << "[ConvLM]: Loading LM from " << FLAGS_lm;
       std::shared_ptr<fl::Module> convLmModel;
       Serializer::load(FLAGS_lm, convLmModel);
       convLmModel->eval();
@@ -242,10 +241,11 @@ int main(int argc, char** argv) {
           FLAGS_lm_memory,
           FLAGS_beamsize);
     } else {
-      LOG(FATAL) << "[LM constructing] Invalid LM Type: " << FLAGS_lmtype;
+      FL_LOG(fl::FATAL) << "[LM constructing] Invalid LM Type: "
+                        << FLAGS_lmtype;
     }
   }
-  LOG(INFO) << "[Decoder] LM constructed.\n";
+  FL_LOG(fl::INFO) << "[Decoder] LM constructed.\n";
 
   // Build Trie
   int blankIdx =
@@ -272,7 +272,7 @@ int main(int argc, char** argv) {
         trie->insert(tokensTensor, usrIdx, score);
       }
     }
-    LOG(INFO) << "[Decoder] Trie planted.\n";
+    FL_LOG(fl::INFO) << "[Decoder] Trie planted.\n";
 
     // Smearing
     SmearingMode smear_mode = SmearingMode::NONE;
@@ -281,10 +281,11 @@ int main(int argc, char** argv) {
     } else if (FLAGS_smearing == "max") {
       smear_mode = SmearingMode::MAX;
     } else if (FLAGS_smearing != "none") {
-      LOG(FATAL) << "[Decoder] Invalid smearing mode: " << FLAGS_smearing;
+      FL_LOG(fl::FATAL) << "[Decoder] Invalid smearing mode: "
+                        << FLAGS_smearing;
     }
     trie->smear(smear_mode);
-    LOG(INFO) << "[Decoder] Trie smeared.\n";
+    FL_LOG(fl::INFO) << "[Decoder] Trie smeared.\n";
   }
 
   /* ===================== AM Forwarding ===================== */
@@ -308,362 +309,375 @@ int main(int argc, char** argv) {
   std::mutex dataReadMutex;
   int datasetGlobalSampleId = 0; // A gloabal index for data reading
 
-  auto runAmForward = [&dataReadMutex,
-                       &datasetGlobalSampleId,
-                       &network,
-                       &criterion,
-                       &nSamples,
-                       &ds,
-                       &tokenDict,
-                       &wordDict,
-                       &emissionQueue](int tid) {
-    // Initialize AM
-    af::setDevice(tid);
-    std::shared_ptr<fl::Module> localNetwork = network;
-    std::shared_ptr<SequenceCriterion> localCriterion = criterion;
-    if (tid != 0) {
-      std::unordered_map<std::string, std::string> dummyCfg;
-      Serializer::load(FLAGS_am, dummyCfg, localNetwork, localCriterion);
-      localNetwork->eval();
-      localCriterion->eval();
-    }
-
-    while (datasetGlobalSampleId < nSamples) {
-      /* 1. Get sample */
-      int datasetLocalSampleId = -1;
-      std::vector<af::array> sample;
-      {
-        std::lock_guard<std::mutex> lock(dataReadMutex);
-        sample = ds->get(datasetGlobalSampleId);
-        datasetLocalSampleId = datasetGlobalSampleId;
-        datasetGlobalSampleId++;
-      }
-      auto sampleId = readSampleIds(sample[kSampleIdx]).front();
-
-      /* 2. Load Targets */
-      TargetUnit targetUnit;
-      auto tokenTarget = afToVector<int>(sample[kTargetIdx]);
-      auto wordTarget = afToVector<int>(sample[kWordIdx]);
-      // TODO: we will reform the dataset so that the loaded word
-      // targets are strings already
-      std::vector<std::string> wordTargetStr;
-      if (FLAGS_uselexicon) {
-        wordTargetStr = wrdIdx2Wrd(wordTarget, wordDict);
-      } else {
-        auto letterTarget = tknTarget2Ltr(tokenTarget, tokenDict);
-        wordTargetStr = tkn2Wrd(letterTarget);
-      }
-
-      targetUnit.wordTargetStr = wordTargetStr;
-      targetUnit.tokenTarget = tokenTarget;
-
-      /* 3. Load Emissions */
-      EmissionUnit emissionUnit;
-      if (FLAGS_emission_dir.empty()) {
-        auto rawEmission =
-            localNetwork->forward({fl::input(sample[kInputIdx])}).front();
-        emissionUnit = EmissionUnit(
-            afToVector<float>(rawEmission),
-            sampleId,
-            rawEmission.dims(1),
-            rawEmission.dims(0));
-      } else {
-        auto cleanTestPath = cleanFilepath(FLAGS_test);
-        std::string emissionDir =
-            pathsConcat(FLAGS_emission_dir, cleanTestPath);
-        std::string savePath = pathsConcat(emissionDir, sampleId + ".bin");
-        Serializer::load(savePath, emissionUnit);
-      }
-
-      emissionQueue.add({emissionUnit, targetUnit});
-      if (datasetLocalSampleId == nSamples - 1) {
-        emissionQueue.finishAdding();
-      }
-    }
-
-    localNetwork.reset(); // AM is only used in running forward pass. So we will
-    // free the space of it on GPU or memory.
-    // localNetwork.use_count() will be 0 after this call.
-
-    af::deviceGC(); // Explicitly call the Garbage collector.
-  };
-
-  /* ===================== Decode ===================== */
-  auto runDecoder = [&criterion,
-                     &lm,
-                     &trie,
-                     &silIdx,
-                     &blankIdx,
-                     &unkWordIdx,
-                     &criterionType,
-                     &transition,
-                     &usrDict,
-                     &tokenDict,
-                     &wordDict,
-                     &decoderOpt,
-                     &emissionQueue,
-                     &writeHyp,
-                     &writeRef,
-                     &writeLog,
-                     &sliceWer,
-                     &sliceLer,
-                     &sliceNumWords,
-                     &sliceNumTokens,
-                     &sliceNumSamples,
-                     &sliceTime](int tid) {
-    try {
-      /* 1. Prepare GPU-dependent resources */
-      // Note: These 2 GPU-dependent models should be placed on different
-      // cards
-      // for different threads and nthread_decoder should not be greater
-      // than
-      // the number of GPUs.
-      std::shared_ptr<SequenceCriterion> localCriterion = criterion;
-      std::shared_ptr<LM> localLm = lm;
-      if (FLAGS_lmtype == "convlm" || criterionType == CriterionType::S2S) {
-        if (tid >= af::getDeviceCount()) {
-          LOG(FATAL)
-              << "FLAGS_nthread_decoder exceeds the number of visible GPUs";
-        }
+  auto runAmForward =
+      [&dataReadMutex,
+       &datasetGlobalSampleId,
+       &network,
+       &criterion,
+       &nSamples,
+       &ds,
+       &tokenDict,
+       &wordDict,
+       &emissionQueue](int tid) {
+        // Initialize AM
         af::setDevice(tid);
-      }
-
-      // Make a copy for non-main threads.
-      if (tid != 0) {
-        if (FLAGS_lmtype == "convlm") {
-          LOG(INFO) << "[ConvLM]: Loading LM from " << FLAGS_lm;
-          std::shared_ptr<fl::Module> convLmModel;
-          Serializer::load(FLAGS_lm, convLmModel);
-          convLmModel->eval();
-
-          auto getConvLmScoreFunc = buildGetConvLmScoreFunction(convLmModel);
-          localLm = std::make_shared<ConvLM>(
-              getConvLmScoreFunc,
-              FLAGS_lm_vocab,
-              usrDict,
-              FLAGS_lm_memory,
-              FLAGS_beamsize);
-        }
-
-        if (criterionType == CriterionType::S2S) {
-          std::shared_ptr<fl::Module> dummyNetwork;
+        std::shared_ptr<fl::Module> localNetwork = network;
+        std::shared_ptr<SequenceCriterion> localCriterion = criterion;
+        if (tid != 0) {
           std::unordered_map<std::string, std::string> dummyCfg;
-          Serializer::load(FLAGS_am, dummyCfg, dummyNetwork, localCriterion);
+          Serializer::load(FLAGS_am, dummyCfg, localNetwork, localCriterion);
+          localNetwork->eval();
           localCriterion->eval();
         }
-      }
 
-      /* 2. Build Decoder */
-      std::unique_ptr<Decoder> decoder;
-      if (criterionType == CriterionType::S2S) {
-        auto amUpdateFunc = FLAGS_criterion == kSeq2SeqCriterion
-            ? buildAmUpdateFunction(localCriterion)
-            : buildTransformerAmUpdateFunction(localCriterion);
-        int eosIdx = tokenDict.getIndex(fl::app::asr::kEosToken);
-
-        if (FLAGS_decodertype == "wrd") {
-          decoder.reset(new LexiconSeq2SeqDecoder(
-              decoderOpt,
-              trie,
-              localLm,
-              eosIdx,
-              amUpdateFunc,
-              FLAGS_maxdecoderoutputlen,
-              false));
-          LOG(INFO)
-              << "[Decoder] LexiconSeq2Seq decoder with word-LM loaded in thread: "
-              << tid;
-        } else if (FLAGS_decodertype == "tkn") {
-          if (FLAGS_uselexicon) {
-            decoder.reset(new LexiconSeq2SeqDecoder(
-                decoderOpt,
-                trie,
-                localLm,
-                eosIdx,
-                amUpdateFunc,
-                FLAGS_maxdecoderoutputlen,
-                true));
-            LOG(INFO)
-                << "[Decoder] LexiconSeq2Seq decoder with token-LM loaded in thread: "
-                << tid;
-          } else {
-            decoder.reset(new LexiconFreeSeq2SeqDecoder(
-                decoderOpt,
-                localLm,
-                eosIdx,
-                amUpdateFunc,
-                FLAGS_maxdecoderoutputlen));
-            LOG(INFO)
-                << "[Decoder] LexiconFreeSeq2Seq decoder with token-LM loaded in thread: "
-                << tid;
+        while (datasetGlobalSampleId < nSamples) {
+          /* 1. Get sample */
+          int datasetLocalSampleId = -1;
+          std::vector<af::array> sample;
+          {
+            std::lock_guard<std::mutex> lock(dataReadMutex);
+            sample = ds->get(datasetGlobalSampleId);
+            datasetLocalSampleId = datasetGlobalSampleId;
+            datasetGlobalSampleId++;
           }
-        } else {
-          LOG(FATAL) << "Unsupported decoder type: " << FLAGS_decodertype;
+          auto sampleId = readSampleIds(sample[kSampleIdx]).front();
+
+          /* 2. Load Targets */
+          TargetUnit targetUnit;
+          auto tokenTarget = afToVector<int>(sample[kTargetIdx]);
+          auto wordTarget = afToVector<int>(sample[kWordIdx]);
+          // TODO: we will reform the dataset so that the loaded word
+          // targets are strings already
+          std::vector<std::string> wordTargetStr;
+          if (FLAGS_uselexicon) {
+            wordTargetStr = wrdIdx2Wrd(wordTarget, wordDict);
+          } else {
+            auto letterTarget = tknTarget2Ltr(tokenTarget, tokenDict);
+            wordTargetStr = tkn2Wrd(letterTarget);
+          }
+
+          targetUnit.wordTargetStr = wordTargetStr;
+          targetUnit.tokenTarget = tokenTarget;
+
+          /* 3. Load Emissions */
+          EmissionUnit emissionUnit;
+          if (FLAGS_emission_dir.empty()) {
+            auto rawEmission =
+                localNetwork->forward({fl::input(sample[kInputIdx])}).front();
+            emissionUnit = EmissionUnit(
+                afToVector<float>(rawEmission),
+                sampleId,
+                rawEmission.dims(1),
+                rawEmission.dims(0));
+          } else {
+            auto cleanTestPath = cleanFilepath(FLAGS_test);
+            std::string emissionDir =
+                pathsConcat(FLAGS_emission_dir, cleanTestPath);
+            std::string savePath = pathsConcat(emissionDir, sampleId + ".bin");
+            Serializer::load(savePath, emissionUnit);
+          }
+
+          emissionQueue.add({emissionUnit, targetUnit});
+          if (datasetLocalSampleId == nSamples - 1) {
+            emissionQueue.finishAdding();
+          }
         }
-      } else {
-        if (FLAGS_decodertype == "wrd") {
-          decoder.reset(new LexiconDecoder(
-              decoderOpt,
-              trie,
-              localLm,
-              silIdx,
-              blankIdx,
-              unkWordIdx,
-              transition,
-              false));
-          LOG(INFO)
-              << "[Decoder] Lexicon decoder with word-LM loaded in thread: "
-              << tid;
-        } else if (FLAGS_decodertype == "tkn") {
-          if (FLAGS_uselexicon) {
-            decoder.reset(new LexiconDecoder(
-                decoderOpt,
-                trie,
-                localLm,
-                silIdx,
-                blankIdx,
-                unkWordIdx,
-                transition,
-                true));
-            LOG(INFO)
-                << "[Decoder] Lexicon decoder with token-LM loaded in thread: "
-                << tid;
-          } else {
-            decoder.reset(new LexiconFreeDecoder(
-                decoderOpt, localLm, silIdx, blankIdx, transition));
-            LOG(INFO)
-                << "[Decoder] Lexicon-free decoder with token-LM loaded in thread: "
-                << tid;
+
+        localNetwork
+            .reset(); // AM is only used in running forward pass. So we will
+        // free the space of it on GPU or memory.
+        // localNetwork.use_count() will be 0 after this call.
+
+        af::deviceGC(); // Explicitly call the Garbage collector.
+      };
+
+  /* ===================== Decode ===================== */
+  auto runDecoder =
+      [&criterion,
+       &lm,
+       &trie,
+       &silIdx,
+       &blankIdx,
+       &unkWordIdx,
+       &criterionType,
+       &transition,
+       &usrDict,
+       &tokenDict,
+       &wordDict,
+       &decoderOpt,
+       &emissionQueue,
+       &writeHyp,
+       &writeRef,
+       &writeLog,
+       &sliceWer,
+       &sliceLer,
+       &sliceNumWords,
+       &sliceNumTokens,
+       &sliceNumSamples,
+       &sliceTime](int tid) {
+        try {
+          /* 1. Prepare GPU-dependent resources */
+          // Note: These 2 GPU-dependent models should be placed on different
+          // cards
+          // for different threads and nthread_decoder should not be greater
+          // than
+          // the number of GPUs.
+          std::shared_ptr<SequenceCriterion> localCriterion = criterion;
+          std::shared_ptr<LM> localLm = lm;
+          if (FLAGS_lmtype == "convlm" || criterionType == CriterionType::S2S) {
+            if (tid >= af::getDeviceCount()) {
+              FL_LOG(fl::FATAL)
+                  << "FLAGS_nthread_decoder exceeds the number of visible GPUs";
+            }
+            af::setDevice(tid);
           }
-        } else {
-          LOG(FATAL) << "Unsupported decoder type: " << FLAGS_decodertype;
-        }
-      }
 
-      /* 3. Get data and run decoder */
-      TestMeters meters;
-      EmissionTargetPair emissionTargetPair;
-      while (emissionQueue.get(emissionTargetPair)) {
-        const auto& emissionUnit = emissionTargetPair.first;
-        const auto& targetUnit = emissionTargetPair.second;
+          // Make a copy for non-main threads.
+          if (tid != 0) {
+            if (FLAGS_lmtype == "convlm") {
+              FL_LOG(fl::INFO) << "[ConvLM]: Loading LM from " << FLAGS_lm;
+              std::shared_ptr<fl::Module> convLmModel;
+              Serializer::load(FLAGS_lm, convLmModel);
+              convLmModel->eval();
 
-        const auto& nFrames = emissionUnit.nFrames;
-        const auto& nTokens = emissionUnit.nTokens;
-        const auto& emission = emissionUnit.emission;
-        const auto& sampleId = emissionUnit.sampleId;
-        const auto& wordTarget = targetUnit.wordTargetStr;
-        const auto& tokenTarget = targetUnit.tokenTarget;
-
-        // DecodeResult
-        meters.timer.reset();
-        meters.timer.resume();
-        const auto& results =
-            decoder->decode(emission.data(), nFrames, nTokens);
-        meters.timer.stop();
-
-        int nTopHyps = FLAGS_isbeamdump ? results.size() : 1;
-        for (int i = 0; i < nTopHyps; i++) {
-          // Cleanup predictions
-          auto rawWordPrediction = results[i].words;
-          auto rawTokenPrediction = results[i].tokens;
-
-          auto letterTarget = tknTarget2Ltr(tokenTarget, tokenDict);
-          auto letterPrediction =
-              tknPrediction2Ltr(rawTokenPrediction, tokenDict);
-          std::vector<std::string> wordPrediction;
-          if (FLAGS_uselexicon) {
-            rawWordPrediction =
-                validateIdx(rawWordPrediction, wordDict.getIndex(kUnkToken));
-            wordPrediction = wrdIdx2Wrd(rawWordPrediction, wordDict);
-          } else {
-            wordPrediction = tkn2Wrd(letterPrediction);
-          }
-          auto wordTargetStr = join(" ", wordTarget);
-          auto wordPredictionStr = join(" ", wordPrediction);
-
-          // Normal decoding and computing WER
-          if (!FLAGS_isbeamdump) {
-            meters.werSlice.add(wordPrediction, wordTarget);
-            meters.lerSlice.add(letterPrediction, letterTarget);
-
-            if (!FLAGS_sclite.empty()) {
-              std::string suffix = " (" + sampleId + ")\n";
-              writeHyp(wordPredictionStr + suffix);
-              writeRef(wordTargetStr + suffix);
+              auto getConvLmScoreFunc =
+                  buildGetConvLmScoreFunction(convLmModel);
+              localLm = std::make_shared<ConvLM>(
+                  getConvLmScoreFunc,
+                  FLAGS_lm_vocab,
+                  usrDict,
+                  FLAGS_lm_memory,
+                  FLAGS_beamsize);
             }
 
-            if (FLAGS_show) {
-              meters.wer.reset();
-              meters.ler.reset();
-              meters.wer.add(wordPrediction, wordTarget);
-              meters.ler.add(letterPrediction, letterTarget);
+            if (criterionType == CriterionType::S2S) {
+              std::shared_ptr<fl::Module> dummyNetwork;
+              std::unordered_map<std::string, std::string> dummyCfg;
+              Serializer::load(
+                  FLAGS_am, dummyCfg, dummyNetwork, localCriterion);
+              localCriterion->eval();
+            }
+          }
 
-              std::stringstream buffer;
-              buffer << "|T|: " << wordTargetStr << std::endl;
-              buffer << "|P|: " << wordPredictionStr << std::endl;
-              if (FLAGS_showletters) {
-                buffer << "|t|: " << join(" ", letterTarget) << std::endl;
-                buffer << "|p|: " << join(" ", letterPrediction) << std::endl;
+          /* 2. Build Decoder */
+          std::unique_ptr<Decoder> decoder;
+          if (criterionType == CriterionType::S2S) {
+            auto amUpdateFunc = FLAGS_criterion == kSeq2SeqCriterion
+                ? buildAmUpdateFunction(localCriterion)
+                : buildTransformerAmUpdateFunction(localCriterion);
+            int eosIdx = tokenDict.getIndex(fl::app::asr::kEosToken);
+
+            if (FLAGS_decodertype == "wrd") {
+              decoder.reset(new LexiconSeq2SeqDecoder(
+                  decoderOpt,
+                  trie,
+                  localLm,
+                  eosIdx,
+                  amUpdateFunc,
+                  FLAGS_maxdecoderoutputlen,
+                  false));
+              FL_LOG(fl::INFO)
+                  << "[Decoder] LexiconSeq2Seq decoder with word-LM loaded in thread: "
+                  << tid;
+            } else if (FLAGS_decodertype == "tkn") {
+              if (FLAGS_uselexicon) {
+                decoder.reset(new LexiconSeq2SeqDecoder(
+                    decoderOpt,
+                    trie,
+                    localLm,
+                    eosIdx,
+                    amUpdateFunc,
+                    FLAGS_maxdecoderoutputlen,
+                    true));
+                FL_LOG(fl::INFO)
+                    << "[Decoder] LexiconSeq2Seq decoder with token-LM loaded in thread: "
+                    << tid;
+              } else {
+                decoder.reset(new LexiconFreeSeq2SeqDecoder(
+                    decoderOpt,
+                    localLm,
+                    eosIdx,
+                    amUpdateFunc,
+                    FLAGS_maxdecoderoutputlen));
+                FL_LOG(fl::INFO)
+                    << "[Decoder] LexiconFreeSeq2Seq decoder with token-LM loaded in thread: "
+                    << tid;
               }
-              buffer << "[sample: " << sampleId
-                     << ", WER: " << meters.wer.value()[0]
-                     << "\%, LER: " << meters.ler.value()[0]
-                     << "\%, slice WER: " << meters.werSlice.value()[0]
-                     << "\%, slice LER: " << meters.lerSlice.value()[0]
-                     << "\%, decoded samples (thread " << tid
-                     << "): " << sliceNumSamples[tid] + 1 << "]" << std::endl;
+            } else {
+              FL_LOG(fl::FATAL) << "Unsupported decoder type: "
+                                << FLAGS_decodertype;
+            }
+          } else {
+            if (FLAGS_decodertype == "wrd") {
+              decoder.reset(new LexiconDecoder(
+                  decoderOpt,
+                  trie,
+                  localLm,
+                  silIdx,
+                  blankIdx,
+                  unkWordIdx,
+                  transition,
+                  false));
+              FL_LOG(fl::INFO)
+                  << "[Decoder] Lexicon decoder with word-LM loaded in thread: "
+                  << tid;
+            } else if (FLAGS_decodertype == "tkn") {
+              if (FLAGS_uselexicon) {
+                decoder.reset(new LexiconDecoder(
+                    decoderOpt,
+                    trie,
+                    localLm,
+                    silIdx,
+                    blankIdx,
+                    unkWordIdx,
+                    transition,
+                    true));
+                FL_LOG(fl::INFO)
+                    << "[Decoder] Lexicon decoder with token-LM loaded in thread: "
+                    << tid;
+              } else {
+                decoder.reset(new LexiconFreeDecoder(
+                    decoderOpt, localLm, silIdx, blankIdx, transition));
+                FL_LOG(fl::INFO)
+                    << "[Decoder] Lexicon-free decoder with token-LM loaded in thread: "
+                    << tid;
+              }
+            } else {
+              FL_LOG(fl::FATAL) << "Unsupported decoder type: "
+                                << FLAGS_decodertype;
+            }
+          }
 
-              std::cout << buffer.str();
-              if (!FLAGS_sclite.empty()) {
-                writeLog(buffer.str());
+          /* 3. Get data and run decoder */
+          TestMeters meters;
+          EmissionTargetPair emissionTargetPair;
+          while (emissionQueue.get(emissionTargetPair)) {
+            const auto& emissionUnit = emissionTargetPair.first;
+            const auto& targetUnit = emissionTargetPair.second;
+
+            const auto& nFrames = emissionUnit.nFrames;
+            const auto& nTokens = emissionUnit.nTokens;
+            const auto& emission = emissionUnit.emission;
+            const auto& sampleId = emissionUnit.sampleId;
+            const auto& wordTarget = targetUnit.wordTargetStr;
+            const auto& tokenTarget = targetUnit.tokenTarget;
+
+            // DecodeResult
+            meters.timer.reset();
+            meters.timer.resume();
+            const auto& results =
+                decoder->decode(emission.data(), nFrames, nTokens);
+            meters.timer.stop();
+
+            int nTopHyps = FLAGS_isbeamdump ? results.size() : 1;
+            for (int i = 0; i < nTopHyps; i++) {
+              // Cleanup predictions
+              auto rawWordPrediction = results[i].words;
+              auto rawTokenPrediction = results[i].tokens;
+
+              auto letterTarget = tknTarget2Ltr(tokenTarget, tokenDict);
+              auto letterPrediction =
+                  tknPrediction2Ltr(rawTokenPrediction, tokenDict);
+              std::vector<std::string> wordPrediction;
+              if (FLAGS_uselexicon) {
+                rawWordPrediction = validateIdx(
+                    rawWordPrediction, wordDict.getIndex(kUnkToken));
+                wordPrediction = wrdIdx2Wrd(rawWordPrediction, wordDict);
+              } else {
+                wordPrediction = tkn2Wrd(letterPrediction);
+              }
+              auto wordTargetStr = join(" ", wordTarget);
+              auto wordPredictionStr = join(" ", wordPrediction);
+
+              // Normal decoding and computing WER
+              if (!FLAGS_isbeamdump) {
+                meters.werSlice.add(wordPrediction, wordTarget);
+                meters.lerSlice.add(letterPrediction, letterTarget);
+
+                if (!FLAGS_sclite.empty()) {
+                  std::string suffix = " (" + sampleId + ")\n";
+                  writeHyp(wordPredictionStr + suffix);
+                  writeRef(wordTargetStr + suffix);
+                }
+
+                if (FLAGS_show) {
+                  meters.wer.reset();
+                  meters.ler.reset();
+                  meters.wer.add(wordPrediction, wordTarget);
+                  meters.ler.add(letterPrediction, letterTarget);
+
+                  std::stringstream buffer;
+                  buffer << "|T|: " << wordTargetStr << std::endl;
+                  buffer << "|P|: " << wordPredictionStr << std::endl;
+                  if (FLAGS_showletters) {
+                    buffer << "|t|: " << join(" ", letterTarget) << std::endl;
+                    buffer << "|p|: " << join(" ", letterPrediction)
+                           << std::endl;
+                  }
+                  buffer << "[sample: " << sampleId
+                         << ", WER: " << meters.wer.value()[0]
+                         << "\%, LER: " << meters.ler.value()[0]
+                         << "\%, slice WER: " << meters.werSlice.value()[0]
+                         << "\%, slice LER: " << meters.lerSlice.value()[0]
+                         << "\%, decoded samples (thread " << tid
+                         << "): " << sliceNumSamples[tid] + 1 << "]"
+                         << std::endl;
+
+                  std::cout << buffer.str();
+                  if (!FLAGS_sclite.empty()) {
+                    writeLog(buffer.str());
+                  }
+                }
+
+                // Update conters
+                sliceNumWords[tid] += wordTarget.size();
+                sliceNumTokens[tid] += letterTarget.size();
+                sliceTime[tid] += meters.timer.value();
+                sliceNumSamples[tid] += 1;
+              }
+              // Beam Dump
+              else {
+                meters.wer.reset();
+                meters.wer.add(wordPrediction, wordTarget);
+                auto wer = meters.wer.value()[0];
+
+                if (FLAGS_sclite.empty()) {
+                  FL_LOG(fl::FATAL)
+                      << "FLAGS_sclite is empty, nowhere to dump the beam.";
+                }
+
+                auto score = results[i].score;
+                auto amScore = results[i].amScore;
+                auto lmScore = results[i].lmScore;
+                auto outString = sampleId + " | " + std::to_string(score) +
+                    " | " + std::to_string(amScore) + " | " +
+                    std::to_string(lmScore) + " | " + std::to_string(wer) +
+                    " | " + wordPredictionStr + "\n";
+                writeHyp(outString);
               }
             }
-
-            // Update conters
-            sliceNumWords[tid] += wordTarget.size();
-            sliceNumTokens[tid] += letterTarget.size();
-            sliceTime[tid] += meters.timer.value();
-            sliceNumSamples[tid] += 1;
           }
-          // Beam Dump
-          else {
-            meters.wer.reset();
-            meters.wer.add(wordPrediction, wordTarget);
-            auto wer = meters.wer.value()[0];
-
-            if (FLAGS_sclite.empty()) {
-              LOG(FATAL) << "FLAGS_sclite is empty, nowhere to dump the beam.";
-            }
-
-            auto score = results[i].score;
-            auto amScore = results[i].amScore;
-            auto lmScore = results[i].lmScore;
-            auto outString = sampleId + " | " + std::to_string(score) + " | " +
-                std::to_string(amScore) + " | " + std::to_string(lmScore) +
-                " | " + std::to_string(wer) + " | " + wordPredictionStr + "\n";
-            writeHyp(outString);
-          }
+          sliceWer[tid] = meters.werSlice.value()[0];
+          sliceLer[tid] = meters.lerSlice.value()[0];
+        } catch (const std::exception& exc) {
+          FL_LOG(fl::FATAL) << "Exception in thread " << tid << "\n"
+                            << exc.what();
         }
-      }
-      sliceWer[tid] = meters.werSlice.value()[0];
-      sliceLer[tid] = meters.lerSlice.value()[0];
-    } catch (const std::exception& exc) {
-      LOG(FATAL) << "Exception in thread " << tid << "\n" << exc.what();
-    }
-  };
+      };
 
   /* ===================== Spread threades ===================== */
   if (FLAGS_nthread_decoder_am_forward <= 0) {
-    LOG(FATAL) << "FLAGS_nthread_decoder_am_forward ("
-               << FLAGS_nthread_decoder_am_forward << ") need to be positive ";
+    FL_LOG(fl::FATAL) << "FLAGS_nthread_decoder_am_forward ("
+                      << FLAGS_nthread_decoder_am_forward
+                      << ") need to be positive ";
   }
   if (FLAGS_nthread_decoder <= 0) {
-    LOG(FATAL) << "FLAGS_nthread_decoder (" << FLAGS_nthread_decoder
-               << ") need to be positive ";
+    FL_LOG(fl::FATAL) << "FLAGS_nthread_decoder (" << FLAGS_nthread_decoder
+                      << ") need to be positive ";
   }
 
   auto startThreadsAndJoin = [&runAmForward, &runDecoder](
-                                 int nAmThreads, int nDecoderThreads) {
+      int nAmThreads, int nDecoderThreads) {
     // We have to run AM forwarding and decoding in sequential to avoid GPU
     // OOM with two large neural nets.
     if (FLAGS_lmtype == "convlm") {
@@ -721,7 +735,7 @@ int main(int argc, char** argv) {
          << totalTime / totalSamples
          << "s/sample) -- WER: " << std::setprecision(6) << totalWer
          << ", LER: " << totalLer << "]" << std::endl;
-  LOG(INFO) << buffer.str();
+  FL_LOG(fl::INFO) << buffer.str();
   if (!FLAGS_sclite.empty()) {
     writeLog(buffer.str());
     hypStream.close();

--- a/app/asr/Test.cpp
+++ b/app/asr/Test.cpp
@@ -13,7 +13,6 @@
 #include <vector>
 
 #include <gflags/gflags.h>
-#include <glog/logging.h>
 #include "flashlight/flashlight/flashlight.h"
 
 #include "flashlight/app/asr/common/Defines.h"
@@ -21,7 +20,6 @@
 #include "flashlight/app/asr/decoder/Defines.h"
 #include "flashlight/app/asr/decoder/TranscriptionUtils.h"
 #include "flashlight/app/asr/runtime/runtime.h"
-
 #include "flashlight/ext/common/DistributedUtils.h"
 #include "flashlight/lib/common/System.h"
 #include "flashlight/lib/text/dictionary/Dictionary.h"
@@ -33,8 +31,6 @@ using namespace fl::lib::text;
 using namespace fl::app::asr;
 
 int main(int argc, char** argv) {
-  google::InitGoogleLogging(argv[0]);
-  google::InstallFailureSignalHandler();
   std::string exec(argv[0]);
   std::vector<std::string> argvs;
   for (int i = 0; i < argc; i++) {
@@ -42,15 +38,15 @@ int main(int argc, char** argv) {
   }
   gflags::SetUsageMessage("Usage: Please refer to https://git.io/JvJuR");
   if (argc <= 1) {
-    LOG(FATAL) << gflags::ProgramUsage();
+    FL_LOG(fl::FATAL) << gflags::ProgramUsage();
   }
 
   /* ===================== Parse Options ===================== */
-  LOG(INFO) << "Parsing command line flags";
+  FL_LOG(fl::INFO) << "Parsing command line flags";
   gflags::ParseCommandLineFlags(&argc, &argv, false);
   auto flagsfile = FLAGS_flagsfile;
   if (!flagsfile.empty()) {
-    LOG(INFO) << "Reading flags from file " << flagsfile;
+    FL_LOG(fl::INFO) << "Reading flags from file " << flagsfile;
     gflags::ReadFromFlagsFile(flagsfile, argv[0], true);
   }
 
@@ -58,21 +54,21 @@ int main(int argc, char** argv) {
   std::shared_ptr<fl::Module> network;
   std::shared_ptr<SequenceCriterion> criterion;
   std::unordered_map<std::string, std::string> cfg;
-  LOG(INFO) << "[Network] Reading acoustic model from " << FLAGS_am;
+  FL_LOG(fl::INFO) << "[Network] Reading acoustic model from " << FLAGS_am;
   af::setDevice(0);
   Serializer::load(FLAGS_am, cfg, network, criterion);
   network->eval();
   criterion->eval();
 
-  LOG(INFO) << "[Network] " << network->prettyString();
-  LOG(INFO) << "[Criterion] " << criterion->prettyString();
-  LOG(INFO) << "[Network] Number of params: " << numTotalParams(network);
+  FL_LOG(fl::INFO) << "[Network] " << network->prettyString();
+  FL_LOG(fl::INFO) << "[Criterion] " << criterion->prettyString();
+  FL_LOG(fl::INFO) << "[Network] Number of params: " << numTotalParams(network);
 
   auto flags = cfg.find(kGflags);
   if (flags == cfg.end()) {
-    LOG(FATAL) << "[Network] Invalid config loaded from " << FLAGS_am;
+    FL_LOG(fl::FATAL) << "[Network] Invalid config loaded from " << FLAGS_am;
   }
-  LOG(INFO) << "[Network] Updating flags from config file: " << FLAGS_am;
+  FL_LOG(fl::INFO) << "[Network] Updating flags from config file: " << FLAGS_am;
   gflags::ReadFlagsFromString(flags->second, gflags::GetArgv0(), true);
 
   // override with user-specified flags
@@ -85,7 +81,7 @@ int main(int argc, char** argv) {
   // flags are present and corresponding new flags aren't
   handleDeprecatedFlags();
 
-  LOG(INFO) << "Gflags after parsing \n" << serializeGflags("; ");
+  FL_LOG(fl::INFO) << "Gflags after parsing \n" << serializeGflags("; ");
 
   /* ===================== Create Dictionary ===================== */
   auto dictPath = pathsConcat(FLAGS_tokensdir, FLAGS_tokens);
@@ -106,14 +102,14 @@ int main(int argc, char** argv) {
   }
 
   int numClasses = tokenDict.indexSize();
-  LOG(INFO) << "Number of classes (network): " << numClasses;
+  FL_LOG(fl::INFO) << "Number of classes (network): " << numClasses;
 
   Dictionary wordDict;
   LexiconMap lexicon;
   if (!FLAGS_lexicon.empty()) {
     lexicon = loadWords(FLAGS_lexicon, FLAGS_maxword);
     wordDict = createWordDict(lexicon);
-    LOG(INFO) << "Number of words: " << wordDict.indexSize();
+    FL_LOG(fl::INFO) << "Number of words: " << wordDict.indexSize();
   }
 
   DictionaryMap dicts = {{kTargetIdx, tokenDict}, {kWordIdx, wordDict}};
@@ -133,7 +129,7 @@ int main(int argc, char** argv) {
   if (FLAGS_maxload > 0) {
     nSamples = std::min(nSamples, FLAGS_maxload);
   }
-  LOG(INFO) << "[Dataset] Dataset loaded.";
+  FL_LOG(fl::INFO) << "[Dataset] Dataset loaded.";
 
   /* ===================== Test ===================== */
   std::vector<double> sliceWer(FLAGS_nthread_decoder_am_forward);
@@ -158,10 +154,10 @@ int main(int argc, char** argv) {
     hypStream.open(hypPath);
     refStream.open(refPath);
     if (!hypStream.is_open() || !hypStream.good()) {
-      LOG(FATAL) << "Error opening hypothesis file: " << hypPath;
+      FL_LOG(fl::FATAL) << "Error opening hypothesis file: " << hypPath;
     }
     if (!refStream.is_open() || !refStream.good()) {
-      LOG(FATAL) << "Error opening reference file: " << refPath;
+      FL_LOG(fl::FATAL) << "Error opening reference file: " << refPath;
     }
   }
 
@@ -179,114 +175,115 @@ int main(int argc, char** argv) {
   std::mutex dataReadMutex;
   int datasetSampleId = 0; // A gloabal index for data reading
 
-  auto run = [&dataReadMutex,
-              &datasetSampleId,
-              &network,
-              &criterion,
-              &nSamples,
-              &ds,
-              &tokenDict,
-              &wordDict,
-              &writeHyp,
-              &writeRef,
-              &emissionDir,
-              &sliceWer,
-              &sliceLer,
-              &sliceNumWords,
-              &sliceNumTokens,
-              &sliceNumSamples,
-              &sliceTime](int tid) {
-    // Initialize AM
-    af::setDevice(tid);
-    std::shared_ptr<fl::Module> localNetwork = network;
-    std::shared_ptr<SequenceCriterion> localCriterion = criterion;
-    if (tid != 0) {
-      std::unordered_map<std::string, std::string> dummyCfg;
-      Serializer::load(FLAGS_am, dummyCfg, localNetwork, localCriterion);
-      localNetwork->eval();
-      localCriterion->eval();
-    }
+  auto run =
+      [&dataReadMutex,
+       &datasetSampleId,
+       &network,
+       &criterion,
+       &nSamples,
+       &ds,
+       &tokenDict,
+       &wordDict,
+       &writeHyp,
+       &writeRef,
+       &emissionDir,
+       &sliceWer,
+       &sliceLer,
+       &sliceNumWords,
+       &sliceNumTokens,
+       &sliceNumSamples,
+       &sliceTime](int tid) {
+        // Initialize AM
+        af::setDevice(tid);
+        std::shared_ptr<fl::Module> localNetwork = network;
+        std::shared_ptr<SequenceCriterion> localCriterion = criterion;
+        if (tid != 0) {
+          std::unordered_map<std::string, std::string> dummyCfg;
+          Serializer::load(FLAGS_am, dummyCfg, localNetwork, localCriterion);
+          localNetwork->eval();
+          localCriterion->eval();
+        }
 
-    TestMeters meters;
-    meters.timer.resume();
-    while (datasetSampleId < nSamples) {
-      std::vector<af::array> sample;
-      {
-        std::lock_guard<std::mutex> lock(dataReadMutex);
-        sample = ds->get(datasetSampleId);
-        datasetSampleId++;
-      }
-      auto rawEmission =
-          localNetwork->forward({fl::input(sample[kInputIdx])}).front();
-      auto emission = afToVector<float>(rawEmission);
-      auto tokenTarget = afToVector<int>(sample[kTargetIdx]);
-      auto wordTarget = afToVector<int>(sample[kWordIdx]);
-      auto sampleId = readSampleIds(sample[kSampleIdx]).front();
+        TestMeters meters;
+        meters.timer.resume();
+        while (datasetSampleId < nSamples) {
+          std::vector<af::array> sample;
+          {
+            std::lock_guard<std::mutex> lock(dataReadMutex);
+            sample = ds->get(datasetSampleId);
+            datasetSampleId++;
+          }
+          auto rawEmission =
+              localNetwork->forward({fl::input(sample[kInputIdx])}).front();
+          auto emission = afToVector<float>(rawEmission);
+          auto tokenTarget = afToVector<int>(sample[kTargetIdx]);
+          auto wordTarget = afToVector<int>(sample[kWordIdx]);
+          auto sampleId = readSampleIds(sample[kSampleIdx]).front();
 
-      auto letterTarget = tknTarget2Ltr(tokenTarget, tokenDict);
-      std::vector<std::string> wordTargetStr;
-      if (FLAGS_uselexicon) {
-        wordTargetStr = wrdIdx2Wrd(wordTarget, wordDict);
-      } else {
-        wordTargetStr = tkn2Wrd(letterTarget);
-      }
+          auto letterTarget = tknTarget2Ltr(tokenTarget, tokenDict);
+          std::vector<std::string> wordTargetStr;
+          if (FLAGS_uselexicon) {
+            wordTargetStr = wrdIdx2Wrd(wordTarget, wordDict);
+          } else {
+            wordTargetStr = tkn2Wrd(letterTarget);
+          }
 
-      // Tokens
-      auto tokenPrediction =
-          afToVector<int>(localCriterion->viterbiPath(rawEmission.array()));
-      auto letterPrediction = tknPrediction2Ltr(tokenPrediction, tokenDict);
+          // Tokens
+          auto tokenPrediction =
+              afToVector<int>(localCriterion->viterbiPath(rawEmission.array()));
+          auto letterPrediction = tknPrediction2Ltr(tokenPrediction, tokenDict);
 
-      meters.lerSlice.add(letterPrediction, letterTarget);
+          meters.lerSlice.add(letterPrediction, letterTarget);
 
-      // Words
-      std::vector<std::string> wrdPredictionStr = tkn2Wrd(letterPrediction);
-      meters.werSlice.add(wrdPredictionStr, wordTargetStr);
+          // Words
+          std::vector<std::string> wrdPredictionStr = tkn2Wrd(letterPrediction);
+          meters.werSlice.add(wrdPredictionStr, wordTargetStr);
 
-      if (!FLAGS_sclite.empty()) {
-        writeRef(join(" ", wordTargetStr) + " (" + sampleId + ")\n");
-        writeHyp(join(" ", wrdPredictionStr) + " (" + sampleId + ")\n");
-      }
+          if (!FLAGS_sclite.empty()) {
+            writeRef(join(" ", wordTargetStr) + " (" + sampleId + ")\n");
+            writeHyp(join(" ", wrdPredictionStr) + " (" + sampleId + ")\n");
+          }
 
-      if (FLAGS_show) {
-        meters.ler.reset();
-        meters.wer.reset();
-        meters.ler.add(letterPrediction, letterTarget);
-        meters.wer.add(wrdPredictionStr, wordTargetStr);
+          if (FLAGS_show) {
+            meters.ler.reset();
+            meters.wer.reset();
+            meters.ler.add(letterPrediction, letterTarget);
+            meters.wer.add(wrdPredictionStr, wordTargetStr);
 
-        std::cout << "|T|: " << join(" ", letterTarget) << std::endl;
-        std::cout << "|P|: " << join(" ", letterPrediction) << std::endl;
-        std::cout << "[sample: " << sampleId
-                  << ", WER: " << meters.wer.value()[0]
-                  << "\%, LER: " << meters.ler.value()[0]
-                  << "\%, total WER: " << meters.werSlice.value()[0]
-                  << "\%, total LER: " << meters.lerSlice.value()[0]
-                  << "\%, progress (thread " << tid << "): "
-                  << static_cast<float>(datasetSampleId) / nSamples * 100
-                  << "\%]" << std::endl;
-      }
+            std::cout << "|T|: " << join(" ", letterTarget) << std::endl;
+            std::cout << "|P|: " << join(" ", letterPrediction) << std::endl;
+            std::cout << "[sample: " << sampleId
+                      << ", WER: " << meters.wer.value()[0]
+                      << "\%, LER: " << meters.ler.value()[0]
+                      << "\%, total WER: " << meters.werSlice.value()[0]
+                      << "\%, total LER: " << meters.lerSlice.value()[0]
+                      << "\%, progress (thread " << tid << "): "
+                      << static_cast<float>(datasetSampleId) / nSamples * 100
+                      << "\%]" << std::endl;
+          }
 
-      /* Save emission and targets */
-      int nTokens = rawEmission.dims(0);
-      int nFrames = rawEmission.dims(1);
-      EmissionUnit emissionUnit(emission, sampleId, nFrames, nTokens);
+          /* Save emission and targets */
+          int nTokens = rawEmission.dims(0);
+          int nFrames = rawEmission.dims(1);
+          EmissionUnit emissionUnit(emission, sampleId, nFrames, nTokens);
 
-      // Update counters
-      sliceNumWords[tid] += wordTarget.size();
-      sliceNumTokens[tid] += letterTarget.size();
-      sliceNumSamples[tid]++;
+          // Update counters
+          sliceNumWords[tid] += wordTarget.size();
+          sliceNumTokens[tid] += letterTarget.size();
+          sliceNumSamples[tid]++;
 
-      if (!emissionDir.empty()) {
-        std::string savePath = pathsConcat(emissionDir, sampleId + ".bin");
-        Serializer::save(savePath, emissionUnit);
-      }
-    }
+          if (!emissionDir.empty()) {
+            std::string savePath = pathsConcat(emissionDir, sampleId + ".bin");
+            Serializer::save(savePath, emissionUnit);
+          }
+        }
 
-    meters.timer.stop();
+        meters.timer.stop();
 
-    sliceWer[tid] = meters.werSlice.value()[0];
-    sliceLer[tid] = meters.lerSlice.value()[0];
-    sliceTime[tid] = meters.timer.value();
-  };
+        sliceWer[tid] = meters.werSlice.value()[0];
+        sliceLer[tid] = meters.lerSlice.value()[0];
+        sliceTime[tid] = meters.timer.value();
+      };
 
   /* Spread threades */
   auto startThreadsAndJoin = [&run](int nThreads) {
@@ -298,7 +295,7 @@ int main(int argc, char** argv) {
         threadPool.enqueue(run, i);
       }
     } else {
-      LOG(FATAL) << "Invalid negative FLAGS_nthread_decoder_am_forward";
+      FL_LOG(fl::FATAL) << "Invalid negative FLAGS_nthread_decoder_am_forward";
     }
   };
   auto timer = fl::TimeMeter();
@@ -319,12 +316,13 @@ int main(int argc, char** argv) {
     totalTime += sliceTime[i];
   }
 
-  LOG(INFO) << "------";
-  LOG(INFO) << "[Test " << FLAGS_test << " (" << totalSamples << " samples) in "
-            << timer.value() << "s (actual decoding time "
-            << std::setprecision(3) << totalTime / totalSamples
-            << "s/sample) -- WER: " << std::setprecision(6) << totalWer
-            << ", LER: " << totalLer << "]" << std::endl;
+  FL_LOG(fl::INFO) << "------";
+  FL_LOG(fl::INFO) << "[Test " << FLAGS_test << " (" << totalSamples
+                   << " samples) in " << timer.value()
+                   << "s (actual decoding time " << std::setprecision(3)
+                   << totalTime / totalSamples
+                   << "s/sample) -- WER: " << std::setprecision(6) << totalWer
+                   << ", LER: " << totalLer << "]";
 
   return 0;
 }

--- a/app/asr/Train.cpp
+++ b/app/asr/Train.cpp
@@ -15,7 +15,7 @@
 #include <cereal/archives/json.hpp>
 #include <cereal/types/unordered_map.hpp>
 #include <gflags/gflags.h>
-#include <glog/logging.h>
+
 #include "flashlight/flashlight/contrib/contrib.h"
 #include "flashlight/flashlight/flashlight.h"
 
@@ -38,8 +38,6 @@ using namespace fl::lib::audio;
 using namespace fl::app::asr;
 
 int main(int argc, char** argv) {
-  google::InitGoogleLogging(argv[0]);
-  google::InstallFailureSignalHandler();
   std::string exec(argv[0]);
   std::vector<std::string> argvs;
   for (int i = 0; i < argc; i++) {
@@ -58,13 +56,13 @@ int main(int argc, char** argv) {
   int64_t startEpoch = 0;
   int64_t startUpdate = 0;
   if (argc <= 1) {
-    LOG(FATAL) << gflags::ProgramUsage();
+    FL_LOG(fl::FATAL) << gflags::ProgramUsage();
   }
   if (runStatus == kTrainMode) {
-    LOG(INFO) << "Parsing command line flags";
+    FL_LOG(fl::INFO) << "Parsing command line flags";
     gflags::ParseCommandLineFlags(&argc, &argv, false);
     if (!FLAGS_flagsfile.empty()) {
-      LOG(INFO) << "Reading flags from file " << FLAGS_flagsfile;
+      FL_LOG(fl::INFO) << "Reading flags from file " << FLAGS_flagsfile;
       gflags::ReadFromFlagsFile(FLAGS_flagsfile, argv[0], true);
     }
     gflags::ParseCommandLineFlags(&argc, &argv, false);
@@ -75,34 +73,37 @@ int main(int argc, char** argv) {
       ++runIdx;
     }
     reloadPath = getRunFile("model_last.bin", runIdx - 1, runPath);
-    LOG(INFO) << "reload path is " << reloadPath;
+    FL_LOG(fl::INFO) << "reload path is " << reloadPath;
     std::unordered_map<std::string, std::string> cfg;
     Serializer::load(reloadPath, cfg);
     auto flags = cfg.find(kGflags);
     if (flags == cfg.end()) {
-      LOG(FATAL) << "Invalid config loaded from " << reloadPath;
+      FL_LOG(fl::FATAL) << "Invalid config loaded from " << reloadPath;
     }
-    LOG(INFO) << "Reading flags from config file " << reloadPath;
+    FL_LOG(fl::INFO) << "Reading flags from config file " << reloadPath;
     gflags::ReadFlagsFromString(flags->second, gflags::GetArgv0(), true);
     if (argc > 3) {
-      LOG(INFO) << "Parsing command line flags";
-      LOG(INFO) << "Overriding flags should be mutable when using `continue`";
+      FL_LOG(fl::INFO) << "Parsing command line flags";
+      FL_LOG(fl::INFO)
+          << "Overriding flags should be mutable when using `continue`";
       gflags::ParseCommandLineFlags(&argc, &argv, false);
     }
     if (!FLAGS_flagsfile.empty()) {
-      LOG(INFO) << "Reading flags from file " << FLAGS_flagsfile;
+      FL_LOG(fl::INFO) << "Reading flags from file " << FLAGS_flagsfile;
       gflags::ReadFromFlagsFile(FLAGS_flagsfile, argv[0], true);
     }
     gflags::ParseCommandLineFlags(&argc, &argv, false);
     auto epoch = cfg.find(kEpoch);
     if (epoch == cfg.end()) {
-      LOG(WARNING) << "Did not find epoch to start from, starting from 0.";
+      FL_LOG(fl::WARNING)
+          << "Did not find epoch to start from, starting from 0.";
     } else {
       startEpoch = std::stoi(epoch->second);
     }
     auto nbupdates = cfg.find(kUpdates);
     if (nbupdates == cfg.end()) {
-      LOG(WARNING) << "Did not find #updates to start from, starting from 0.";
+      FL_LOG(fl::WARNING)
+          << "Did not find #updates to start from, starting from 0.";
     } else {
       startUpdate = std::stoi(nbupdates->second);
     }
@@ -112,26 +113,27 @@ int main(int argc, char** argv) {
     Serializer::load(reloadPath, cfg);
     auto flags = cfg.find(kGflags);
     if (flags == cfg.end()) {
-      LOG(FATAL) << "Invalid config loaded from " << reloadPath;
+      FL_LOG(fl::FATAL) << "Invalid config loaded from " << reloadPath;
     }
 
-    LOG(INFO) << "Reading flags from config file " << reloadPath;
+    FL_LOG(fl::INFO) << "Reading flags from config file " << reloadPath;
     gflags::ReadFlagsFromString(flags->second, gflags::GetArgv0(), true);
 
     if (argc > 3) {
-      LOG(INFO) << "Parsing command line flags";
-      LOG(INFO) << "Overriding flags should be mutable when using `fork`";
+      FL_LOG(fl::INFO) << "Parsing command line flags";
+      FL_LOG(fl::INFO)
+          << "Overriding flags should be mutable when using `fork`";
       gflags::ParseCommandLineFlags(&argc, &argv, false);
     }
 
     if (!FLAGS_flagsfile.empty()) {
-      LOG(INFO) << "Reading flags from file" << FLAGS_flagsfile;
+      FL_LOG(fl::INFO) << "Reading flags from file" << FLAGS_flagsfile;
       gflags::ReadFromFlagsFile(FLAGS_flagsfile, argv[0], true);
     }
     gflags::ParseCommandLineFlags(&argc, &argv, false);
     runPath = newRunPath(FLAGS_rundir, FLAGS_runname, FLAGS_tag);
   } else {
-    LOG(FATAL) << gflags::ProgramUsage();
+    FL_LOG(fl::FATAL) << gflags::ProgramUsage();
   }
   // Only new flags are re-serialized. Copy any values from deprecated flags to
   // new flags when deprecated flags are present and corresponding new flags
@@ -156,9 +158,9 @@ int main(int argc, char** argv) {
   int worldSize = fl::getWorldSize();
   bool isMaster = (worldRank == 0);
 
-  LOG_MASTER(INFO) << "Gflags after parsing \n" << serializeGflags("; ");
-  LOG_MASTER(INFO) << "Experiment path: " << runPath;
-  LOG_MASTER(INFO) << "Experiment runidx: " << runIdx;
+  FL_LOG_MASTER(fl::INFO) << "Gflags after parsing \n" << serializeGflags("; ");
+  FL_LOG_MASTER(fl::INFO) << "Experiment path: " << runPath;
+  FL_LOG_MASTER(fl::INFO) << "Experiment runidx: " << runIdx;
 
   std::unordered_map<std::string, std::string> config = {
       {kProgramName, exec},
@@ -204,14 +206,14 @@ int main(int argc, char** argv) {
   }
 
   int numClasses = tokenDict.indexSize();
-  LOG(INFO) << "Number of classes (network): " << numClasses;
+  FL_LOG(fl::INFO) << "Number of classes (network): " << numClasses;
 
   Dictionary wordDict;
   LexiconMap lexicon;
   if (!FLAGS_lexicon.empty()) {
     lexicon = loadWords(FLAGS_lexicon, FLAGS_maxword);
     wordDict = createWordDict(lexicon);
-    LOG(INFO) << "Number of words: " << wordDict.indexSize();
+    FL_LOG(fl::INFO) << "Number of words: " << wordDict.indexSize();
   }
 
   /* ===================== Create Dataset ===================== */
@@ -298,7 +300,8 @@ int main(int argc, char** argv) {
   auto scalemode = getCriterionScaleMode(FLAGS_onorm, FLAGS_sqnorm);
   if (runStatus == kTrainMode) {
     auto archfile = pathsConcat(FLAGS_archdir, FLAGS_arch);
-    LOG_MASTER(INFO) << "Loading architecture file from " << archfile;
+    FL_LOG_MASTER(fl::INFO) << "Loading architecture file from " << archfile;
+    auto numFeatures = getSpeechFeatureSize();
     // Encoder network, works on audio
     network = buildSequentialModule(archfile, numFeatures, numClasses);
 
@@ -319,7 +322,7 @@ int main(int argc, char** argv) {
               FLAGS_am_decoder_tr_layerdrop,
               tokenDict.getIndex(fl::app::asr::kEosToken)));
     } else {
-      LOG(FATAL) << "unimplemented criterion";
+      FL_LOG(fl::FATAL) << "unimplemented criterion";
     }
   } else if (runStatus == kForkMode) {
     std::unordered_map<std::string, std::string> cfg; // unused
@@ -328,9 +331,10 @@ int main(int argc, char** argv) {
     std::unordered_map<std::string, std::string> cfg; // unused
     Serializer::load(reloadPath, cfg, network, criterion, netoptim, critoptim);
   }
-  LOG_MASTER(INFO) << "[Network] " << network->prettyString();
-  LOG_MASTER(INFO) << "[Network Params: " << numTotalParams(network) << "]";
-  LOG_MASTER(INFO) << "[Criterion] " << criterion->prettyString();
+  FL_LOG_MASTER(fl::INFO) << "[Network] " << network->prettyString();
+  FL_LOG_MASTER(fl::INFO) << "[Network Params: " << numTotalParams(network)
+                          << "]";
+  FL_LOG_MASTER(fl::INFO) << "[Criterion] " << criterion->prettyString();
 
   if (runStatus == kTrainMode || runStatus == kForkMode) {
     netoptim = initOptimizer(
@@ -338,8 +342,9 @@ int main(int argc, char** argv) {
     critoptim =
         initOptimizer({criterion}, FLAGS_critoptim, FLAGS_lrcrit, 0.0, 0.0);
   }
-  LOG_MASTER(INFO) << "[Network Optimizer] " << netoptim->prettyString();
-  LOG_MASTER(INFO) << "[Criterion Optimizer] " << critoptim->prettyString();
+  FL_LOG_MASTER(fl::INFO) << "[Network Optimizer] " << netoptim->prettyString();
+  FL_LOG_MASTER(fl::INFO) << "[Criterion Optimizer] "
+                          << critoptim->prettyString();
 
   double initLinNetlr = FLAGS_linlr >= 0.0 ? FLAGS_linlr : FLAGS_lr;
   double initLinCritlr =
@@ -349,13 +354,13 @@ int main(int argc, char** argv) {
   std::shared_ptr<fl::FirstOrderOptimizer> linCritoptim;
   if (FLAGS_linseg > startUpdate) {
     if (FLAGS_criterion != kAsgCriterion) {
-      LOG(FATAL) << "linseg may only be used with ASG criterion";
+      FL_LOG(fl::FATAL) << "linseg may only be used with ASG criterion";
     }
     linseg = std::make_shared<LinSegCriterion>(numClasses, scalemode);
     linseg->setParams(criterion->param(0), 0);
-    LOG_MASTER(INFO) << "[Criterion] " << linseg->prettyString()
-                     << " (for first " << FLAGS_linseg - startUpdate
-                     << " updates)";
+    FL_LOG_MASTER(fl::INFO) << "[Criterion] " << linseg->prettyString()
+                            << " (for first " << FLAGS_linseg - startUpdate
+                            << " updates)";
 
     linNetoptim = initOptimizer(
         {network},
@@ -366,12 +371,12 @@ int main(int argc, char** argv) {
     linCritoptim =
         initOptimizer({linseg}, FLAGS_critoptim, initLinCritlr, 0.0, 0.0);
 
-    LOG_MASTER(INFO) << "[Network Optimizer] " << linNetoptim->prettyString()
-                     << " (for first " << FLAGS_linseg - startUpdate
-                     << " updates)";
-    LOG_MASTER(INFO) << "[Criterion Optimizer] " << linCritoptim->prettyString()
-                     << " (for first " << FLAGS_linseg - startUpdate
-                     << " updates)";
+    FL_LOG_MASTER(fl::INFO) << "[Network Optimizer] "
+                            << linNetoptim->prettyString() << " (for first "
+                            << FLAGS_linseg - startUpdate << " updates)";
+    FL_LOG_MASTER(fl::INFO) << "[Criterion Optimizer] "
+                            << linCritoptim->prettyString() << " (for first "
+                            << FLAGS_linseg - startUpdate << " updates)";
   }
 
   /* ===================== Meters ===================== */
@@ -392,11 +397,11 @@ int main(int argc, char** argv) {
     dirCreate(runPath);
     logFile.open(getRunFile("log", runIdx, runPath));
     if (!logFile.is_open()) {
-      LOG(FATAL) << "failed to open log file for writing";
+      FL_LOG(fl::FATAL) << "failed to open log file for writing";
     }
     perfFile.open(getRunFile("perf", runIdx, runPath));
     if (!perfFile.is_open()) {
-      LOG(FATAL) << "failed to open perf file for writing";
+      FL_LOG(fl::FATAL) << "failed to open perf file for writing";
     }
     // write perf header
     auto perfMsg = getStatus(meters, 0, 0, 0, 0, false, true, "\t").first;
@@ -408,11 +413,11 @@ int main(int argc, char** argv) {
   }
 
   auto logStatus = [&perfFile, &logFile, isMaster](
-                       TrainMeters& mtrs,
-                       int64_t epoch,
-                       int64_t nupdates,
-                       double lr,
-                       double lrcrit) {
+      TrainMeters& mtrs,
+      int64_t epoch,
+      int64_t nupdates,
+      double lr,
+      double lrcrit) {
     syncMeter(mtrs);
 
     if (isMaster) {
@@ -421,7 +426,7 @@ int main(int argc, char** argv) {
               .second;
       auto perfMsg =
           getStatus(mtrs, epoch, nupdates, lr, lrcrit, false, true).second;
-      LOG_MASTER(INFO) << logMsg;
+      FL_LOG_MASTER(fl::INFO) << logMsg;
       appendToLog(logFile, logMsg);
       appendToLog(perfFile, perfMsg);
     }
@@ -469,9 +474,7 @@ int main(int argc, char** argv) {
 
   /* ===================== Hooks ===================== */
   auto evalOutput = [&tokenDict, &criterion](
-                        const af::array& op,
-                        const af::array& target,
-                        DatasetMeters& mtr) {
+      const af::array& op, const af::array& target, DatasetMeters& mtr) {
     auto batchsz = op.dims(2);
     for (int b = 0; b < batchsz; ++b) {
       auto tgt = target(af::span, b);
@@ -497,10 +500,10 @@ int main(int argc, char** argv) {
   };
 
   auto test = [&evalOutput](
-                  std::shared_ptr<fl::Module> ntwrk,
-                  std::shared_ptr<SequenceCriterion> crit,
-                  std::shared_ptr<fl::Dataset> validds,
-                  DatasetMeters& mtrs) {
+      std::shared_ptr<fl::Module> ntwrk,
+      std::shared_ptr<SequenceCriterion> crit,
+      std::shared_ptr<fl::Dataset> validds,
+      DatasetMeters& mtrs) {
     ntwrk->eval();
     crit->eval();
     mtrs.tknEdit.reset();
@@ -521,234 +524,238 @@ int main(int argc, char** argv) {
 
   int64_t curEpoch = startEpoch;
 
-  auto train = [&meters,
-                &test,
-                &logStatus,
-                &saveModels,
-                &evalOutput,
-                &validds,
-                &curEpoch,
-                &startUpdate,
-                reducer](
-                   std::shared_ptr<fl::Module> ntwrk,
-                   std::shared_ptr<SequenceCriterion> crit,
-                   std::shared_ptr<fl::Dataset> trainset,
-                   std::shared_ptr<fl::FirstOrderOptimizer> netopt,
-                   std::shared_ptr<fl::FirstOrderOptimizer> critopt,
-                   double initlr,
-                   double initcritlr,
-                   bool clampCrit,
-                   int64_t nbatches) {
-    if (reducer) {
-      fl::distributeModuleGrads(ntwrk, reducer);
-      fl::distributeModuleGrads(crit, reducer);
-    }
-
-    meters.train.loss.reset();
-    meters.train.tknEdit.reset();
-    meters.train.wrdEdit.reset();
-
-    std::shared_ptr<fl::SpecAugment> saug;
-    if (FLAGS_saug_start_update >= 0) {
-      saug = std::make_shared<fl::SpecAugment>(
-          FLAGS_filterbanks,
-          FLAGS_saug_fmaskf,
-          FLAGS_saug_fmaskn,
-          FLAGS_saug_tmaskt,
-          FLAGS_saug_tmaskp,
-          FLAGS_saug_tmaskn);
-    }
-
-    fl::allReduceParameters(ntwrk);
-    fl::allReduceParameters(crit);
-
-    auto resetTimeStatMeters = [&meters]() {
-      meters.runtime.reset();
-      meters.stats.reset();
-      meters.sampletimer.reset();
-      meters.fwdtimer.reset();
-      meters.critfwdtimer.reset();
-      meters.bwdtimer.reset();
-      meters.optimtimer.reset();
-      meters.timer.reset();
-    };
-    auto runValAndSaveModel = [&](int64_t totalEpochs,
-                                  int64_t totalUpdates,
-                                  double lr,
-                                  double lrcrit) {
-      meters.runtime.stop();
-      meters.timer.stop();
-      meters.sampletimer.stop();
-      meters.fwdtimer.stop();
-      meters.critfwdtimer.stop();
-      meters.bwdtimer.stop();
-      meters.optimtimer.stop();
-
-      // valid
-      for (auto& vds : validds) {
-        test(ntwrk, crit, vds.second, meters.valid[vds.first]);
-      }
-
-      // print status
-      try {
-        logStatus(meters, totalEpochs, totalUpdates, lr, lrcrit);
-      } catch (const std::exception& ex) {
-        LOG(ERROR) << "Error while writing logs: " << ex.what();
-      }
-      // save last and best models
-      try {
-        saveModels(totalEpochs, totalUpdates);
-      } catch (const std::exception& ex) {
-        LOG(FATAL) << "Error while saving models: " << ex.what();
-      }
-      // reset meters for next readings
-      meters.train.loss.reset();
-      meters.train.tknEdit.reset();
-      meters.train.wrdEdit.reset();
-    };
-
-    int64_t curBatch = startUpdate;
-    while (curBatch < nbatches) {
-      ++curEpoch; // counts partial epochs too!
-      int64_t epochsAfterDecay = curEpoch - FLAGS_lr_decay;
-      double lrDecayScale = std::pow(
-          0.5,
-          (epochsAfterDecay < 0 ? 0
-                                : 1 + epochsAfterDecay / FLAGS_lr_decay_step));
-      ntwrk->train();
-      crit->train();
-      if (FLAGS_reportiters == 0) {
-        resetTimeStatMeters();
-      }
-      std::hash<std::string> hasher;
-      LOG_MASTER(INFO) << "Shuffling trainset";
-      auto curTrainset = loadPrefetchDataset(
-          trainset, FLAGS_nthread, true /* shuffle */, curEpoch /* seed */);
-      af::sync();
-      meters.sampletimer.resume();
-      meters.runtime.resume();
-      meters.timer.resume();
-      LOG_MASTER(INFO) << "Epoch " << curEpoch << " started!";
-      for (auto& batch : *curTrainset) {
-        ++curBatch;
-        double lrScheduleScale;
-        if (FLAGS_lrcosine) {
-          const double pi = std::acos(-1);
-          lrScheduleScale =
-              std::cos(((double)curBatch) / ((double)nbatches) * pi / 2.0);
-        } else {
-          lrScheduleScale =
-              std::pow(FLAGS_gamma, (double)curBatch / (double)FLAGS_stepsize);
-        }
-        netopt->setLr(
-            initlr * lrDecayScale * lrScheduleScale *
-            std::min(curBatch / double(FLAGS_warmup), 1.0));
-        critopt->setLr(
-            initcritlr * lrDecayScale * lrScheduleScale *
-            std::min(curBatch / double(FLAGS_warmup), 1.0));
-        af::sync();
-        meters.timer.incUnit();
-        meters.sampletimer.stopAndIncUnit();
-        meters.stats.add(batch[kInputIdx], batch[kTargetIdx]);
-        if (af::anyTrue<bool>(af::isNaN(batch[kInputIdx])) ||
-            af::anyTrue<bool>(af::isNaN(batch[kTargetIdx]))) {
-          LOG(FATAL) << "Sample has NaN values - "
-                     << join(",", readSampleIds(batch[kSampleIdx]));
-        }
-
-        // forward
-        meters.fwdtimer.resume();
-        auto input = fl::input(batch[kInputIdx]);
-        if (FLAGS_saug_start_update >= 0 &&
-            curBatch >= FLAGS_saug_start_update) {
-          input = saug->forward(input);
-        }
-        auto output = ntwrk->forward({input}).front();
-        af::sync();
-        meters.critfwdtimer.resume();
-        auto loss =
-            crit->forward({output, fl::noGrad(batch[kTargetIdx])}).front();
-        af::sync();
-        meters.fwdtimer.stopAndIncUnit();
-        meters.critfwdtimer.stopAndIncUnit();
-
-        if (af::anyTrue<bool>(af::isNaN(loss.array()))) {
-          LOG(FATAL) << "Loss has NaN values. Samples - "
-                     << join(",", readSampleIds(batch[kSampleIdx]));
-        }
-        meters.train.loss.add(loss.array());
-
-        if (hasher(join(",", readSampleIds(batch[kSampleIdx]))) % 100 <=
-            FLAGS_pcttraineval) {
-          evalOutput(output.array(), batch[kTargetIdx], meters.train);
-        }
-
-        // backward
-        meters.bwdtimer.resume();
-        netopt->zeroGrad();
-        critopt->zeroGrad();
-        loss.backward();
+  auto train =
+      [&meters,
+       &test,
+       &logStatus,
+       &saveModels,
+       &evalOutput,
+       &validds,
+       &curEpoch,
+       &startUpdate,
+       reducer](
+          std::shared_ptr<fl::Module> ntwrk,
+          std::shared_ptr<SequenceCriterion> crit,
+          std::shared_ptr<fl::Dataset> trainset,
+          std::shared_ptr<fl::FirstOrderOptimizer> netopt,
+          std::shared_ptr<fl::FirstOrderOptimizer> critopt,
+          double initlr,
+          double initcritlr,
+          bool clampCrit,
+          int64_t nbatches) {
         if (reducer) {
-          reducer->finalize();
+          fl::distributeModuleGrads(ntwrk, reducer);
+          fl::distributeModuleGrads(crit, reducer);
         }
-        af::sync();
-        meters.bwdtimer.stopAndIncUnit();
 
-        // optimizer
-        meters.optimtimer.resume();
+        meters.train.loss.reset();
+        meters.train.tknEdit.reset();
+        meters.train.wrdEdit.reset();
 
-        // scale down gradients by batchsize
-        for (const auto& p : ntwrk->params()) {
-          if (!p.isGradAvailable()) {
-            continue;
+        std::shared_ptr<fl::SpecAugment> saug;
+        if (FLAGS_saug_start_update >= 0) {
+          saug = std::make_shared<fl::SpecAugment>(
+              FLAGS_filterbanks,
+              FLAGS_saug_fmaskf,
+              FLAGS_saug_fmaskn,
+              FLAGS_saug_tmaskt,
+              FLAGS_saug_tmaskp,
+              FLAGS_saug_tmaskn);
+        }
+
+        fl::allReduceParameters(ntwrk);
+        fl::allReduceParameters(crit);
+
+        auto resetTimeStatMeters = [&meters]() {
+          meters.runtime.reset();
+          meters.stats.reset();
+          meters.sampletimer.reset();
+          meters.fwdtimer.reset();
+          meters.critfwdtimer.reset();
+          meters.bwdtimer.reset();
+          meters.optimtimer.reset();
+          meters.timer.reset();
+        };
+        auto runValAndSaveModel = [&](
+            int64_t totalEpochs,
+            int64_t totalUpdates,
+            double lr,
+            double lrcrit) {
+          meters.runtime.stop();
+          meters.timer.stop();
+          meters.sampletimer.stop();
+          meters.fwdtimer.stop();
+          meters.critfwdtimer.stop();
+          meters.bwdtimer.stop();
+          meters.optimtimer.stop();
+
+          // valid
+          for (auto& vds : validds) {
+            test(ntwrk, crit, vds.second, meters.valid[vds.first]);
           }
-          p.grad() = p.grad() / FLAGS_batchsize;
-        }
-        for (const auto& p : crit->params()) {
-          if (!p.isGradAvailable()) {
-            continue;
+
+          // print status
+          try {
+            logStatus(meters, totalEpochs, totalUpdates, lr, lrcrit);
+          } catch (const std::exception& ex) {
+            FL_LOG(fl::ERROR) << "Error while writing logs: " << ex.what();
           }
-          p.grad() = p.grad() / FLAGS_batchsize;
-        }
-
-        // clamp gradients
-        if (FLAGS_maxgradnorm > 0) {
-          auto params = ntwrk->params();
-          if (clampCrit) {
-            auto critparams = crit->params();
-            params.insert(params.end(), critparams.begin(), critparams.end());
+          // save last and best models
+          try {
+            saveModels(totalEpochs, totalUpdates);
+          } catch (const std::exception& ex) {
+            FL_LOG(fl::FATAL) << "Error while saving models: " << ex.what();
           }
-          fl::clipGradNorm(params, FLAGS_maxgradnorm);
-        }
+          // reset meters for next readings
+          meters.train.loss.reset();
+          meters.train.tknEdit.reset();
+          meters.train.wrdEdit.reset();
+        };
 
-        // update weights
-        critopt->step();
-        netopt->step();
-        af::sync();
-        meters.optimtimer.stopAndIncUnit();
-        meters.sampletimer.resume();
-
-        if (FLAGS_reportiters > 0 && curBatch % FLAGS_reportiters == 0) {
-          runValAndSaveModel(
-              curEpoch, curBatch, netopt->getLr(), critopt->getLr());
-          resetTimeStatMeters();
+        int64_t curBatch = startUpdate;
+        while (curBatch < nbatches) {
+          ++curEpoch; // counts partial epochs too!
+          int64_t epochsAfterDecay = curEpoch - FLAGS_lr_decay;
+          double lrDecayScale = std::pow(
+              0.5,
+              (epochsAfterDecay < 0
+                   ? 0
+                   : 1 + epochsAfterDecay / FLAGS_lr_decay_step));
           ntwrk->train();
           crit->train();
+          if (FLAGS_reportiters == 0) {
+            resetTimeStatMeters();
+          }
+          std::hash<std::string> hasher;
+          FL_LOG_MASTER(fl::INFO) << "Shuffling trainset";
+          auto curTrainset = loadPrefetchDataset(
+              trainset, FLAGS_nthread, true /* shuffle */, curEpoch /* seed */);
+          af::sync();
           meters.sampletimer.resume();
           meters.runtime.resume();
           meters.timer.resume();
+          FL_LOG_MASTER(fl::INFO) << "Epoch " << curEpoch << " started!";
+          for (auto& batch : *curTrainset) {
+            ++curBatch;
+            double lrScheduleScale;
+            if (FLAGS_lrcosine) {
+              const double pi = std::acos(-1);
+              lrScheduleScale =
+                  std::cos(((double)curBatch) / ((double)nbatches) * pi / 2.0);
+            } else {
+              lrScheduleScale = std::pow(
+                  FLAGS_gamma, (double)curBatch / (double)FLAGS_stepsize);
+            }
+            netopt->setLr(
+                initlr * lrDecayScale * lrScheduleScale *
+                std::min(curBatch / double(FLAGS_warmup), 1.0));
+            critopt->setLr(
+                initcritlr * lrDecayScale * lrScheduleScale *
+                std::min(curBatch / double(FLAGS_warmup), 1.0));
+            af::sync();
+            meters.timer.incUnit();
+            meters.sampletimer.stopAndIncUnit();
+            meters.stats.add(batch[kInputIdx], batch[kTargetIdx]);
+            if (af::anyTrue<bool>(af::isNaN(batch[kInputIdx])) ||
+                af::anyTrue<bool>(af::isNaN(batch[kTargetIdx]))) {
+              FL_LOG(fl::FATAL) << "Sample has NaN values - "
+                                << join(",", readSampleIds(batch[kSampleIdx]));
+            }
+
+            // forward
+            meters.fwdtimer.resume();
+            auto input = fl::input(batch[kInputIdx]);
+            if (FLAGS_saug_start_update >= 0 &&
+                curBatch >= FLAGS_saug_start_update) {
+              input = saug->forward(input);
+            }
+            auto output = ntwrk->forward({input}).front();
+            af::sync();
+            meters.critfwdtimer.resume();
+            auto loss =
+                crit->forward({output, fl::noGrad(batch[kTargetIdx])}).front();
+            af::sync();
+            meters.fwdtimer.stopAndIncUnit();
+            meters.critfwdtimer.stopAndIncUnit();
+
+            if (af::anyTrue<bool>(af::isNaN(loss.array()))) {
+              FL_LOG(fl::FATAL) << "Loss has NaN values. Samples - "
+                                << join(",", readSampleIds(batch[kSampleIdx]));
+            }
+            meters.train.loss.add(loss.array());
+
+            if (hasher(join(",", readSampleIds(batch[kSampleIdx]))) % 100 <=
+                FLAGS_pcttraineval) {
+              evalOutput(output.array(), batch[kTargetIdx], meters.train);
+            }
+
+            // backward
+            meters.bwdtimer.resume();
+            netopt->zeroGrad();
+            critopt->zeroGrad();
+            loss.backward();
+            if (reducer) {
+              reducer->finalize();
+            }
+            af::sync();
+            meters.bwdtimer.stopAndIncUnit();
+
+            // optimizer
+            meters.optimtimer.resume();
+
+            // scale down gradients by batchsize
+            for (const auto& p : ntwrk->params()) {
+              if (!p.isGradAvailable()) {
+                continue;
+              }
+              p.grad() = p.grad() / FLAGS_batchsize;
+            }
+            for (const auto& p : crit->params()) {
+              if (!p.isGradAvailable()) {
+                continue;
+              }
+              p.grad() = p.grad() / FLAGS_batchsize;
+            }
+
+            // clamp gradients
+            if (FLAGS_maxgradnorm > 0) {
+              auto params = ntwrk->params();
+              if (clampCrit) {
+                auto critparams = crit->params();
+                params.insert(
+                    params.end(), critparams.begin(), critparams.end());
+              }
+              fl::clipGradNorm(params, FLAGS_maxgradnorm);
+            }
+
+            // update weights
+            critopt->step();
+            netopt->step();
+            af::sync();
+            meters.optimtimer.stopAndIncUnit();
+            meters.sampletimer.resume();
+
+            if (FLAGS_reportiters > 0 && curBatch % FLAGS_reportiters == 0) {
+              runValAndSaveModel(
+                  curEpoch, curBatch, netopt->getLr(), critopt->getLr());
+              resetTimeStatMeters();
+              ntwrk->train();
+              crit->train();
+              meters.sampletimer.resume();
+              meters.runtime.resume();
+              meters.timer.resume();
+            }
+            if (curBatch > nbatches) {
+              break;
+            }
+          }
+          af::sync();
+          if (FLAGS_reportiters == 0) {
+            runValAndSaveModel(
+                curEpoch, curBatch, netopt->getLr(), critopt->getLr());
+          }
         }
-        if (curBatch > nbatches) {
-          break;
-        }
-      }
-      af::sync();
-      if (FLAGS_reportiters == 0) {
-        runValAndSaveModel(
-            curEpoch, curBatch, netopt->getLr(), critopt->getLr());
-      }
-    }
-  };
+      };
 
   /* ===================== Train ===================== */
   if (FLAGS_linseg - startUpdate > 0) {
@@ -764,14 +771,14 @@ int main(int argc, char** argv) {
         FLAGS_linseg - startUpdate);
 
     startUpdate = FLAGS_linseg;
-    LOG_MASTER(INFO) << "Finished LinSeg";
+    FL_LOG_MASTER(fl::INFO) << "Finished LinSeg";
   }
 
   auto s2s = std::dynamic_pointer_cast<Seq2SeqCriterion>(criterion);
   auto trde = std::dynamic_pointer_cast<TransformerCriterion>(criterion);
   if (FLAGS_pretrainWindow - startUpdate > 0) {
     if (!s2s && !trde) {
-      LOG(FATAL) << "Window pretraining only allowed for seq2seq.";
+      FL_LOG(fl::FATAL) << "Window pretraining only allowed for seq2seq.";
     }
     train(
         network,
@@ -784,7 +791,7 @@ int main(int argc, char** argv) {
         true,
         FLAGS_pretrainWindow - startUpdate);
     startUpdate = FLAGS_pretrainWindow;
-    LOG_MASTER(INFO) << "Finished window pretraining.";
+    FL_LOG_MASTER(fl::INFO) << "Finished window pretraining.";
   }
   if (s2s) {
     s2s->clearWindow();
@@ -803,6 +810,6 @@ int main(int argc, char** argv) {
       true /* clampCrit */,
       FLAGS_iter);
 
-  LOG_MASTER(INFO) << "Finished training";
+  FL_LOG_MASTER(fl::INFO) << "Finished training";
   return 0;
 }

--- a/app/asr/data/BlobsDataset.cpp
+++ b/app/asr/data/BlobsDataset.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <glog/logging.h>
 #include <functional>
 #include <numeric>
 #include <sstream>
@@ -39,7 +38,7 @@ BlobsDataset::BlobsDataset(
       skipUnk_(skipUnk) {
   includeWrd_ = (dicts.find(kWordIdx) != dicts.end());
 
-  LOG_IF(FATAL, dicts.find(kTargetIdx) == dicts.end())
+  FL_LOG_IF(fl::FATAL, dicts.find(kTargetIdx) == dicts.end())
       << "Target dictionary does not exist";
 
   auto filesVec = lib::split(',', filenames);
@@ -67,7 +66,7 @@ BlobsDataset::BlobsDataset(
       FLAGS_outputbinsize);
 
   shuffle(-1);
-  LOG(INFO) << "Total batches (i.e. iters): " << sampleBatches_.size();
+  FL_LOG(fl::INFO) << "Total batches (i.e. iters): " << sampleBatches_.size();
 }
 
 BlobsDataset::~BlobsDataset() {
@@ -129,7 +128,7 @@ std::vector<SpeechSampleMetaInfo> BlobsDataset::loadBlob(
 
   blobs_.push_back(blob);
 
-  LOG(INFO) << samplesMetaInfo.size() << " files found. ";
+  FL_LOG(fl::INFO) << samplesMetaInfo.size() << " files found. ";
 
   return samplesMetaInfo;
 }

--- a/app/asr/data/Dataset.cpp
+++ b/app/asr/data/Dataset.cpp
@@ -11,8 +11,6 @@
 #include <numeric>
 #include <utility>
 
-#include <glog/logging.h>
-
 #include "flashlight/app/asr/common/Defines.h"
 
 using fl::lib::text::DictionaryMap;
@@ -33,7 +31,7 @@ Dataset::Dataset(
       threadpool_(fl::cpp::make_unique<fl::ThreadPool>(FLAGS_nthread)) {
   if (batchSize_ < 1 || worldRank_ < 0 || worldSize_ < 1 ||
       worldRank_ >= worldSize_) {
-    LOG(FATAL) << "Invalid arguments!";
+    FL_LOG(fl::FATAL) << "Invalid arguments!";
   }
 }
 

--- a/app/asr/data/Featurize.cpp
+++ b/app/asr/data/Featurize.cpp
@@ -11,8 +11,6 @@
 #include <fstream>
 #include <vector>
 
-#include <glog/logging.h>
-
 #include "flashlight/app/asr/common/Defines.h"
 #include "flashlight/lib/audio/feature/Mfcc.h"
 #include "flashlight/lib/audio/feature/Mfsc.h"
@@ -118,7 +116,8 @@ FeatureData featurize(
   if (FLAGS_pow || FLAGS_mfsc || FLAGS_mfcc) {
     if ((FLAGS_mfcc && FLAGS_mfsc) || (FLAGS_pow && FLAGS_mfsc) ||
         (FLAGS_mfcc && FLAGS_pow)) {
-      LOG(FATAL) << "Only one of -mfsc, -mfcc, -pow options can set to true";
+      FL_LOG(fl::FATAL)
+          << "Only one of -mfsc, -mfcc, -pow options can set to true";
     }
     int64_t featSz = 1;
     if (FLAGS_mfcc) {
@@ -156,13 +155,14 @@ FeatureData featurize(
     std::vector<std::vector<int>> tgtFeat;
     size_t maxTgtSize = 0;
     if (dicts.find(targetType) == dicts.end()) {
-      LOG(FATAL) << "Dictionary not provided for target: " << targetType;
+      FL_LOG(fl::FATAL) << "Dictionary not provided for target: " << targetType;
     }
     auto dict = dicts.find(targetType)->second;
 
     for (const auto& d : data) {
       if (d.targets.find(targetType) == d.targets.end()) {
-        LOG(FATAL) << "Target type not found for featurization: " << targetType;
+        FL_LOG(fl::FATAL) << "Target type not found for featurization: "
+                          << targetType;
       }
       auto target = d.targets.find(targetType)->second;
 
@@ -203,7 +203,7 @@ FeatureData featurize(
         feat.targets[targetType].resize(batchSz * maxTgtSize, padVal);
         feat.targetDims[targetType] = af::dim4(maxTgtSize, batchSz);
       } else {
-        LOG(FATAL) << "Unrecognized target type" << targetType;
+        FL_LOG(fl::FATAL) << "Unrecognized target type" << targetType;
       }
     }
 

--- a/app/asr/data/ListFilesDataset.cpp
+++ b/app/asr/data/ListFilesDataset.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <glog/logging.h>
 #include <functional>
 #include <numeric>
 
@@ -38,7 +37,7 @@ ListFilesDataset::ListFilesDataset(
       skipUnk_(skipUnk) {
   includeWrd_ = (dicts.find(kWordIdx) != dicts.end());
 
-  LOG_IF(FATAL, dicts.find(kTargetIdx) == dicts.end())
+  FL_LOG_IF(fl::FATAL, dicts.find(kTargetIdx) == dicts.end())
       << "Target dictionary does not exist";
 
   auto filesVec = lib::split(',', filenames);
@@ -66,7 +65,7 @@ ListFilesDataset::ListFilesDataset(
       FLAGS_outputbinsize);
 
   shuffle(-1);
-  LOG(INFO) << "Total batches (i.e. iters): " << sampleBatches_.size();
+  FL_LOG(fl::INFO) << "Total batches (i.e. iters): " << sampleBatches_.size();
 }
 
 ListFilesDataset::~ListFilesDataset() {
@@ -109,7 +108,7 @@ std::vector<SpeechSampleMetaInfo> ListFilesDataset::loadListFile(
     const std::string& filename) {
   std::ifstream infile(filename);
 
-  LOG_IF(FATAL, !infile) << "Could not read file '" << filename << "'";
+  FL_LOG_IF(fl::FATAL, !infile) << "Could not read file '" << filename << "'";
 
   // The format of the list: columns should be space-separated
   // [utterance id] [audio file (full path)] [audio length] [word transcripts]
@@ -120,7 +119,7 @@ std::vector<SpeechSampleMetaInfo> ListFilesDataset::loadListFile(
   while (std::getline(infile, line)) {
     auto tokens = splitOnWhitespace(line, true);
 
-    LOG_IF(FATAL, tokens.size() < 3) << "Cannot parse " << line;
+    FL_LOG_IF(fl::FATAL, tokens.size() < 3) << "Cannot parse " << line;
 
     data_.emplace_back(SpeechSample(
         tokens[0],
@@ -145,7 +144,7 @@ std::vector<SpeechSampleMetaInfo> ListFilesDataset::loadListFile(
     throw std::runtime_error("Train files not found from " + filename);
   }
 
-  LOG(INFO) << samplesMetaInfo.size() << " files found. ";
+  FL_LOG(fl::INFO) << samplesMetaInfo.size() << " files found. ";
 
   return samplesMetaInfo;
 }

--- a/app/asr/data/SpeechSample.cpp
+++ b/app/asr/data/SpeechSample.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "flashlight/app/asr/data/SpeechSample.h"
+#include "flashlight/flashlight/common/Logging.h"
 
 namespace fl {
 namespace app {
@@ -22,7 +23,7 @@ std::vector<int64_t> sortSamples(
     // Sort samples in increasing order of output bins. For samples in the same
     // output bin, sorting is done based on input size in alternating manner
     // (spiral) for consecutive bins.
-    VLOG(1) << "Doing data ordering by input_spiral";
+    FL_VLOG(1) << "Doing data ordering by input_spiral";
     std::sort(
         sortedIndices.begin(),
         sortedIndices.end(),
@@ -44,7 +45,7 @@ std::vector<int64_t> sortSamples(
     // Sort samples in increasing order of input bins. For samples in the same
     // input bin, sorting is done based on output size in alternating manner
     // (spiral) for consecutive bins.
-    VLOG(1) << "Doing data ordering by output_spiral";
+    FL_VLOG(1) << "Doing data ordering by output_spiral";
     std::sort(
         sortedIndices.begin(),
         sortedIndices.end(),
@@ -64,7 +65,7 @@ std::vector<int64_t> sortSamples(
         });
   } else if (dataorder.compare("input") == 0) {
     // Sort by input size
-    VLOG(1) << "Doing data ordering by input";
+    FL_VLOG(1) << "Doing data ordering by input";
     std::sort(
         sortedIndices.begin(),
         sortedIndices.end(),
@@ -100,8 +101,8 @@ void filterSamples(
                 sample.reflength() > maxTargetSz;
           }),
       samples.end());
-  LOG(INFO) << "Filtered " << initialSize - samples.size() << "/" << initialSize
-            << " samples";
+  FL_LOG(fl::INFO) << "Filtered " << initialSize - samples.size() << "/"
+                   << initialSize << " samples";
 }
 } // namespace asr
 } // namespace app

--- a/app/asr/data/SpeechSample.h
+++ b/app/asr/data/SpeechSample.h
@@ -6,12 +6,12 @@
  */
 
 #pragma once
+
 #include <algorithm>
 #include <numeric>
+#include <stdexcept>
 #include <string>
 #include <vector>
-
-#include <glog/logging.h>
 
 namespace fl {
 namespace app {

--- a/app/asr/experimental/tools/StreamingTDSModelConverter.cpp
+++ b/app/asr/experimental/tools/StreamingTDSModelConverter.cpp
@@ -14,7 +14,6 @@
 
 #include <flashlight/flashlight.h>
 #include <gflags/gflags.h>
-#include <glog/logging.h>
 
 #include "flashlight/app/asr/common/Defines.h"
 #include "flashlight/app/asr/criterion/criterion.h"
@@ -36,7 +35,7 @@ using namespace fl::lib;
 namespace {
 std::shared_ptr<streaming::ModuleParameter> variableToModuleParam(
     const fl::Variable& var) {
-  LOG_IF(FATAL, var.type() != af::dtype::f32) << "Invalid variable type";
+  FL_LOG_IF(fl::FATAL, var.type() != af::dtype::f32) << "Invalid variable type";
   std::vector<float> hostVec(var.elements());
   var.host(hostVec.data());
   return std::make_shared<streaming::ModuleParameter>(
@@ -46,7 +45,7 @@ std::shared_ptr<streaming::ModuleParameter> variableToModuleParam(
 std::shared_ptr<streaming::LayerNorm>
 convertLayerNorm(int featSz, const fl::Variable& wt, const fl::Variable& bs) {
   if (wt.elements() != 1 || bs.elements() != 1) {
-    LOG(FATAL) << "Invalid params for layernorm.";
+    FL_LOG(fl::FATAL) << "Invalid params for layernorm.";
   }
   return std::make_shared<streaming::LayerNorm>(
       featSz, wt.scalar<float>(), bs.scalar<float>());
@@ -63,9 +62,10 @@ std::shared_ptr<streaming::Conv1d> convertConv1d(
     const fl::Variable& bs) {
   if (wt.elements() != (cIn * cOut * kw) / (groups * groups) ||
       bs.elements() != cOut / groups) {
-    LOG(INFO) << "Invalid params for conv1d. wt.elements():" << wt.elements()
-              << " cIn:" << cIn << " cOut:" << cOut << " kw:" << kw
-              << " groups:" << groups << "  bs.elements():" << bs.elements();
+    FL_LOG(fl::INFO) << "Invalid params for conv1d. wt.elements():"
+                     << wt.elements() << " cIn:" << cIn << " cOut:" << cOut
+                     << " kw:" << kw << " groups:" << groups
+                     << "  bs.elements():" << bs.elements();
   }
   if (padding.first == -1 && padding.second == -1) {
     auto totalPad = kw - dw;
@@ -93,7 +93,7 @@ std::shared_ptr<streaming::Linear> convertLinear(
     const fl::Variable& wt,
     const fl::Variable& bs) {
   if (wt.elements() != (nIn * nOut) || bs.elements() != nOut) {
-    LOG(FATAL) << "Invalid params for linear.";
+    FL_LOG(fl::FATAL) << "Invalid params for linear.";
   }
   return streaming::createLinear(
       nIn, nOut, variableToModuleParam(wt), variableToModuleParam(bs));
@@ -137,31 +137,30 @@ std::shared_ptr<streaming::TDSBlock> convertTDS(
 } // namespace
 
 int main(int argc, char** argv) {
-  google::InitGoogleLogging(argv[0]);
   google::InstallFailureSignalHandler();
 
   /* ===================== Parse Options ===================== */
-  LOG(INFO) << "Parsing command line flags";
+  FL_LOG(fl::INFO) << "Parsing command line flags";
   gflags::ParseCommandLineFlags(&argc, &argv, false);
 
   /* ===================== Create Network ===================== */
   std::shared_ptr<fl::Module> network;
   std::shared_ptr<SequenceCriterion> criterion;
   std::unordered_map<std::string, std::string> cfg;
-  LOG(INFO) << "[Network] Reading acoustic model from " << FLAGS_am;
+  FL_LOG(fl::INFO) << "[Network] Reading acoustic model from " << FLAGS_am;
   Serializer::load(FLAGS_am, cfg, network, criterion);
   network->eval();
   criterion->eval();
 
-  LOG(INFO) << "[Network] " << network->prettyString();
-  LOG(INFO) << "[Criterion] " << criterion->prettyString();
-  LOG(INFO) << "[Network] Number of params: " << numTotalParams(network);
+  FL_LOG(fl::INFO) << "[Network] " << network->prettyString();
+  FL_LOG(fl::INFO) << "[Criterion] " << criterion->prettyString();
+  FL_LOG(fl::INFO) << "[Network] Number of params: " << numTotalParams(network);
 
   auto flags = cfg.find(kGflags);
   if (flags == cfg.end()) {
-    LOG(FATAL) << "[Network] Invalid config loaded from " << FLAGS_am;
+    FL_LOG(fl::FATAL) << "[Network] Invalid config loaded from " << FLAGS_am;
   }
-  LOG(INFO) << "[Network] Updating flags from config file: " << FLAGS_am;
+  FL_LOG(fl::INFO) << "[Network] Updating flags from config file: " << FLAGS_am;
   gflags::ReadFlagsFromString(flags->second, gflags::GetArgv0(), true);
 
   // override with user-specified flags
@@ -170,7 +169,7 @@ int main(int argc, char** argv) {
     gflags::ReadFromFlagsFile(FLAGS_flagsfile, argv[0], true);
   }
 
-  LOG(INFO) << "Gflags after parsing \n" << serializeGflags("; ");
+  FL_LOG(fl::INFO) << "Gflags after parsing \n" << serializeGflags("; ");
 
   /* ===================== Create Dictionary ===================== */
   auto dictPath = pathsConcat(FLAGS_tokensdir, FLAGS_tokens);
@@ -185,16 +184,16 @@ int main(int argc, char** argv) {
   if (FLAGS_criterion == kCtcCriterion) {
     tokenDict.addEntry(kBlankToken);
   } else if (FLAGS_criterion != kAsgCriterion) {
-    LOG(FATAL) << "This script currently support only CTC/ASG criterion";
+    FL_LOG(fl::FATAL) << "This script currently support only CTC/ASG criterion";
   }
   int numTokens = tokenDict.indexSize();
-  LOG(INFO) << "Number of classes (network): " << numTokens;
+  FL_LOG(fl::INFO) << "Number of classes (network): " << numTokens;
 
   int nFeat = 0;
   if (FLAGS_mfsc) {
     nFeat = FLAGS_filterbanks;
   } else {
-    LOG(FATAL) << "This script currently support only mfsc features";
+    FL_LOG(fl::FATAL) << "This script currently support only mfsc features";
   }
 
   auto lines = getFileContent(pathsConcat(FLAGS_archdir, FLAGS_arch));
@@ -212,7 +211,7 @@ int main(int argc, char** argv) {
     auto layerType = columns[0];
     if (layerType == "C2") {
       if (columns.size() < 8) {
-        LOG(FATAL) << "Invalid arch specified for C2";
+        FL_LOG(fl::FATAL) << "Invalid arch specified for C2";
       }
       auto conv1d = convertConv1d(
           std::stoi(columns[1]) * nFeat,
@@ -230,10 +229,10 @@ int main(int argc, char** argv) {
       curFeatSz = std::stoi(columns[2]) * nFeat;
     } else if (layerType == "PD") {
       if (columns.size() != 4) {
-        LOG(FATAL) << "Padding is supported only along time axis";
+        FL_LOG(fl::FATAL) << "Padding is supported only along time axis";
       }
       if (!startsWith(lines[i + 1], "C2")) {
-        LOG(FATAL) << "Padding layer must be followed by conv layer";
+        FL_LOG(fl::FATAL) << "Padding layer must be followed by conv layer";
       }
       leftPad = std::stoi(columns[2]);
       rightPad = std::stoi(columns[3]);
@@ -242,7 +241,7 @@ int main(int argc, char** argv) {
           std::make_shared<streaming::Relu>(streaming::DataType::FLOAT));
     } else if (layerType == "LN") {
       if (columns[1] != "1" || columns[2] != "2") {
-        LOG(FATAL)
+        FL_LOG(fl::FATAL)
             << "Unsupported LayerNorm axis: must be {1, 2} for streaming";
       }
       auto lyrNorm =
@@ -253,7 +252,8 @@ int main(int argc, char** argv) {
       int outDim = (columns[2] == "NLABEL") ? numTokens : std::stoi(columns[2]);
       int inDim = std::stoi(columns[1]);
       if (params.size() < paramIdx + 2) {
-        LOG(FATAL) << "Error serializing Linear module. Not enough parameters.";
+        FL_LOG(fl::FATAL)
+            << "Error serializing Linear module. Not enough parameters.";
       }
       auto linear =
           convertLinear(inDim, outDim, params[paramIdx], params[paramIdx + 1]);
@@ -285,7 +285,7 @@ int main(int argc, char** argv) {
   {
     std::string amFilePath = pathsConcat(FLAGS_outdir, "acoustic_model.bin");
     std::ofstream amFile(amFilePath, std::ios::binary);
-    LOG(INFO) << "Serializing acoustic model to '" << amFilePath << "'";
+    FL_LOG(fl::INFO) << "Serializing acoustic model to '" << amFilePath << "'";
 
     if (!amFile.is_open()) {
       throw std::runtime_error("failed to open file for reading");
@@ -297,7 +297,7 @@ int main(int argc, char** argv) {
   {
     std::string tokenFilePath = pathsConcat(FLAGS_outdir, "tokens.txt");
     std::ofstream tokenFile(tokenFilePath);
-    LOG(INFO) << "Writing tokens file to '" << tokenFilePath << "'";
+    FL_LOG(fl::INFO) << "Writing tokens file to '" << tokenFilePath << "'";
     for (int i = 0; i < tokenDict.indexSize(); ++i) {
       tokenFile << tokenDict.getEntry(i) << "\n";
     }
@@ -313,7 +313,8 @@ int main(int argc, char** argv) {
     std::string transitionsFilePath =
         pathsConcat(FLAGS_outdir, "transitions.bin");
     std::ofstream transitionsFile(transitionsFilePath);
-    LOG(INFO) << "Writing transitions file to '" << transitionsFilePath << "'";
+    FL_LOG(fl::INFO) << "Writing transitions file to '" << transitionsFilePath
+                     << "'";
     std::vector<float> transitionsVec(criterion->param(0).elements());
     criterion->param(0).host(transitionsVec.data());
     fl::save(transitionsFile, transitionsVec);
@@ -324,11 +325,11 @@ int main(int argc, char** argv) {
     std::string featFilePath =
         pathsConcat(FLAGS_outdir, "feature_extractor.bin");
     std::ofstream featFile(featFilePath, std::ios::binary);
-    LOG(INFO) << "Serializing feature extraction model to '" << featFilePath
-              << "'";
+    FL_LOG(fl::INFO) << "Serializing feature extraction model to '"
+                     << featFilePath << "'";
     auto featureModule = std::make_shared<streaming::Sequential>();
     featureModule->add(std::make_shared<streaming::LogMelFeature>(nFeat));
-    LOG_IF(FATAL, FLAGS_localnrmlleftctx <= 0)
+    FL_LOG_IF(fl::FATAL, FLAGS_localnrmlleftctx <= 0)
         << "Local Norm should be used for online inference";
     featureModule->add(std::make_shared<streaming::LocalNorm>(
         nFeat, FLAGS_localnrmlleftctx, FLAGS_localnrmlrightctx));
@@ -340,7 +341,7 @@ int main(int argc, char** argv) {
     ar(featureModule);
   }
 
-  LOG(INFO) << "verifying serialization ...";
+  FL_LOG(fl::INFO) << "verifying serialization ...";
   af::array inputArr = af::randu(16, 80);
   auto outputArr = network->forward({fl::Variable(inputArr, false)})[0].array();
   std::vector<float> outputVec(outputArr.elements());
@@ -358,16 +359,16 @@ int main(int argc, char** argv) {
 
   std::shared_ptr<streaming::IOBuffer> outputBuffer = outputState->buffer(0);
 
-  LOG_IF(FATAL, outputBuffer->size<float>() != outputVec.size())
+  FL_LOG_IF(fl::FATAL, outputBuffer->size<float>() != outputVec.size())
       << "[Serialization Error] Incorrect output sizes";
   float* outPtr = outputBuffer->data<float>();
   for (int i = 0; i < outputBuffer->size<float>(); i++) {
     float streamingOut = outPtr[i];
     float w2lOut = outputVec[i];
-    LOG_IF(ERROR, fabs(streamingOut - w2lOut) > 1e-2)
+    FL_LOG_IF(ERROR, fabs(streamingOut - w2lOut) > 1e-2)
         << "[Serialization Error] Mismatched output w2l:" << w2lOut
         << " vs streaming:" << streamingOut;
   }
-  LOG(INFO) << "Done !";
+  FL_LOG(fl::INFO) << "Done !";
   return 0;
 }

--- a/app/asr/experimental/tools/VoiceActivityDetection-CTC.cpp
+++ b/app/asr/experimental/tools/VoiceActivityDetection-CTC.cpp
@@ -32,7 +32,6 @@
 
 #include <flashlight/flashlight.h>
 #include <gflags/gflags.h>
-#include <glog/logging.h>
 
 #include "flashlight/app/asr/common/Defines.h"
 #include "flashlight/app/asr/criterion/criterion.h"
@@ -62,7 +61,6 @@ using namespace fl::lib;
 using namespace fl::ext;
 
 int main(int argc, char** argv) {
-  google::InitGoogleLogging(argv[0]);
   google::InstallFailureSignalHandler();
   std::string exec(argv[0]);
   std::vector<std::string> argvs;
@@ -71,15 +69,15 @@ int main(int argc, char** argv) {
   }
   gflags::SetUsageMessage("Usage: Please refer to https://git.io/Je9lG");
   if (argc <= 1) {
-    LOG(FATAL) << gflags::ProgramUsage();
+    FL_LOG(fl::FATAL) << gflags::ProgramUsage();
   }
 
   /* ===================== Parse Options ===================== */
-  LOG(INFO) << "Parsing command line flags";
+  FL_LOG(fl::INFO) << "Parsing command line flags";
   gflags::ParseCommandLineFlags(&argc, &argv, false);
   auto flagsfile = FLAGS_flagsfile;
   if (!flagsfile.empty()) {
-    LOG(INFO) << "Reading flags from file " << flagsfile;
+    FL_LOG(fl::INFO) << "Reading flags from file " << flagsfile;
     gflags::ReadFromFlagsFile(flagsfile, argv[0], true);
   }
 
@@ -87,20 +85,20 @@ int main(int argc, char** argv) {
   std::shared_ptr<fl::Module> network;
   std::shared_ptr<SequenceCriterion> criterion;
   std::unordered_map<std::string, std::string> cfg;
-  LOG(INFO) << "[Network] Reading acoustic model from " << FLAGS_am;
+  FL_LOG(fl::INFO) << "[Network] Reading acoustic model from " << FLAGS_am;
   Serializer::load(FLAGS_am, cfg, network, criterion);
   network->eval();
   criterion->eval();
 
-  LOG(INFO) << "[Network] " << network->prettyString();
-  LOG(INFO) << "[Criterion] " << criterion->prettyString();
-  LOG(INFO) << "[Network] Number of params: " << numTotalParams(network);
+  FL_LOG(fl::INFO) << "[Network] " << network->prettyString();
+  FL_LOG(fl::INFO) << "[Criterion] " << criterion->prettyString();
+  FL_LOG(fl::INFO) << "[Network] Number of params: " << numTotalParams(network);
 
   auto flags = cfg.find(kGflags);
   if (flags == cfg.end()) {
-    LOG(FATAL) << "[Network] Invalid config loaded from " << FLAGS_am;
+    FL_LOG(fl::FATAL) << "[Network] Invalid config loaded from " << FLAGS_am;
   }
-  LOG(INFO) << "[Network] Updating flags from config file: " << FLAGS_am;
+  FL_LOG(fl::INFO) << "[Network] Updating flags from config file: " << FLAGS_am;
   gflags::ReadFlagsFromString(flags->second, gflags::GetArgv0(), true);
 
   // override with user-specified flags
@@ -109,7 +107,7 @@ int main(int argc, char** argv) {
     gflags::ReadFromFlagsFile(flagsfile, argv[0], true);
   }
 
-  LOG(INFO) << "Gflags after parsing \n" << serializeGflags("; ");
+  FL_LOG(fl::INFO) << "Gflags after parsing \n" << serializeGflags("; ");
 
   /* ===================== Create Dictionary ===================== */
   auto dictPath = pathsConcat(FLAGS_tokensdir, FLAGS_tokens);
@@ -126,21 +124,21 @@ int main(int argc, char** argv) {
   if (FLAGS_criterion == kCtcCriterion) {
     tokenDict.addEntry(kBlankToken);
   } else {
-    LOG(FATAL) << "CTC-trained model required for VAD-CTC.";
+    FL_LOG(fl::FATAL) << "CTC-trained model required for VAD-CTC.";
   }
   if (FLAGS_eostoken) {
     tokenDict.addEntry(kEosToken);
   }
 
   int numClasses = tokenDict.indexSize();
-  LOG(INFO) << "Number of classes (network): " << numClasses;
+  FL_LOG(fl::INFO) << "Number of classes (network): " << numClasses;
 
   Dictionary wordDict;
   text::LexiconMap lexicon;
   if (!FLAGS_lexicon.empty()) {
     lexicon = text::loadWords(FLAGS_lexicon, FLAGS_maxword);
     wordDict = text::createWordDict(lexicon);
-    LOG(INFO) << "Number of words: " << wordDict.indexSize();
+    FL_LOG(fl::INFO) << "Number of words: " << wordDict.indexSize();
     wordDict.setDefaultIndex(wordDict.getIndex(text::kUnkToken));
   }
 
@@ -148,7 +146,7 @@ int main(int argc, char** argv) {
 
   /* ===================== Create Dataset ===================== */
   auto ds = createDataset(FLAGS_test, dicts, lexicon, 1, 0, 1);
-  LOG(INFO) << "[Dataset] Dataset loaded.";
+  FL_LOG(fl::INFO) << "[Dataset] Dataset loaded.";
 
   /* ===================== Build LM ===================== */
   std::shared_ptr<text::LM> lm;
@@ -168,7 +166,7 @@ int main(int argc, char** argv) {
   for (auto& sample : *ds) {
     auto rawEmission = network->forward({fl::input(sample[kInputIdx])}).front();
     auto sampleId = readSampleIds(sample[kSampleIdx]).front();
-    LOG(INFO) << "Processing sample ID " << sampleId << std::endl;
+    FL_LOG(fl::INFO) << "Processing sample ID " << sampleId << std::endl;
 
     // Hypothesis
     auto tokenPrediction =

--- a/app/asr/experimental/tools/alignment/Align.cpp
+++ b/app/asr/experimental/tools/alignment/Align.cpp
@@ -6,21 +6,18 @@
  */
 
 #include <gflags/gflags.h>
-#include <glog/logging.h>
 
 #include "flashlight/app/asr/criterion/criterion.h"
+#include "flashlight/app/asr/experimental/tools/alignment/Utils.h"
 #include "flashlight/app/asr/runtime/runtime.h"
 #include "flashlight/ext/common/SequentialBuilder.h"
 #include "flashlight/lib/text/dictionary/Dictionary.h"
-
-#include "flashlight/app/asr/experimental/tools/alignment/Utils.h"
 
 using namespace fl::app::asr;
 using namespace fl::lib;
 using namespace w2l::alignment;
 
 int main(int argc, char** argv) {
-  google::InitGoogleLogging(argv[0]);
   std::string exec(argv[0]);
   std::vector<std::string> argvs;
   for (int i = 0; i < argc; i++) {
@@ -28,16 +25,16 @@ int main(int argc, char** argv) {
   }
   gflags::SetUsageMessage("Usage: \n " + exec + " align_file_path [flags]");
   if (argc <= 2) {
-    LOG(FATAL) << gflags::ProgramUsage();
+    FL_LOG(fl::FATAL) << gflags::ProgramUsage();
   }
 
   std::string alignFilePath = argv[1];
 
   /* ===================== Parse Options ===================== */
-  LOG(INFO) << "Parsing command line flags";
+  FL_LOG(fl::INFO) << "Parsing command line flags";
   gflags::ParseCommandLineFlags(&argc, &argv, false);
   if (!FLAGS_flagsfile.empty()) {
-    LOG(INFO) << "Reading flags from file " << FLAGS_flagsfile;
+    FL_LOG(fl::INFO) << "Reading flags from file " << FLAGS_flagsfile;
     gflags::ReadFromFlagsFile(FLAGS_flagsfile, argv[0], true);
   }
 
@@ -45,32 +42,32 @@ int main(int argc, char** argv) {
   std::shared_ptr<fl::Module> network;
   std::shared_ptr<SequenceCriterion> criterion;
   std::unordered_map<std::string, std::string> cfg;
-  LOG(INFO) << "[Network] Reading acoustic model from " << FLAGS_am;
+  FL_LOG(fl::INFO) << "[Network] Reading acoustic model from " << FLAGS_am;
   Serializer::load(FLAGS_am, cfg, network, criterion);
   network->eval();
   criterion->eval();
 
-  LOG(INFO) << "[Network] " << network->prettyString();
-  LOG(INFO) << "[Criterion] " << criterion->prettyString();
-  LOG(INFO) << "[Network] Number of params: " << numTotalParams(network);
+  FL_LOG(fl::INFO) << "[Network] " << network->prettyString();
+  FL_LOG(fl::INFO) << "[Criterion] " << criterion->prettyString();
+  FL_LOG(fl::INFO) << "[Network] Number of params: " << numTotalParams(network);
 
   auto flags = cfg.find(kGflags);
   if (flags == cfg.end()) {
-    LOG(FATAL) << "[Network] Invalid config loaded from " << FLAGS_am;
+    FL_LOG(fl::FATAL) << "[Network] Invalid config loaded from " << FLAGS_am;
   }
-  LOG(INFO) << "[Network] Updating flags from config file: " << FLAGS_am;
+  FL_LOG(fl::INFO) << "[Network] Updating flags from config file: " << FLAGS_am;
   gflags::ReadFlagsFromString(flags->second, gflags::GetArgv0(), true);
   gflags::ParseCommandLineFlags(&argc, &argv, false);
   if (!FLAGS_flagsfile.empty()) {
-    LOG(INFO) << "Reading flags from file " << FLAGS_flagsfile;
+    FL_LOG(fl::INFO) << "Reading flags from file " << FLAGS_flagsfile;
     gflags::ReadFromFlagsFile(FLAGS_flagsfile, argv[0], true);
   }
 
-  LOG(INFO) << "Gflags after parsing \n" << serializeGflags("; ");
+  FL_LOG(fl::INFO) << "Gflags after parsing \n" << serializeGflags("; ");
 
   /* ===================== Create Dictionary ===================== */
   auto dictPath = pathsConcat(FLAGS_tokensdir, FLAGS_tokens);
-  LOG(INFO) << "Loading dictionary from " << dictPath;
+  FL_LOG(fl::INFO) << "Loading dictionary from " << dictPath;
   if (dictPath.empty() || !fileExists(dictPath)) {
     throw std::invalid_argument("Invalid dictionary filepath specified.");
   }
@@ -88,7 +85,7 @@ int main(int argc, char** argv) {
   }
 
   int numClasses = tokenDict.indexSize();
-  LOG(INFO) << "Number of classes (network): " << numClasses;
+  FL_LOG(fl::INFO) << "Number of classes (network): " << numClasses;
 
   text::DictionaryMap dicts;
   dicts.insert({kTargetIdx, tokenDict});
@@ -97,9 +94,9 @@ int main(int argc, char** argv) {
   std::ofstream alignFile;
   alignFile.open(alignFilePath);
   if (!alignFile.is_open() || !alignFile.good()) {
-    LOG(FATAL) << "Error opening log file";
+    FL_LOG(fl::FATAL) << "Error opening log file";
   } else {
-    LOG(INFO) << "Writing alignment to: " << alignFilePath;
+    FL_LOG(fl::INFO) << "Writing alignment to: " << alignFilePath;
   }
 
   text::LexiconMap lexicon;
@@ -107,7 +104,7 @@ int main(int argc, char** argv) {
     lexicon = text::loadWords(FLAGS_lexicon, FLAGS_maxword);
   }
 
-  LOG(INFO) << "Loaded lexicon";
+  FL_LOG(fl::INFO) << "Loaded lexicon";
 
   auto writeLog = [&](const std::string& logStr) {
     std::lock_guard<std::mutex> lock(write_mutex);
@@ -124,7 +121,7 @@ int main(int argc, char** argv) {
   ds = createDataset(
       FLAGS_test, dicts, lexicon, FLAGS_batchsize, worldRank, worldSize);
 
-  LOG(INFO) << "[Dataset] Dataset loaded";
+  FL_LOG(fl::INFO) << "[Dataset] Dataset loaded";
 
   auto postprocessFN = getWordSegmenter(criterion);
 
@@ -141,7 +138,7 @@ int main(int argc, char** argv) {
     if (!rawEmissions.empty()) {
       rawEmission = rawEmissions.front();
     } else {
-      LOG(ERROR) << "Network did not produce any outputs";
+      FL_LOG(ERROR) << "Network did not produce any outputs";
     }
 
     fwdMtr.stop();
@@ -173,14 +170,14 @@ int main(int argc, char** argv) {
     parseMtr.stop();
     ++batches;
     if (batches % 500 == 0) {
-      LOG(INFO) << "Done batches: " << batches
-                << " , samples: " << batches * FLAGS_batchsize;
+      FL_LOG(fl::INFO) << "Done batches: " << batches
+                       << " , samples: " << batches * FLAGS_batchsize;
     }
   }
 
-  LOG(INFO) << "Align time: " << alignMtr.value();
-  LOG(INFO) << "Fwd time: " << fwdMtr.value();
-  LOG(INFO) << "Parse time: " << parseMtr.value();
+  FL_LOG(fl::INFO) << "Align time: " << alignMtr.value();
+  FL_LOG(fl::INFO) << "Fwd time: " << fwdMtr.value();
+  FL_LOG(fl::INFO) << "Parse time: " << parseMtr.value();
   alignFile.close();
   return 0;
 }

--- a/app/asr/runtime/Helpers.cpp
+++ b/app/asr/runtime/Helpers.cpp
@@ -7,7 +7,6 @@
 
 #include "flashlight/app/asr/runtime/Helpers.h"
 
-#include <glog/logging.h>
 #include <random>
 
 #include "flashlight/ext/common/DistributedUtils.h"
@@ -137,8 +136,8 @@ std::shared_ptr<Dataset> createDataset(
         FLAGS_datadir,
         FLAGS_use_memcache);
 #else
-    LOG(FATAL) << "EverstoreDataset not supported: "
-               << "build with -DFL_BUILD_FB_DEPENDENCIES";
+    FL_LOG(fl::FATAL) << "EverstoreDataset not supported: "
+                      << "build with -DFL_BUILD_FB_DEPENDENCIES";
 #endif
   } else if (FLAGS_blobdata) {
     ds = std::make_shared<BlobsDataset>(

--- a/app/asr/runtime/Logger.cpp
+++ b/app/asr/runtime/Logger.cpp
@@ -9,8 +9,6 @@
 
 #include <thread>
 
-#include <glog/logging.h>
-
 #include "flashlight/app/asr/common/Defines.h"
 #include "flashlight/ext/common/DistributedUtils.h"
 #include "flashlight/lib/common/String.h"

--- a/app/asr/runtime/Logger.h
+++ b/app/asr/runtime/Logger.h
@@ -13,7 +13,7 @@
 
 #include "SpeechStatMeter.h"
 
-#define LOG_MASTER(lvl) LOG_IF(lvl, (fl::getWorldRank() == 0))
+#define FL_LOG_MASTER(lvl) FL_LOG_IF(lvl, (fl::getWorldRank() == 0))
 
 namespace fl {
 namespace app {

--- a/app/asr/runtime/Optimizer.cpp
+++ b/app/asr/runtime/Optimizer.cpp
@@ -7,7 +7,6 @@
 
 #include "flashlight/app/asr/runtime/Optimizer.h"
 
-#include <glog/logging.h>
 
 namespace fl {
 namespace app {
@@ -67,7 +66,7 @@ std::shared_ptr<fl::FirstOrderOptimizer> initOptimizer(
         FLAGS_optimepsilon,
         weightdecay);
   } else {
-    LOG(FATAL) << "Optimizer option " << optimizer << " not implemented";
+    FL_LOG(fl::FATAL) << "Optimizer option " << optimizer << " not implemented";
   }
 
   return opt;

--- a/app/asr/runtime/Serialization.h
+++ b/app/asr/runtime/Serialization.h
@@ -9,7 +9,6 @@
 
 #include <unordered_map>
 
-#include <glog/logging.h>
 #include "flashlight/flashlight/flashlight.h"
 
 #include "flashlight/app/asr/common/Defines.h"
@@ -56,8 +55,8 @@ struct Serializer {
       ar(std::string(FL_TASK_ASR_VERSION));
       ar(args...);
     } catch (const std::exception& ex) {
-      LOG(ERROR) << "Error while saving \"" << filepath << "\": " << ex.what()
-                 << "\n";
+      FL_LOG(ERROR) << "Error while saving \"" << filepath
+                    << "\": " << ex.what() << "\n";
       throw;
     }
   }
@@ -75,8 +74,8 @@ struct Serializer {
       ar(version);
       ar(args...);
     } catch (const std::exception& ex) {
-      LOG(ERROR) << "Error while loading \"" << filepath << "\": " << ex.what()
-                 << "\n";
+      FL_LOG(ERROR) << "Error while loading \"" << filepath
+                    << "\": " << ex.what() << "\n";
       throw;
     }
   }

--- a/app/asr/test/decoder/DecoderTest.cpp
+++ b/app/asr/test/decoder/DecoderTest.cpp
@@ -10,7 +10,6 @@
 #include <string>
 #include <vector>
 
-#include <glog/logging.h>
 #include <gtest/gtest.h>
 
 #include "flashlight/app/asr/criterion/criterion.h"
@@ -81,7 +80,8 @@ TEST(DecoderTest, run) {
   tr_stream.read((char*)transitions.data(), N * N * sizeof(float));
   tr_stream.close();
 
-  LOG(INFO) << "[Serialization] Loaded emissions [" << T << " x " << N << ']';
+  FL_LOG(fl::INFO) << "[Serialization] Loaded emissions [" << T << " x " << N
+                   << ']';
 
   /* ===================== Create Dictionary ===================== */
   auto lexicon = loadWords(pathsConcat(dataDir, "words.lst"));
@@ -89,12 +89,12 @@ TEST(DecoderTest, run) {
   tokenDict.addEntry("1"); // replabel
   auto wordDict = createWordDict(lexicon);
 
-  LOG(INFO) << "[Dictionary] Number of words: " << wordDict.indexSize();
+  FL_LOG(fl::INFO) << "[Dictionary] Number of words: " << wordDict.indexSize();
 
   /* ===================== Decode ===================== */
   /* -------- Build Language Model --------*/
   auto lm = std::make_shared<KenLM>(pathsConcat(dataDir, "lm.arpa"), wordDict);
-  LOG(INFO) << "[Decoder] LM constructed.\n";
+  FL_LOG(fl::INFO) << "[Decoder] LM constructed.\n";
 
   std::vector<std::string> sentence{"the", "cat", "sat", "on", "the", "mat"};
   auto inState = lm->start(0);
@@ -131,11 +131,11 @@ TEST(DecoderTest, run) {
       trie->insert(tokensTensor, usrIdx, score);
     }
   }
-  LOG(INFO) << "[Decoder] Trie planted.\n";
+  FL_LOG(fl::INFO) << "[Decoder] Trie planted.\n";
 
   // Smearing
   trie->smear(SmearingMode::MAX);
-  LOG(INFO) << "[Decoder] Trie smeared.\n";
+  FL_LOG(fl::INFO) << "[Decoder] Trie smeared.\n";
 
   std::vector<float> trieScoreTarget{
       -1.05971, -2.87742, -2.64553, -3.05081, -1.05971, -3.08968};
@@ -161,7 +161,7 @@ TEST(DecoderTest, run) {
 
   LexiconDecoder decoder(
       decoderOpt, trie, lm, silIdx, blankIdx, unkIdx, transitions, false);
-  LOG(INFO) << "[Decoder] Decoder constructed.\n";
+  FL_LOG(fl::INFO) << "[Decoder] Decoder constructed.\n";
 
   /* -------- Run --------*/
   auto emission = emissionUnit.emission;
@@ -180,7 +180,7 @@ TEST(DecoderTest, run) {
   ASSERT_EQ(n_hyp, 16); // only one with nice ending
 
   for (int i = 0; i < std::min(n_hyp, 5); i++) {
-    LOG(INFO) << results[i].score;
+    FL_LOG(fl::INFO) << results[i].score;
   }
 
   std::vector<float> hypScoreTarget{

--- a/flashlight/common/Logging.cpp
+++ b/flashlight/common/Logging.cpp
@@ -13,8 +13,8 @@
 #include "flashlight/flashlight/common/Utils.h"
 
 namespace fl {
-LogLevel Logging::maxLoggingLevel_ = DEFUALT_MAX_LOGGING_LEVEL;
-int VerboseLogging::maxLoggingLevel_ = DEFUALT_MAX_VERBOSE_LOGGING_LEVEL;
+LogLevel Logging::maxLoggingLevel_ = DEFAULT_MAX_FL_LOGGING_LEVEL;
+int VerboseLogging::maxLoggingLevel_ = DEFAULT_MAX_VERBOSE_FL_LOGGING_LEVEL;
 
 namespace {
 // Constatnts for ANSI terminal colors.
@@ -94,7 +94,12 @@ Logging::~Logging() {
 }
 
 void Logging::setMaxLoggingLevel(LogLevel maxLoggingLevel) {
-  Logging::maxLoggingLevel_ = maxLoggingLevel;
+  if (maxLoggingLevel != Logging::maxLoggingLevel_) {
+    std::cerr << "Logging::setMaxLoggingLevel(maxLoggingLevel="
+              << logLevelName(maxLoggingLevel) << ") Logging::maxLoggingLevel_="
+              << logLevelName(Logging::maxLoggingLevel_) << std::endl;
+    Logging::maxLoggingLevel_ = maxLoggingLevel;
+  }
 }
 
 Logging&& operator<<(Logging&& log, const std::string& s) {
@@ -170,7 +175,12 @@ VerboseLogging::~VerboseLogging() {
 }
 
 void VerboseLogging::setMaxLoggingLevel(int maxLoggingLevel) {
-  VerboseLogging::maxLoggingLevel_ = maxLoggingLevel;
+  if (maxLoggingLevel != VerboseLogging::maxLoggingLevel_) {
+    std::cerr << "VerboseLogging::setMaxLoggingLevel(maxLoggingLevel="
+              << maxLoggingLevel << ") VerboseLogging::maxLoggingLevel_="
+              << VerboseLogging::maxLoggingLevel_ << std::endl;
+    VerboseLogging::maxLoggingLevel_ = maxLoggingLevel;
+  }
 }
 
 VerboseLogging&& operator<<(VerboseLogging&& log, const std::string& s) {
@@ -219,6 +229,39 @@ VerboseLogging&& operator<<(VerboseLogging&& log, double d) {
 
 VerboseLogging&& operator<<(VerboseLogging&& log, bool b) {
   return std::move(log.print(b));
+}
+
+constexpr std::array<LogLevel, 5> flLogLevelValues = {fl::INFO,
+                                                      fl::WARNING,
+                                                      fl::ERROR,
+                                                      fl::FATAL,
+                                                      fl::DISABLED};
+constexpr std::array<const char* const, 5> flLogLevelNames =
+    {"INFO", "WARNING", "ERROR", "FATAL", "DISABLED"};
+
+std::string logLevelName(LogLevel level) {
+  for (int i = 0; i < flLogLevelValues.size(); ++i) {
+    if (level == flLogLevelValues.at(i)) {
+      return flLogLevelNames.at(i);
+    }
+  }
+  std::stringstream ss;
+  ss << "logLevelName(level=" << static_cast<int>(level)
+     << ") invalid level. Level should be in the range [0.."
+     << (flLogLevelNames.size() - 1) << "]";
+  throw std::invalid_argument(ss.str());
+}
+
+LogLevel logLevelValue(const std::string& level) {
+  for (int i = 0; i < flLogLevelValues.size(); ++i) {
+    if (level == std::string(flLogLevelNames.at(i))) {
+      return flLogLevelValues.at(i);
+    }
+  }
+  std::stringstream ss;
+  ss << "logLevelValue(level=" << level
+     << ") invalid level. Level should be INFO, WARNING, ERROR or FATAL";
+  throw std::invalid_argument(ss.str());
 }
 
 } // namespace fl

--- a/flashlight/flashlight.h
+++ b/flashlight/flashlight.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "flashlight/flashlight/autograd/autograd.h"
+#include "flashlight/flashlight/common/Logging.h"
 #include "flashlight/flashlight/common/common.h"
 #include "flashlight/flashlight/dataset/datasets.h"
 #include "flashlight/flashlight/distributed/distributed.h"

--- a/flashlight/memory/MemoryManagerInstaller.cpp
+++ b/flashlight/memory/MemoryManagerInstaller.cpp
@@ -11,7 +11,6 @@
 #include <cstdlib>
 #include <stdexcept>
 
-#include "flashlight/flashlight/common/Logging.h"
 #include "flashlight/flashlight/common/Utils.h"
 #include "flashlight/flashlight/memory/managers/CachingMemoryManager.h"
 

--- a/flashlight/test/common/LoggingTest.cpp
+++ b/flashlight/test/common/LoggingTest.cpp
@@ -19,10 +19,9 @@ namespace {
 using testing::HasSubstr;
 using testing::Not;
 
-// VLOG(l) should print to stdout when VerboseLogging::setMaxLoggingLevel(i)
+// FL_VLOG(l) should print to stdout when VerboseLogging::setMaxLoggingLevel(i)
 // i>=l
 TEST(Logging, vlogOnOff) {
-  LOG(INFO) << "test" << 1 << 1UL << 1L << 1.0;
   std::stringstream stdoutBuffer;
   std::stringstream stderrBuffer;
 
@@ -33,12 +32,12 @@ TEST(Logging, vlogOnOff) {
   std::cerr.rdbuf(stderrBuffer.rdbuf());
 
   for (int i = 0; i < 11; ++i) {
-    stdoutBuffer.str(""); // clear content
-    stderrBuffer.str(""); // clear content
+    stdoutBuffer.clear();
+    stderrBuffer.clear();
     VerboseLogging::setMaxLoggingLevel(i);
-    VLOG(0) << "vlog-0";
-    VLOG(1) << "vlog-1";
-    VLOG(10) << "vlog-10";
+    FL_VLOG(0) << "vlog-0";
+    FL_VLOG(1) << "vlog-1";
+    FL_VLOG(10) << "vlog-10";
 
     // Prints to stdout
     EXPECT_THAT(stdoutBuffer.str(), HasSubstr("vlog-0"));
@@ -65,10 +64,10 @@ TEST(Logging, vlogOnOff) {
   std::cerr.rdbuf(origStderrBuffer);
 }
 
-// LOG(l) should print to stdout when Logging::setMaxLoggingLevel(i) i>=l and l
-// is INFO or WARNING.
-// LOG(l) should print to stderr when Logging::setMaxLoggingLevel(i) i>=l and l
-// is ERROR.
+// FL_LOG(l) should print to stdout when Logging::setMaxLoggingLevel(i) i>=l and
+// l is fl::INFO or WARNING.
+// FL_LOG(l) should print to stderr when Logging::setMaxLoggingLevel(i) i>=l and
+// l is ERROR.
 TEST(Logging, logOnOff) {
   std::stringstream stdoutBuffer;
   std::stringstream stderrBuffer;
@@ -80,18 +79,18 @@ TEST(Logging, logOnOff) {
   std::cerr.rdbuf(stderrBuffer.rdbuf());
 
   const std::vector<LogLevel> logLevels = {
-      DISABLE_LOGGING, FATAL, ERROR, WARNING, INFO};
+      fl::DISABLED, fl::FATAL, fl::ERROR, fl::WARNING, fl::INFO};
   for (LogLevel l : logLevels) {
-    stdoutBuffer.str(""); // clear content
-    stderrBuffer.str(""); // clear content
+    stdoutBuffer.clear();
+    stderrBuffer.clear();
 
     Logging::setMaxLoggingLevel(l);
-    LOG(INFO) << "log-info";
-    LOG(WARNING) << "log-warning";
-    LOG(ERROR) << "log-error";
+    FL_LOG(fl::INFO) << "log-info";
+    FL_LOG(WARNING) << "log-warning";
+    FL_LOG(ERROR) << "log-error";
 
     // Prints to stdout
-    if (l >= INFO) {
+    if (l >= fl::INFO) {
       EXPECT_THAT(stdoutBuffer.str(), HasSubstr("log-info"));
     } else {
       EXPECT_THAT(stdoutBuffer.str(), Not(HasSubstr("log-info")));
@@ -130,16 +129,16 @@ TEST(LoggingDeathTest, FatalOnOff) {
   std::cout.rdbuf(stdoutBuffer.rdbuf());
   std::cerr.rdbuf(stderrBuffer.rdbuf());
 
-  Logging::setMaxLoggingLevel(DISABLE_LOGGING);
-  LOG(FATAL) << "log-fatal";
+  Logging::setMaxLoggingLevel(DISABLED);
+  FL_LOG(fl::FATAL) << "log-fatal";
   EXPECT_THAT(stdoutBuffer.str(), Not(HasSubstr("log-fatal")));
   EXPECT_THAT(stderrBuffer.str(), Not(HasSubstr("log-fatal")));
 
   std::cout.rdbuf(origStdoutBuffer);
   std::cerr.rdbuf(origStderrBuffer);
 
-  Logging::setMaxLoggingLevel(FATAL);
-  EXPECT_DEATH({ LOG(FATAL) << "log-fatal"; }, "");
+  Logging::setMaxLoggingLevel(fl::FATAL);
+  EXPECT_DEATH({ FL_LOG(fl::FATAL) << "log-fatal"; }, "");
 }
 
 } // namespace

--- a/lib/test/common/StringTest.cpp
+++ b/lib/test/common/StringTest.cpp
@@ -7,7 +7,6 @@
 
 #include <string>
 
-#include <glog/logging.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/lib/test/common/SystemTest.cpp
+++ b/lib/test/common/SystemTest.cpp
@@ -9,7 +9,6 @@
 #include <string>
 #include <vector>
 
-#include <glog/logging.h>
 #include <gtest/gtest.h>
 
 #include "flashlight/lib/common/System.h"

--- a/lib/test/text/dictionary/DictionaryTest.cpp
+++ b/lib/test/text/dictionary/DictionaryTest.cpp
@@ -7,7 +7,6 @@
 
 #include <string>
 
-#include <glog/logging.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
Summary
FL_LOG is a lightweight, dependency free, multi-level, filterable infrastructure for logging.
It uses an interface that feels familiar to glog users. In this commit:

Replace all glog #include with include of "flashlight/flashlight/common/Logging.h"
Add InitFlLogging(char* argv[]) function as replacement for google::InitGoogleLogging(argv[0]) with 2 new flags:
--fl_log_level=XXX; where XXX is one of INFO, WARNING, ERROR or FATAL
--fl_vlog_level=N; where N is an integer with recommended values 0..10
Add support for functionality.
Both the assignment sign and space are valid between the flag and its value.
These are equivalent:  `--fl_log_level=INFO` and `--fl_log_level INFO`

This function removes FL_LOG flags and values from argv[] by setting them to an empty string. This means that following flag processing such as gflag will not see them.