### PR TITLE
Add compiling support for CUDA v11 and cuDNN v8

### DIFF
--- a/flashlight/fl/autograd/backend/cuda/CudnnUtils.cpp
+++ b/flashlight/fl/autograd/backend/cuda/CudnnUtils.cpp
@@ -278,7 +278,7 @@ RNNDescriptor::RNNDescriptor(
   cudnnRNNAlgo_t algo = CUDNN_RNN_ALGO_STANDARD;
   cudnnDataType_t cudnntype = cudnnMapToType(type);
 
-#if CUDNN_VERSION >= 7000
+#if CUDNN_VERSION >= 7000 && CUDNN_VERSION < 8000 
   CUDNN_CHECK_ERR(cudnnSetRNNDescriptor(
       handle,
       descriptor,


### PR DESCRIPTION
**Original Issue**: [#198] & [#213] & [#147]

### Summary

- I updated [CMakeList.txt](https://github.com/facebookresearch/flashlight/blob/master/app/asr/third_party/warpctc/CMakeLists.txt) of third party library (warp-ctc)[https://github.com/baidu-research/warp-ctc]. The latest CMakeLists.txt  handles conditional compilation for architecture **compute_30** depending on CUDA version (CUDAv11 deprecates this architecture). 
- The same is done for main [CMakeLists.txt]() file
- The [deprecation policy of CUDA has changed](https://docs.nvidia.com/deeplearning/cudnn/developer-guide/index.html#backward-compatibility). Therefore, the condition of **cudnnSetRNNDescriptor** used [here](https://github.com/facebookresearch/flashlight/blob/master/flashlight/autograd/backend/cuda/CudnnUtils.cpp#L281) needs to also include until version 8000 of cuDNN.
- Finally, with CUDA v11 [Nvidia cub](https://nvlabs.github.io/cub/) is included in CUDA toolkit, but because **flashlight** downloads and uses it's own version, it collides with _Thrust_ version. Hence,  **THRUST_IGNORE_CUB_VERSION_CHECK** must be define in if using CUDA v11