### PR TITLE
Add search paths for Kenlm components when Kenlm is installed, fix wr…

### DIFF
--- a/cmake/Findkenlm.cmake
+++ b/cmake/Findkenlm.cmake
@@ -1,11 +1,7 @@
 # Try to find the KenLM library
 #
 # The following variables are optionally searched for defaults
-#  KENLM_DIR: Base directory where all KENLM components are found
-#  KENLM_INCLUDE_DIR: Directory where KENLM headers are found
-#  KENLM_LIB_DIR: Directory where KENLM library is found
-#  KENLM_UTIL_LIB: Directory where KENLM utils are found
-#  KENLM_MAX_ORDER: Max order build setting for kenlm
+#  KENLM_ROOT_DIR: Base directory where all KENLM components are found
 #
 # The following are set after configuration is done:
 #  KENLM_FOUND
@@ -18,25 +14,21 @@ message(STATUS "Looking for KenLM")
 find_library(
   KENLM_LIB
   kenlm
-  ENV KENLM_ROOT_DIR
+  HINTS
+    ${KENLM_ROOT_DIR}/lib
+    ${KENLM_ROOT_DIR}/build/lib
   PATHS
-    $ENV{KENLM_ROOT_DIR}
-  HINT
-    ${KENLM_DIR}
-    ${KENLM_LIB_DIR}
     $ENV{KENLM_ROOT_DIR}/lib
     $ENV{KENLM_ROOT_DIR}/build/lib
-    )
+  )
 
 find_library(
   KENLM_UTIL_LIB
   kenlm_util
-  ENV KENLM_ROOT_DIR
+  HINTS
+    ${KENLM_ROOT_DIR}/lib
+    ${KENLM_ROOT_DIR}/build/lib
   PATHS
-    $ENV{KENLM_ROOT_DIR}
-  HINT
-    ${KENLM_DIR}
-    ${KENLM_LIB_DIR}
     $ENV{KENLM_ROOT_DIR}/lib
     $ENV{KENLM_ROOT_DIR}/build/lib
   )
@@ -44,39 +36,31 @@ find_library(
 if(KENLM_LIB)
   message(STATUS "Using kenlm library found in ${KENLM_LIB}")
 else()
-  message(FATAL_ERROR "kenlm library not found; please set CMAKE_LIBRARY_PATH or KENLM_LIB")
+  message(FATAL_ERROR "kenlm library not found; please set CMAKE_LIBRARY_PATH, KENLM_LIB or KENLM_ROOT_DIR environment variable")
 endif()
 
 if(KENLM_UTIL_LIB)
-  message(STATUS "Using kenlm utils library found in ${KENLM_LIB}")
+  message(STATUS "Using kenlm utils library found in ${KENLM_UTIL_LIB}")
 else()
-  message(FATAL_ERROR "kenlm utils library not found; please set CMAKE_LIBRARY_PATH or KENLM_UTIL_LIB")
+  message(FATAL_ERROR "kenlm utils library not found; please set CMAKE_LIBRARY_PATH, KENLM_UTIL_LIB or KENLM_ROOT_DIR environment variable")
 endif()
 
 # find a model header, then get the entire include directory. We need to do this because
 # cmake consistently confuses other things along this path
 find_file(KENLM_MODEL_HEADER
-  lm/model.hh
-  ENV KENLM_INC
-  HINT
-    ${KENLM_DIR}
-    ${KENLM_DIR}/lm
-    $ENV{KENLM_INC}
-    ${KENLM_INC}
-    $ENV{KENLM_ROOT_DIR}
-    $ENV{KENLM_ROOT_DIR}/lm
-    ${KENLM_LIB}
+  model.hh
+  HINTS
+    ${KENLM_ROOT_DIR}/lm
+    ${KENLM_ROOT_DIR}/include/kenlm/lm
   PATHS
-    ${KENLM_INC}
-    $ENV{KENLM_INC}
-    ${KENLM_ROOT_DIR}
-    $ENV{KENLM_ROOT_DIR}
+    $ENV{KENLM_ROOT_DIR}/lm
+    $ENV{KENLM_ROOT_DIR}/include/kenlm/lm
   )
 
 if(KENLM_MODEL_HEADER)
-  message(STATUS "kenlm lm/model.hh found in ${KENLM_MODEL_HEADER}")
+  message(STATUS "kenlm model.hh found in ${KENLM_MODEL_HEADER}")
 else()
-  message(FATAL_ERROR "kenlm lm/model.hh not found; please set CMAKE_INCLUDE_PATH or KENLM_INC")
+  message(FATAL_ERROR "kenlm model.hh not found; please set CMAKE_INCLUDE_PATH, KENLM_MODEL_HEADER or KENLM_ROOT_DIR environment variable")
 endif()
 get_filename_component(KENLM_INCLUDE_LM ${KENLM_MODEL_HEADER} DIRECTORY)
 get_filename_component(KENLM_INCLUDE_DIR ${KENLM_INCLUDE_LM} DIRECTORY)


### PR DESCRIPTION
**Original Issue**: [253]

### Summary
- Adds search paths for Kenlm when pointing to the installation directory
- Removes unnecessary variables
- Fix error messages

closes #[issue number]