### PR TITLE
Get rid of region-based doxygen groups, fix logging docs

### DIFF
--- a/docs/source/logging.rst
+++ b/docs/source/logging.rst
@@ -1,0 +1,4 @@
+Logging
+======
+
+.. doxygengroup:: logging

--- a/flashlight/fl/common/Logging.h
+++ b/flashlight/fl/common/Logging.h
@@ -67,18 +67,11 @@
  *
  * Note that `VLOG(level)` only prints when level is less than or equal to the
  * value set to `VerboseLogging`
- *
- * @{
  */
-
-#include <signal.h>
-#include <iostream>
-#include <sstream>
-#include <string>
-#include <utility>
 
 namespace fl {
 
+/// \ingroup logging
 enum LogLevel {
   DISABLED, // use only for when calling setMaxLoggingLevel() or
   // setting DEFAULT_MAX_FL_LOGGING_LEVEL.
@@ -88,35 +81,61 @@ enum LogLevel {
   INFO,
 };
 
+/**
+ * Gets the `LogLevel` for a given string. Throws if invalid.
+ *
+ * \ingroup logging
+ */
 LogLevel logLevelValue(const std::string& level);
+
+/**
+ * Gets string representation of a given `LogLevel`.
+ *
+ * \ingroup logging
+ */
 std::string logLevelName(LogLevel level);
 
 /**
- *  DEFAULT_MAX_FL_LOGGING_LEVEL is used for globally limit FL_LOG(level).
+ *  Used to globally limit `FL_LOG(level)`.
+ *
+ * \ingroup logging
  */
 constexpr LogLevel DEFAULT_MAX_FL_LOGGING_LEVEL = LogLevel::INFO;
 /**
- * MAX_VERBOSE_FL_LOGGING_LEVEL values are based on the values used in
- * FL_VLOG() and can be any value, but expected reasonable values are: 0..10
+ * `MAX_VERBOSE_FL_LOGGING_LEVEL` values are based on the values used in
+ * `FL_VLOG()` and can be any value, but expected reasonable values are: 0..10
  * for print none and print all respectively.
+ *
+ * \ingroup logging
  */
 constexpr int DEFAULT_MAX_VERBOSE_FL_LOGGING_LEVEL = 0;
 
+/**
+ * Write to log output for a given `LogLevel`.
+ *
+ * \ingroup logging
+ */
 #define FL_LOG(level) fl::Logging(level, __FILE__, __LINE__)
+
+/**
+ * Write to verbose log output for a given verbose logging level.
+ *
+ * \ingroup logging
+ */
 #define FL_VLOG(level) fl::VerboseLogging(level, __FILE__, __LINE__)
 
 // Optimization macros that allow to run code only we are going to log it.
 #define IF_LOG(level) if (fl::Logging::ifLog(level))
 #define IF_VLOG(level) if (fl::VerboseLogging::ifLog(level))
 
+/// \ingroup logging
 #define FL_LOG_IF(level, exp) \
   if (exp)                    \
   fl::Logging(level, __FILE__, __LINE__)
+/// \ingroup logging
 #define FL_VLOG_IF(level, exp) \
   if (exp)                     \
   fl::VerboseLogging(level, __FILE__, __LINE__)
-
-/** @} */
 
 class Logging {
  public:

--- a/flashlight/fl/nn/Init.h
+++ b/flashlight/fl/nn/Init.h
@@ -13,6 +13,11 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
+#pragma once
+
+#include "flashlight/fl/autograd/Variable.h"
+#include "flashlight/fl/common/Defines.h"
+
 /**
  * \defgroup nn_init_utils NN Initialization Functions
  *
@@ -21,14 +26,7 @@
  * Provides facilities for creating a `fl::Variable` tensor of different types
  * and initializations vis-a-vis probability distributions, constants, and the
  * identity. Additionally wraps common tensors as integrated into modules.
- *
- * @{
  */
-
-#pragma once
-
-#include "flashlight/fl/autograd/Variable.h"
-#include "flashlight/fl/common/Defines.h"
 
 namespace af {
 /**
@@ -44,6 +42,8 @@ namespace af {
  *
  * @return An `af::array` containing a tensor with random values distributed
  * accordingly.
+ *
+ * \ingroup nn_init_utils
  */
 af::array
 uniform(af::dim4 dims, double min = 0, double max = 1, af::dtype type = f32);
@@ -61,6 +61,8 @@ uniform(af::dim4 dims, double min = 0, double max = 1, af::dtype type = f32);
  *
  * @return An `af::array` containing a tensor with random values distributed
  * accordingly.
+ *
+ * \ingroup nn_init_utils
  */
 af::array
 normal(af::dim4 dims, double stdv = 1, double mean = 0, af::dtype type = f32);
@@ -79,6 +81,8 @@ normal(af::dim4 dims, double stdv = 1, double mean = 0, af::dtype type = f32);
  *
  * @return A `Variable` containing a tensor with random values distributed
  * accordingly.
+ *
+ * \ingroup nn_init_utils
  */
 af::array
 kaimingUniform(af::dim4 shape, int fanIn, af::dtype type = af::dtype::f32);
@@ -94,6 +98,8 @@ kaimingUniform(af::dim4 shape, int fanIn, af::dtype type = af::dtype::f32);
  *
  * @return An `af::array` containing a tensor with random values distributed
  * accordingly.
+ *
+ * \ingroup nn_init_utils
  */
 af::array
 kaimingNormal(af::dim4 shape, int fanIn, af::dtype type = af::dtype::f32);
@@ -112,6 +118,8 @@ kaimingNormal(af::dim4 shape, int fanIn, af::dtype type = af::dtype::f32);
  *
  * @return An `af::array` containing a tensor with random values distributed
  * accordingly.
+ *
+ * \ingroup nn_init_utils
  */
 af::array glorotUniform(
     af::dim4 shape,
@@ -134,6 +142,8 @@ af::array glorotUniform(
  *
  * @return An `af::array` containing a tensor with random values distributed
  * accordingly.
+ *
+ * \ingroup nn_init_utils
  */
 af::array glorotNormal(
     af::dim4 shape,
@@ -151,6 +161,8 @@ namespace fl {
  *
  * @param arr an `af::array` to be used
  * @return a `Variable` from the given array with gradient calculation disabled
+ *
+ * \ingroup nn_init_utils
  */
 Variable input(const af::array& arr);
 
@@ -159,6 +171,8 @@ Variable input(const af::array& arr);
  *
  * @param arr an `af::array` to be used
  * @return a `Variable` from the given array with gradient calculation disabled
+ *
+ * \ingroup nn_init_utils
  */
 Variable noGrad(const af::array& arr);
 
@@ -167,6 +181,8 @@ Variable noGrad(const af::array& arr);
  *
  * @param arr an `af::array` to be used
  * @return a `Variable` from the given array with gradient calculation enabled
+ *
+ * \ingroup nn_init_utils
  */
 Variable param(const af::array& arr);
 
@@ -182,6 +198,8 @@ Variable param(const af::array& arr);
  * `Variable` should be enabled
  *
  * @return A `Variable` containing a tensor with constant values.
+ *
+ * \ingroup nn_init_utils
  */
 Variable constant(
     double val,
@@ -201,6 +219,8 @@ Variable constant(
  * `Variable` should be enabled
  *
  * @return A `Variable` containing a tensor with constant values.
+ *
+ * \ingroup nn_init_utils
  */
 Variable
 constant(double val, af::dim4 dims, af::dtype type = f32, bool calcGrad = true);
@@ -216,6 +236,8 @@ constant(double val, af::dim4 dims, af::dtype type = f32, bool calcGrad = true);
  * `Variable` should be enabled
  *
  * @return A `Variable` containing the identity tensor.
+ *
+ * \ingroup nn_init_utils
  */
 Variable identity(
     int inputSize,
@@ -233,6 +255,8 @@ Variable identity(
  * `Variable` should be enabled
  *
  * @return A `Variable` containing the identity tensor.
+ *
+ * \ingroup nn_init_utils
  */
 Variable identity(af::dim4 dims, af::dtype type = f32, bool calcGrad = true);
 
@@ -252,6 +276,8 @@ Variable identity(af::dim4 dims, af::dtype type = f32, bool calcGrad = true);
  *
  * @return A `Variable` containing a tensor with random values distributed
  * accordingly.
+ *
+ * \ingroup nn_init_utils
  */
 Variable uniform(
     int inputSize,
@@ -276,6 +302,8 @@ Variable uniform(
  *
  * @return A `Variable` containing a tensor with random values distributed
  * accordingly.
+ *
+ * \ingroup nn_init_utils
  */
 Variable uniform(
     af::dim4 dims,
@@ -300,6 +328,8 @@ Variable uniform(
  *
  * @return A `Variable` containing a tensor with random values distributed
  * accordingly.
+ *
+ * \ingroup nn_init_utils
  */
 Variable normal(
     int inputSize,
@@ -324,6 +354,8 @@ Variable normal(
  *
  * @return A `Variable` containing a tensor with random values distributed
  * accordingly.
+ *
+ * \ingroup nn_init_utils
  */
 Variable normal(
     af::dim4 dims,
@@ -346,6 +378,8 @@ Variable normal(
  *
  * @return A `Variable` containing a tensor with random values distributed
  * accordingly.
+ *
+ * \ingroup nn_init_utils
  */
 Variable kaimingUniform(
     af::dim4 shape,
@@ -367,6 +401,8 @@ Variable kaimingUniform(
  *
  * @return A `Variable` containing a tensor with random values distributed
  * accordingly.
+ *
+ * \ingroup nn_init_utils
  */
 Variable kaimingNormal(
     af::dim4 shape,
@@ -390,6 +426,8 @@ Variable kaimingNormal(
  *
  * @return A `Variable` containing a tensor with random values distributed
  * accordingly.
+ *
+ * \ingroup nn_init_utils
  */
 Variable glorotUniform(
     af::dim4 shape,
@@ -415,6 +453,8 @@ Variable glorotUniform(
  *
  * @return A `Variable` containing a tensor with random values distributed
  * accordingly.
+ *
+ * \ingroup nn_init_utils
  */
 Variable glorotNormal(
     af::dim4 shape,
@@ -422,7 +462,5 @@ Variable glorotNormal(
     int fanOut,
     af::dtype type = af::dtype::f32,
     bool calcGrad = true);
-
-/** @} */
 
 } // namespace fl


### PR DESCRIPTION
### Summary
New vision stuff seems to have created some weird cascading effects that have [broken a lot of docs](https://fl.readthedocs.io/en/latest/modules.html) — the entire lib appears in some doc sections.

I'm getting sick of having to fix up weird doxygen group region-based tags having weird behavior (i.e. `@{` and `@}`) so I just got rid of all of them and am using `ingroup`.

### Test Plan (required)
https://fl.readthedocs.io/en/latest/modules.html is an absolute disaster -- fix:

![screencapture-localhost-8000-html-modules-html-2020-11-09-13_25_27-2](https://user-images.githubusercontent.com/7871817/98598479-62e87000-228f-11eb-90e3-8201a5ae1814.png)
![screencapture-localhost-8000-html-modules-html-2020-11-09-13_25_27](https://user-images.githubusercontent.com/7871817/98598493-667bf700-228f-11eb-8324-e51ebe42146b.png)

