### PR TITLE
Add docker login to avoid anonymous, see https://support.circleci.com/hc/en-us/articles/360050623311-Docker-Hub-rate-limiting-FAQ

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,10 @@ jobs:
       - run:
           name: Build flashlight with CUDA backend inside nvidia-docker
           command: |
+            if [ ! -z "$DOCKER_USERNAME" ]
+            then
+                sudo docker login -u=$DOCKER_USERNAME -p=$DOCKER_PASSWORD
+            fi
             sudo docker run --runtime=nvidia --rm -itd --ipc=host --name flashlight flml/flashlight:cuda-base-consolidation-latest
             sudo docker exec -it flashlight bash -c "mkdir /flashlight"
             sudo docker cp . flashlight:/flashlight
@@ -66,6 +70,9 @@ jobs:
   build-cpu:
     docker:
       - image: flml/flashlight:cpu-base-consolidation-latest
+        auth:
+          username: $DOCKER_USERNAME
+          password: $DOCKER_PASSWORD
     steps:
       - checkout:
           path: flashlight


### PR DESCRIPTION
Summary: Add docker login with respect to changed policy on docker pull from docker hub

Differential Revision: D24657541

