### PR TITLE
Add padding mask into transformer block (attention will ignore pad positions); integrate into training

### DIFF
--- a/flashlight/app/asr/Decode.cpp
+++ b/flashlight/app/asr/Decode.cpp
@@ -25,6 +25,7 @@
 #include "flashlight/app/asr/decoder/Defines.h"
 #include "flashlight/app/asr/decoder/TranscriptionUtils.h"
 #include "flashlight/app/asr/runtime/runtime.h"
+#include "flashlight/ext/common/SequentialBuilder.h"
 #include "flashlight/ext/common/Serializer.h"
 #include "flashlight/lib/common/ProducerConsumerQueue.h"
 #include "flashlight/lib/text/decoder/LexiconDecoder.h"
@@ -429,8 +430,8 @@ int main(int argc, char** argv) {
       /* 3. Load Emissions */
       EmissionUnit emissionUnit;
       if (FLAGS_emission_dir.empty()) {
-        auto rawEmission =
-            localNetwork->forward({fl::input(sample[kInputIdx])}).front();
+        auto rawEmission = fl::ext::forwardSequentialModuleWithPadMask(
+            fl::input(sample[kInputIdx]), localNetwork, sample[kDurationIdx]);
         emissionUnit = EmissionUnit(
             afToVector<float>(rawEmission),
             sampleId,

--- a/flashlight/app/asr/Test.cpp
+++ b/flashlight/app/asr/Test.cpp
@@ -22,6 +22,7 @@
 #include "flashlight/app/asr/decoder/TranscriptionUtils.h"
 #include "flashlight/app/asr/runtime/runtime.h"
 #include "flashlight/ext/common/DistributedUtils.h"
+#include "flashlight/ext/common/SequentialBuilder.h"
 #include "flashlight/ext/common/Serializer.h"
 #include "flashlight/lib/common/System.h"
 #include "flashlight/lib/text/dictionary/Dictionary.h"
@@ -274,8 +275,8 @@ int main(int argc, char** argv) {
     meters.timer.resume();
     int cnt = 0;
     for (auto& sample : *localDs) {
-      auto rawEmission =
-          localNetwork->forward({fl::input(sample[kInputIdx])}).front();
+      auto rawEmission = fl::ext::forwardSequentialModuleWithPadMask(
+          fl::input(sample[kInputIdx]), localNetwork, sample[kDurationIdx]);
       auto emission = afToVector<float>(rawEmission);
       auto tokenTarget = afToVector<int>(sample[kTargetIdx]);
       auto wordTarget = afToVector<int>(sample[kWordIdx]);

--- a/flashlight/app/asr/criterion/TransformerCriterion.cpp
+++ b/flashlight/app/asr/criterion/TransformerCriterion.cpp
@@ -172,8 +172,9 @@ std::pair<Variable, Variable> TransformerCriterion::vectorizedDecoder(
   }
 
   Variable alpha, summaries;
+  Variable padMask;
   for (int i = 0; i < nLayer_; i++) {
-    hy = layer(i)->forward(std::vector<Variable>({hy})).front();
+    hy = layer(i)->forward(std::vector<Variable>({hy, padMask})).front();
   }
 
   if (!input.isempty()) {

--- a/flashlight/ext/common/SequentialBuilder.cpp
+++ b/flashlight/ext/common/SequentialBuilder.cpp
@@ -57,6 +57,30 @@ std::shared_ptr<Sequential> buildSequentialModule(
 
   return net;
 }
+
+fl::Variable forwardSequentialModuleWithPadMask(
+    const fl::Variable& input,
+    std::shared_ptr<fl::Module> ntwrk,
+    const af::array& inputSizes) {
+  // expected input dims T x C x 1 x B
+  int T = input.dims(0), B = input.dims(3);
+  auto inputMaxSize = af::tile(af::max(inputSizes), 1, B);
+  af::array inputNotPaddedSize = af::ceil(inputSizes * T / inputMaxSize);
+  auto padMask = af::iota(af::dim4(T, 1), af::dim4(1, B)) <
+      af::tile(inputNotPaddedSize, T, 1);
+  auto ntwrkSeq = std::dynamic_pointer_cast<fl::Sequential>(ntwrk);
+  auto output = input;
+  for (auto& module : ntwrkSeq->modules()) {
+    auto tr = std::dynamic_pointer_cast<fl::Transformer>(module);
+    auto cfr = std::dynamic_pointer_cast<fl::Conformer>(module);
+    if (tr != nullptr || cfr != nullptr) {
+      output = module->forward({output, fl::noGrad(padMask)}).front();
+    } else {
+      output = module->forward({output}).front();
+    }
+  }
+  return output.as(input.type());
+}
 } // namespace ext
 } // namespace fl
 

--- a/flashlight/ext/common/SequentialBuilder.h
+++ b/flashlight/ext/common/SequentialBuilder.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "flashlight/fl/contrib/contrib.h"
+#include "flashlight/fl/contrib/modules/modules.h"
 #include "flashlight/fl/flashlight.h"
 
 namespace fl {
@@ -21,5 +22,19 @@ std::shared_ptr<fl::Sequential> buildSequentialModule(
     const std::string& archfile,
     int64_t nFeatures,
     int64_t nClasses);
+
+/**
+ * Utility function for to run forward with pad masking
+ * casting of modules happens to use pad masking for trasnfromer layers
+ * properly. It assumes that model is constructed with
+ * buildSequentialModule. Caveat: it is not supporting resnet block
+ * with a transformer block in it!
+ * TODO remove with landing plugin arch instead of arch files
+ */
+fl::Variable forwardSequentialModuleWithPadMask(
+    const fl::Variable& input,
+    std::shared_ptr<fl::Module> ntwrk,
+    const af::array& inputSizes);
+
 } // namespace ext
 } // namespace fl

--- a/flashlight/fl/autograd/Functions.h
+++ b/flashlight/fl/autograd/Functions.h
@@ -935,14 +935,16 @@ Variable relativePositionalEmbeddingRotate(const Variable& input);
 /**
  * Multihead Attention function
  * For details, see [Vaswani et al (2017)](https://arxiv.org/abs/1706.03762).
- * @param query query Variable
- * @param key key Variable
- * @param value value Variable
+ * @param query query Variable of size T x nHeads * headDim x B
+ * @param key key Variable of size Time x nHeads * headDim x B
+ * @param value value Variable of size Time x nHeads * headDim x B
  * @param posEmb if non empty then compute relative
  * positional embedding in additon to standard computations
- * @param mask mask or not future in the computations
+ * @param mask mask or not future in the computations T x T
  * if non-empty then don't use future (for example for autoregressive language models
  * or for decoder part in the encoder-decoder transformer models)
+ * @param padMask mask which is 1 for positions where pad token is,
+ * don't attend to the pad-positions, of size T x B
  * @param nHeads number of heads
  * @param pDropout dropout probability
  * @param offset size of the current output from the decoder used now as input
@@ -953,6 +955,7 @@ Variable multiheadAttention(
     const Variable& value,
     const Variable& posEmb,
     const Variable& mask,
+    const Variable& padMask,
     const int32_t nHeads,
     const double pDropout,
     const int32_t offset = 0);

--- a/flashlight/fl/contrib/modules/Conformer.h
+++ b/flashlight/fl/contrib/modules/Conformer.h
@@ -61,7 +61,7 @@ class Conformer : public Container {
   std::shared_ptr<Conv2D> convDepthWise_;
 
   static Variable conformerInitLinear(int32_t inDim, int32_t outDim);
-  Variable mhsa(const Variable& input);
+  Variable mhsa(const Variable& input, const Variable& inputPadMask);
   Variable conv(const Variable& input);
 
   Conformer() = default;

--- a/flashlight/fl/contrib/modules/Transformer.h
+++ b/flashlight/fl/contrib/modules/Transformer.h
@@ -23,14 +23,21 @@ namespace fl {
  * This module also supports layer drop regularization, as introduced in
  * [Fan et al (2019)](https://arxiv.org/abs/1909.11556).
  *
- * Input dimension at forward is assumed to be CxTxBx1, where C is the
+ * Forward takes {previous step[optionally], input, padMask}
+ * previous step is used in for the decoder phase, previous output with size
+ * CxT'xBx1 Input dimension at forward is assumed to be CxTxBx1, where C is the
  * number of features, T the sequence length and B the batch size.
+ * padMask is with T''xB sizes (T'' will be af::resize to the input size)
+ * padMask should be empty if "previous step" is provided (in the decoder phase)
+ * padMask is expected to have "1" on the normal positions and "0" on the padded
+ * positions
  *
  * @param modelDim input embedding dimension
  * @param headDim dimension of each head
  * @param mlpDim dimension of the feed-forward layers
  * @param nHeads number of heads
- * @param bptt size for learnt relative positional embedding matrix (2 * bptt - 1) * nHeads
+ * @param bptt size for learnt relative positional embedding matrix (2 * bptt -
+ * 1) * nHeads
  * @param pDropout dropout probability
  * @param pLayerdrop layer dropout probability
  * @param useMask mask or not future in the computations

--- a/flashlight/fl/test/contrib/modules/ContribSerializationTest.cpp
+++ b/flashlight/fl/test/contrib/modules/ContribSerializationTest.cpp
@@ -82,8 +82,8 @@ TEST(ModuleTest, TransformerSerialization) {
   loaded->eval();
 
   auto input = Variable(af::randu(c, timesteps, batchsize, 1), false);
-  auto output = model->forward({input});
-  auto outputl = loaded->forward({input});
+  auto output = model->forward({input, Variable()});
+  auto outputl = loaded->forward({input, Variable()});
 
   ASSERT_TRUE(allParamsClose(*loaded, *model));
   ASSERT_TRUE(allClose(outputl[0], output[0]));
@@ -105,8 +105,8 @@ TEST(ModuleTest, ConformerSerialization) {
   loaded->eval();
 
   auto input = Variable(af::randu(c, timesteps, batchsize, 1), false);
-  auto output = model->forward({input});
-  auto outputl = loaded->forward({input});
+  auto output = model->forward({input, Variable()});
+  auto outputl = loaded->forward({input, Variable()});
 
   ASSERT_TRUE(allParamsClose(*loaded, *model));
   ASSERT_TRUE(allClose(outputl[0], output[0]));


### PR DESCRIPTION
Summary:
- add additional param for forward pass in transformer
- integrate into training pipeline (test/decode is using batch=1 so we don't need this changes there)

Differential Revision: D24967529

