### PR TITLE
Fix RnnLm example with missing LogSoftmax fwd

### DIFF
--- a/flashlight/fl/examples/RnnLm.cpp
+++ b/flashlight/fl/examples/RnnLm.cpp
@@ -106,6 +106,8 @@ class RnnLm : public Container {
     co.setCalcGrad(false);
 
     output = linear(output);
+    LogSoftmax lsm(0); // max on the main dimension
+    output = lsm(output);
     return std::make_tuple(output, ho, co);
   }
 


### PR DESCRIPTION
Add a missing logsoftmax fwd in the RnnLm example model
to comply with the CatCrossEntropy loss.
fix #139
https://github.com/facebookresearch/flashlight/issues/139

**Original Issue**:
https://github.com/facebookresearch/flashlight/issues/139

closes #139

### Summary
Add a missing logsoftmax fwd in the RnnLm example model
to comply with the CatCrossEntropy loss.

### Test Plan (required)
Run the example and see normal/positive/acceptable positive decreasing loss.
