### PR TITLE
improvement in serialization; improvement in installation for app

### DIFF
--- a/flashlight/app/CMakeLists.txt
+++ b/flashlight/app/CMakeLists.txt
@@ -13,7 +13,7 @@ if (FL_BUILD_APP_ASR)
   if (FLASHLIGHT_USE_CUDA)
     set(INSTALLABLE_TARGETS ${INSTALLABLE_TARGETS} warpctc)
   endif()
-  setup_install_headers(${FLASHLIGHT_APPS_DIR} ${FL_INSTALL_INC_DIR_HEADER_LOC})
+  setup_install_headers(${FL_APP_ASR_ROOT_DIR} ${FL_INSTALL_INC_DIR_HEADER_LOC}/app)
 endif ()
 
 if (FL_BUILD_APP_IMG_CLASS)

--- a/flashlight/app/asr/CMakeLists.txt
+++ b/flashlight/app/asr/CMakeLists.txt
@@ -83,13 +83,13 @@ include(${CMAKE_CURRENT_LIST_DIR}/decoder/CMakeLists.txt)
 include(${CMAKE_CURRENT_LIST_DIR}/runtime/CMakeLists.txt)
 
 # ----------------------------- Binaries -----------------------------
-add_executable(Train ${CMAKE_CURRENT_LIST_DIR}/Train.cpp)
-add_executable(Test ${CMAKE_CURRENT_LIST_DIR}/Test.cpp)
-add_executable(Decoder ${CMAKE_CURRENT_LIST_DIR}/Decode.cpp)
+add_executable(asr_train ${CMAKE_CURRENT_LIST_DIR}/Train.cpp)
+add_executable(asr_test ${CMAKE_CURRENT_LIST_DIR}/Test.cpp)
+add_executable(asr_decode ${CMAKE_CURRENT_LIST_DIR}/Decode.cpp)
 
-target_link_libraries(Train flashlight-app-asr ${CMAKE_DL_LIBS})
-target_link_libraries(Test flashlight-app-asr ${CMAKE_DL_LIBS})
-target_link_libraries(Decoder flashlight-app-asr ${CMAKE_DL_LIBS})
+target_link_libraries(asr_train flashlight-app-asr ${CMAKE_DL_LIBS})
+target_link_libraries(asr_test flashlight-app-asr ${CMAKE_DL_LIBS})
+target_link_libraries(asr_decode flashlight-app-asr ${CMAKE_DL_LIBS})
 
 # --------------------------- Tests ---------------------------
 

--- a/flashlight/app/asr/common/Defines.h
+++ b/flashlight/app/asr/common/Defines.h
@@ -14,7 +14,7 @@
 
 #include <gflags/gflags.h>
 
-#define FL_TASK_ASR_VERSION "0.1"
+#define FL_APP_ASR_VERSION "0.1"
 
 namespace fl {
 namespace app {

--- a/flashlight/app/asr/experimental/tools/StreamingTDSModelConverter.cpp
+++ b/flashlight/app/asr/experimental/tools/StreamingTDSModelConverter.cpp
@@ -17,9 +17,11 @@
 #include "flashlight/app/asr/common/Defines.h"
 #include "flashlight/app/asr/criterion/criterion.h"
 #include "flashlight/app/asr/runtime/runtime.h"
-#include "flashlight/contrib/modules/SpecAugment.h"
-#include "flashlight/contrib/modules/TDSBlock.h"
 #include "flashlight/ext/common/SequentialBuilder.h"
+#include "flashlight/ext/common/Serializer.h"
+#include "flashlight/fl/contrib/modules/SpecAugment.h"
+#include "flashlight/fl/contrib/modules/TDSBlock.h"
+#include "flashlight/lib/common/System.h"
 #include "flashlight/lib/text/dictionary/Dictionary.h"
 #include "inference/module/feature/feature.h"
 #include "inference/module/module.h"
@@ -146,8 +148,9 @@ int main(int argc, char** argv) {
   std::shared_ptr<fl::Module> network;
   std::shared_ptr<SequenceCriterion> criterion;
   std::unordered_map<std::string, std::string> cfg;
+  std::string version;
   FL_LOG(fl::INFO) << "[Network] Reading acoustic model from " << FLAGS_am;
-  Serializer::load(FLAGS_am, cfg, network, criterion);
+  fl::ext::Serializer::load(FLAGS_am, version, cfg, network, criterion);
   network->eval();
   criterion->eval();
 
@@ -171,7 +174,7 @@ int main(int argc, char** argv) {
   FL_LOG(fl::INFO) << "Gflags after parsing \n" << serializeGflags("; ");
 
   /* ===================== Create Dictionary ===================== */
-  auto dictPath = pathsConcat(FLAGS_tokensdir, FLAGS_tokens);
+  auto dictPath = fl::lib::pathsConcat(FLAGS_tokensdir, FLAGS_tokens);
   if (dictPath.empty() || !fileExists(dictPath)) {
     throw std::runtime_error(
         "Invalid dictionary filepath specified " + dictPath);
@@ -195,7 +198,7 @@ int main(int argc, char** argv) {
     FL_LOG(fl::FATAL) << "This script currently support only mfsc features";
   }
 
-  auto lines = getFileContent(pathsConcat(FLAGS_archdir, FLAGS_arch));
+  auto lines = getFileContent(fl::lib::pathsConcat(FLAGS_archdir, FLAGS_arch));
 
   auto streamingModule = std::make_shared<streaming::Sequential>();
   auto params = network->params();
@@ -282,7 +285,8 @@ int main(int argc, char** argv) {
   }
 
   {
-    std::string amFilePath = pathsConcat(FLAGS_outdir, "acoustic_model.bin");
+    std::string amFilePath =
+        fl::lib::pathsConcat(FLAGS_outdir, "acoustic_model.bin");
     std::ofstream amFile(amFilePath, std::ios::binary);
     FL_LOG(fl::INFO) << "Serializing acoustic model to '" << amFilePath << "'";
 
@@ -294,7 +298,8 @@ int main(int argc, char** argv) {
   }
 
   {
-    std::string tokenFilePath = pathsConcat(FLAGS_outdir, "tokens.txt");
+    std::string tokenFilePath =
+        fl::lib::pathsConcat(FLAGS_outdir, "tokens.txt");
     std::ofstream tokenFile(tokenFilePath);
     FL_LOG(fl::INFO) << "Writing tokens file to '" << tokenFilePath << "'";
     for (int i = 0; i < tokenDict.indexSize(); ++i) {
@@ -310,7 +315,7 @@ int main(int argc, char** argv) {
       throw std::runtime_error("Invalid criterion parameters for ASG");
     }
     std::string transitionsFilePath =
-        pathsConcat(FLAGS_outdir, "transitions.bin");
+        fl::lib::pathsConcat(FLAGS_outdir, "transitions.bin");
     std::ofstream transitionsFile(transitionsFilePath);
     FL_LOG(fl::INFO) << "Writing transitions file to '" << transitionsFilePath
                      << "'";
@@ -322,7 +327,7 @@ int main(int argc, char** argv) {
 
   {
     std::string featFilePath =
-        pathsConcat(FLAGS_outdir, "feature_extractor.bin");
+        fl::lib::pathsConcat(FLAGS_outdir, "feature_extractor.bin");
     std::ofstream featFile(featFilePath, std::ios::binary);
     FL_LOG(fl::INFO) << "Serializing feature extraction model to '"
                      << featFilePath << "'";
@@ -364,7 +369,7 @@ int main(int argc, char** argv) {
   for (int i = 0; i < outputBuffer->size<float>(); i++) {
     float streamingOut = outPtr[i];
     float w2lOut = outputVec[i];
-    FL_LOG_IF(ERROR, fabs(streamingOut - w2lOut) > 1e-2)
+    FL_LOG_IF(fl::ERROR, fabs(streamingOut - w2lOut) > 1e-2)
         << "[Serialization Error] Mismatched output w2l:" << w2lOut
         << " vs streaming:" << streamingOut;
   }

--- a/flashlight/app/asr/experimental/tools/alignment/Align.cpp
+++ b/flashlight/app/asr/experimental/tools/alignment/Align.cpp
@@ -7,10 +7,15 @@
 
 #include <gflags/gflags.h>
 
+#include "flashlight/app/asr/common/Defines.h"
 #include "flashlight/app/asr/criterion/criterion.h"
 #include "flashlight/app/asr/experimental/tools/alignment/Utils.h"
 #include "flashlight/app/asr/runtime/runtime.h"
 #include "flashlight/ext/common/SequentialBuilder.h"
+#include "flashlight/ext/common/Serializer.h"
+#include "flashlight/fl/flashlight.h"
+#include "flashlight/lib/common/System.h"
+#include "flashlight/lib/text/dictionary/Defines.h"
 #include "flashlight/lib/text/dictionary/Dictionary.h"
 
 using namespace fl::app::asr;
@@ -42,8 +47,9 @@ int main(int argc, char** argv) {
   std::shared_ptr<fl::Module> network;
   std::shared_ptr<SequenceCriterion> criterion;
   std::unordered_map<std::string, std::string> cfg;
+  std::string version;
   FL_LOG(fl::INFO) << "[Network] Reading acoustic model from " << FLAGS_am;
-  Serializer::load(FLAGS_am, cfg, network, criterion);
+  fl::ext::Serializer::load(FLAGS_am, version, cfg, network, criterion);
   network->eval();
   criterion->eval();
 
@@ -66,7 +72,7 @@ int main(int argc, char** argv) {
   FL_LOG(fl::INFO) << "Gflags after parsing \n" << serializeGflags("; ");
 
   /* ===================== Create Dictionary ===================== */
-  auto dictPath = pathsConcat(FLAGS_tokensdir, FLAGS_tokens);
+  auto dictPath = fl::lib::pathsConcat(FLAGS_tokensdir, FLAGS_tokens);
   FL_LOG(fl::INFO) << "Loading dictionary from " << dictPath;
   if (dictPath.empty() || !fileExists(dictPath)) {
     throw std::invalid_argument("Invalid dictionary filepath specified.");
@@ -138,7 +144,7 @@ int main(int argc, char** argv) {
     if (!rawEmissions.empty()) {
       rawEmission = rawEmissions.front();
     } else {
-      FL_LOG(ERROR) << "Network did not produce any outputs";
+      FL_LOG(fl::ERROR) << "Network did not produce any outputs";
     }
 
     fwdMtr.stop();

--- a/flashlight/app/asr/experimental/tools/alignment/Utils.h
+++ b/flashlight/app/asr/experimental/tools/alignment/Utils.h
@@ -11,7 +11,9 @@
 #include <unordered_map>
 #include <vector>
 
+#include "flashlight/app/asr/common/Defines.h"
 #include "flashlight/app/asr/criterion/criterion.h"
+#include "flashlight/lib/text/dictionary/Dictionary.h"
 
 using namespace fl::app::asr;
 

--- a/flashlight/app/asr/runtime/Logger.h
+++ b/flashlight/app/asr/runtime/Logger.h
@@ -8,10 +8,8 @@
 #pragma once
 
 #include <map>
-
 #include "flashlight/fl/flashlight.h"
-
-#include "SpeechStatMeter.h"
+#include "flashlight/app/asr/runtime/SpeechStatMeter.h"
 
 #define FL_LOG_MASTER(lvl) FL_LOG_IF(lvl, (fl::getWorldRank() == 0))
 

--- a/flashlight/app/asr/runtime/runtime.h
+++ b/flashlight/app/asr/runtime/runtime.h
@@ -10,5 +10,4 @@
 #include "flashlight/app/asr/runtime/Helpers.h"
 #include "flashlight/app/asr/runtime/Logger.h"
 #include "flashlight/app/asr/runtime/Optimizer.h"
-#include "flashlight/app/asr/runtime/Serialization.h"
 #include "flashlight/app/asr/runtime/SpeechStatMeter.h"

--- a/flashlight/app/asr/test/decoder/DecoderTest.cpp
+++ b/flashlight/app/asr/test/decoder/DecoderTest.cpp
@@ -16,6 +16,7 @@
 #include "flashlight/app/asr/decoder/Defines.h"
 #include "flashlight/app/asr/decoder/TranscriptionUtils.h"
 #include "flashlight/app/asr/runtime/runtime.h"
+#include "flashlight/lib/common/System.h"
 #include "flashlight/lib/text/decoder/LexiconDecoder.h"
 #include "flashlight/lib/text/decoder/Trie.h"
 #include "flashlight/lib/text/decoder/lm/KenLM.h"

--- a/flashlight/app/asr/test/runtime/RuntimeTest.cpp
+++ b/flashlight/app/asr/test/runtime/RuntimeTest.cpp
@@ -14,6 +14,7 @@
 #include "flashlight/fl/flashlight.h"
 
 #include "flashlight/app/asr/runtime/runtime.h"
+#include "flashlight/ext/common/Serializer.h"
 
 #include "flashlight/lib/common/System.h"
 
@@ -48,13 +49,15 @@ TEST(RuntimeTest, LoadAndSave) {
   model.add(fl::GatedLinearUnit(2));
   model.add(fl::Dropout(0.214));
 
-  Serializer::save(kPath, config, model);
+  fl::ext::Serializer::save(kPath, FL_APP_ASR_VERSION, config, model);
 
   fl::Sequential modelload;
   std::unordered_map<std::string, std::string> configload;
-  Serializer::load(kPath, configload, modelload);
+  std::string versionload;
+  fl::ext::Serializer::load(kPath, versionload, configload, modelload);
 
   EXPECT_EQ(configload.size(), config.size());
+  EXPECT_EQ(versionload, FL_APP_ASR_VERSION);
   EXPECT_THAT(config, ::testing::ContainerEq(configload));
 
   ASSERT_EQ(model.prettyString(), modelload.prettyString());


### PR DESCRIPTION
### Summary
improvement in serialization; improvement in installation for app

### Test Plan 
make test - all passed

installation looks like
```
flashlight/build$ tree -L 3 ../../usr/include/flashlight/
../../usr/include/flashlight/
├── app
│   └── asr
│       ├── common
│       ├── criterion
│       ├── data
│       ├── decoder
│       ├── experimental
│       ├── runtime
│       ├── test
│       └── third_party
├── ext
│   ├── common
│   │   ├── DistributedUtils.h
│   │   ├── ModelSerializer.h
│   │   ├── ModulePlugin.h
│   │   ├── SequentialBuilder.h
│   │   └── Utils-inl.h
│   └── test
│       ├── cmake
│       └── common
├── fl
│   ├── autograd
│   │   ├── autograd.h
│   │   ├── backend
│   │   ├── Functions.h
│   │   ├── Utils.h
│   │   └── Variable.h
│   ├── common
│   │   ├── common.h
│   │   ├── CppBackports.h
│   │   ├── cuda.h
│   │   ├── CudaUtils.h
│   │   ├── Defines.h
│   │   ├── DevicePtr.h
│   │   ├── DynamicBenchmark.h
│   │   ├── Histogram.h
│   │   ├── Logging.h
│   │   ├── Plugin.h
```