### PR TITLE
Make log level configurable in asr binaries

### DIFF
--- a/flashlight/app/asr/Decode.cpp
+++ b/flashlight/app/asr/Decode.cpp
@@ -61,6 +61,11 @@ int main(int argc, char** argv) {
     gflags::ParseCommandLineFlags(&argc, &argv, false);
   }
 
+  if (!FLAGS_fl_log_level.empty()) {
+    fl::Logging::setMaxLoggingLevel(fl::logLevelValue(FLAGS_fl_log_level));
+  }
+  fl::VerboseLogging::setMaxLoggingLevel(FLAGS_fl_vlog_level);
+
   /* ===================== Create Network ===================== */
   if (FLAGS_emission_dir.empty() && FLAGS_am.empty()) {
     FL_LOG(fl::FATAL) << "Both flags are empty: `-emission_dir` and `-am`";

--- a/flashlight/app/asr/Test.cpp
+++ b/flashlight/app/asr/Test.cpp
@@ -51,6 +51,11 @@ int main(int argc, char** argv) {
     gflags::ReadFromFlagsFile(flagsfile, argv[0], true);
   }
 
+  if (!FLAGS_fl_log_level.empty()) {
+    fl::Logging::setMaxLoggingLevel(fl::logLevelValue(FLAGS_fl_log_level));
+  }
+  fl::VerboseLogging::setMaxLoggingLevel(FLAGS_fl_vlog_level);
+
   /* ===================== Create Network ===================== */
   std::shared_ptr<fl::Module> network;
   std::shared_ptr<SequenceCriterion> criterion;

--- a/flashlight/app/asr/Train.cpp
+++ b/flashlight/app/asr/Train.cpp
@@ -142,6 +142,10 @@ int main(int argc, char** argv) {
   // aren't
   handleDeprecatedFlags();
 
+  if (!FLAGS_fl_log_level.empty()) {
+    fl::Logging::setMaxLoggingLevel(fl::logLevelValue(FLAGS_fl_log_level));
+  }
+  fl::VerboseLogging::setMaxLoggingLevel(FLAGS_fl_vlog_level);
   af::setSeed(FLAGS_seed);
   af::setFFTPlanCacheSize(FLAGS_fftcachesize);
   fl::DynamicBenchmark::setBenchmarkMode(FLAGS_fl_benchmark_mode);

--- a/flashlight/app/asr/common/Defines.cpp
+++ b/flashlight/app/asr/common/Defines.cpp
@@ -183,6 +183,12 @@ DEFINE_string(
     "",
     "Sets the flashlight optimization mode. "
     "Optim modes can be O1, O2, or O3.");
+DEFINE_string(
+    fl_log_level,
+    "",
+    "Sets the logging level - "
+    "must be [FATAL, ERROR, WARNING, INFO]");
+DEFINE_int64(fl_vlog_level, 0, "Sets the verbose logging level");
 
 // MIXED PRECISION OPTIONS
 DEFINE_bool(

--- a/flashlight/app/asr/common/Defines.h
+++ b/flashlight/app/asr/common/Defines.h
@@ -216,6 +216,8 @@ DECLARE_int64(reportiters);
 DECLARE_double(pcttraineval);
 DECLARE_bool(fl_benchmark_mode);
 DECLARE_string(fl_optim_mode);
+DECLARE_string(fl_log_level);
+DECLARE_int64(fl_vlog_level);
 
 /* ========== MIXED PRECISION OPTIONS ========== */
 


### PR DESCRIPTION
Summary:
See title

New flags:
- `--fl_log_level` in `[FATAL, ERROR, WARNING, INFO]`
- `--fl_vlog_level` -- some integer > 0

cc tlikhomanenko who is moving flags (someone will have to rebase, sorry)

Differential Revision: D24804830

