### PR TITLE
integrate DecodeMaster into training for CTC lexicon-based beam search for now, brought by Ronan Collobert @locronan

### DIFF
--- a/flashlight/app/asr/common/Defines.cpp
+++ b/flashlight/app/asr/common/Defines.cpp
@@ -285,6 +285,10 @@ DEFINE_int32(
     std::numeric_limits<int>::max(),
     "hard attention limit");
 
+DEFINE_double(lmweight_low, 0.0, "language model weight (low boundary, search)");
+DEFINE_double(lmweight_high, 4.0, "language model weight (high boundary, search)");
+DEFINE_double(lmweight_step, 0.2, "language model weight (step, search)");
+
 // ASG OPTIONS
 DEFINE_int64(linseg, 0, "# of updates of LinSeg to init transitions for ASG");
 DEFINE_double(linlr, -1.0, "LinSeg learning rate (if < 0, use lr)");

--- a/flashlight/app/asr/common/Defines.h
+++ b/flashlight/app/asr/common/Defines.h
@@ -278,6 +278,10 @@ DECLARE_int32(lm_memory);
 
 DECLARE_int32(emission_queue_size);
 
+DECLARE_double(lmweight_low);
+DECLARE_double(lmweight_high);
+DECLARE_double(lmweight_step);
+
 // Seq2Seq
 DECLARE_double(smoothingtemperature);
 DECLARE_int32(attentionthreshold);

--- a/flashlight/app/asr/decoder/CMakeLists.txt
+++ b/flashlight/app/asr/decoder/CMakeLists.txt
@@ -4,5 +4,6 @@ target_sources(
   flashlight-app-asr
   PRIVATE
   ${CMAKE_CURRENT_LIST_DIR}/ConvLmModule.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/DecodeMaster.cpp
   ${CMAKE_CURRENT_LIST_DIR}/TranscriptionUtils.cpp
   )

--- a/flashlight/app/asr/decoder/DecodeMaster.cpp
+++ b/flashlight/app/asr/decoder/DecodeMaster.cpp
@@ -1,0 +1,349 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "flashlight/app/asr/decoder/DecodeMaster.h"
+
+#include "flashlight/app/asr/common/Defines.h"
+#include "flashlight/app/asr/decoder/TranscriptionUtils.h"
+#include "flashlight/app/asr/runtime/Helpers.h"
+#include "flashlight/ext/common/SequentialBuilder.h"
+#include "flashlight/fl/dataset/MemoryBlobDataset.h"
+#include "flashlight/fl/meter/EditDistanceMeter.h"
+#include "flashlight/lib/text/decoder/LexiconDecoder.h"
+#include "flashlight/lib/text/decoder/LexiconFreeDecoder.h"
+
+namespace {
+
+constexpr size_t kDMTokenTargetIdx = 0;
+constexpr size_t kDMWordTargetIdx = 1;
+constexpr size_t kDMTokenPredIdx = 2;
+constexpr size_t kDMWordPredIdx = 3;
+
+af::array removeNegative(const af::array& arr) {
+  return arr(arr >= 0);
+}
+af::array removePad(const af::array& arr, int32_t padIdx) {
+  return arr(arr != padIdx);
+}
+} // namespace
+
+// TODO threading?
+
+namespace fl {
+namespace app {
+namespace asr {
+
+DecodeMaster::DecodeMaster(
+    const std::shared_ptr<fl::Module> net,
+    const std::shared_ptr<fl::lib::text::LM> lm,
+    bool isTokenLM,
+    const fl::lib::text::Dictionary& tokenDict,
+    const fl::lib::text::Dictionary& wordDict,
+    const DecodeMasterTrainOptions& trainOpt)
+    : net_(net),
+      lm_(lm),
+      isTokenLM_(isTokenLM),
+      tokenDict_(tokenDict),
+      wordDict_(wordDict),
+      trainOpt_(trainOpt) {}
+
+std::pair<std::vector<double>, std::vector<double>>
+DecodeMaster::computeMetrics(const std::shared_ptr<fl::Dataset>& predDataset) {
+  fl::EditDistanceMeter wer, ler;
+
+  for (auto& sample : *predDataset) {
+    if (sample.size() <= kDMWordPredIdx) {
+      throw std::runtime_error(
+          "computeMetrics: need token/word target to compute WER");
+    }
+    auto predictionWrd = sample[kDMWordPredIdx];
+    auto targetWrd = sample[kDMWordTargetIdx];
+    auto prediction = sample[kDMTokenPredIdx];
+    auto target = sample[kDMTokenTargetIdx];
+    bool isPredictingWrd = !predictionWrd.isempty();
+
+    if (prediction.numdims() > 2 || target.numdims() > 2) {
+      throw std::runtime_error(
+          "computeMetrics: expecting TxB for prediction and target");
+    }
+    if (isPredictingWrd &&
+        (predictionWrd.numdims() > 2 || targetWrd.numdims() > 2)) {
+      throw std::runtime_error(
+          "computeMetrics: expecting TxB for prediction and target");
+    }
+
+    if (!prediction.isempty() && !target.isempty() &&
+        (prediction.dims(1) != target.dims(1))) {
+      throw std::runtime_error(
+          "computeMetrics: prediction and target do not match");
+    }
+    if (isPredictingWrd && !predictionWrd.isempty() && !targetWrd.isempty() &&
+        (predictionWrd.dims(1) != targetWrd.dims(1))) {
+      throw std::runtime_error(
+          "computeMetrics: prediction and target do not match");
+    }
+    // token predictions and target
+    std::vector<int> predictionV = fl::ext::afToVector<int>(prediction);
+    std::vector<int> targetV = fl::ext::afToVector<int>(target);
+
+    auto predictionS = computeStringPred(predictionV);
+    auto targetS = computeStringTarget(targetV);
+    ler.add(predictionS, targetS);
+
+    std::vector<std::string> targetWrdS, predictionWrdS;
+    if (isPredictingWrd) {
+      targetWrdS = wrdIdx2Wrd(fl::ext::afToVector<int>(targetWrd), wordDict_);
+      predictionWrdS =
+          wrdIdx2Wrd(fl::ext::afToVector<int>(predictionWrd), wordDict_);
+    } else {
+      targetWrdS = tkn2Wrd(targetS, trainOpt_.wordSep);
+      predictionWrdS = tkn2Wrd(predictionS, trainOpt_.wordSep);
+    }
+    wer.add(predictionWrdS, targetWrdS);
+  }
+  return {ler.value(), wer.value()};
+}
+
+std::shared_ptr<fl::lib::text::Trie> DecodeMaster::buildTrie(
+    const fl::lib::text::LexiconMap& lexicon,
+    fl::lib::text::SmearingMode smearMode) const {
+  auto trie = std::make_shared<fl::lib::text::Trie>(
+      tokenDict_.indexSize(), tokenDict_.getIndex(trainOpt_.wordSep));
+  auto startState = lm_->start(false);
+  for (auto& it : lexicon) {
+    const std::string& word = it.first;
+    int usrIdx = wordDict_.getIndex(word);
+    float score = 0;
+    if (!isTokenLM_) {
+      fl::lib::text::LMStatePtr dummyState;
+      std::tie(dummyState, score) = lm_->score(startState, usrIdx);
+    }
+    for (auto& tokens : it.second) {
+      auto tokensTensor = tkn2Idx(tokens, tokenDict_, trainOpt_.repLabel);
+      trie->insert(tokensTensor, usrIdx, score);
+    }
+  }
+  // Smearing
+  trie->smear(smearMode);
+  return trie;
+}
+
+std::shared_ptr<fl::Dataset> DecodeMaster::forward(
+    const std::shared_ptr<fl::Dataset>& ds) {
+  auto emissionDataset = std::make_shared<fl::MemoryBlobDataset>();
+  for (auto& batch : *ds) {
+    auto output = fl::ext::forwardSequentialModuleWithPadMask(
+                      fl::input(batch[kInputIdx]), net_, batch[kDurationIdx])
+                      .array();
+    if (output.numdims() > 3) {
+      throw std::runtime_error("output should be NxTxB");
+    }
+    af::array tokenTarget =
+        (batch.size() > kTargetIdx ? batch[kTargetIdx] : af::array());
+    af::array wordTarget =
+        (batch.size() > kWordIdx ? batch[kWordIdx] : af::array());
+
+    int B = output.dims(2);
+    if (!tokenTarget.isempty() &&
+        (tokenTarget.numdims() > 2 || tokenTarget.dims(1) != B)) {
+      throw std::runtime_error("token target should be LxB");
+    }
+    if (!wordTarget.isempty() &&
+        (wordTarget.numdims() > 2 || wordTarget.dims(1) != B)) {
+      throw std::runtime_error("word target should be LxB");
+    }
+    // todo s2s, if we pad only with -1 we will be good here (not pad with eos)
+    for (int b = 0; b < B; b++) {
+      std::vector<af::array> res(4);
+      res[kDMTokenPredIdx] = output(af::span, af::span, b);
+      res[kDMTokenTargetIdx] = removeNegative(tokenTarget(af::span, b));
+      res[kDMTokenTargetIdx] =
+          removePad(res[kDMTokenTargetIdx], trainOpt_.targetPadIdx);
+      res[kDMWordTargetIdx] = removeNegative(wordTarget(af::span, b));
+      res[kDMWordTargetIdx] =
+          removePad(res[kDMWordTargetIdx], trainOpt_.targetPadIdx);
+      emissionDataset->add(res);
+    }
+  }
+  emissionDataset->writeIndex();
+  return emissionDataset;
+}
+
+std::shared_ptr<fl::Dataset> DecodeMaster::decode(
+    const std::shared_ptr<fl::Dataset>& emissionDataset,
+    fl::lib::text::Decoder& decoder) {
+  auto predDataset = std::make_shared<fl::MemoryBlobDataset>();
+  for (auto& sample : *emissionDataset) {
+    auto emission = sample[kDMTokenPredIdx];
+    if (emission.numdims() > 2) {
+      throw std::runtime_error("emission should be NxT");
+    }
+    std::vector<float> emissionV(emission.elements());
+    emission.as(af::dtype::f32).host(emissionV.data());
+    auto results =
+        decoder.decode(emissionV.data(), emission.dims(1), emission.dims(0));
+
+    std::vector<int> tokensV, wordsV;
+    if (results.size() > 0) {
+      tokensV = results[0].tokens;
+      wordsV = results[0].words;
+    }
+    tokensV.erase(
+        std::remove(tokensV.begin(), tokensV.end(), -1), tokensV.end());
+    wordsV.erase(std::remove(wordsV.begin(), wordsV.end(), -1), wordsV.end());
+    sample[kDMTokenPredIdx] =
+        (tokensV.size() > 0
+             ? af::array(af::dim4(tokensV.size()), tokensV.data())
+             : af::array());
+    sample[kDMWordPredIdx] =
+        (wordsV.size() > 0 ? af::array(af::dim4(wordsV.size()), wordsV.data())
+                           : af::array());
+    predDataset->add(sample);
+  }
+  predDataset->writeIndex();
+  return predDataset;
+}
+
+TokenDecodeMaster::TokenDecodeMaster(
+    const std::shared_ptr<fl::Module> net,
+    const std::shared_ptr<fl::lib::text::LM> lm,
+    const std::vector<float>& transition,
+    const fl::lib::text::Dictionary& tokenDict,
+    const fl::lib::text::Dictionary& wordDict,
+    const DecodeMasterTrainOptions& trainOpt)
+    : DecodeMaster(net, lm, true, tokenDict, wordDict, trainOpt),
+      transition_(transition) {}
+
+std::shared_ptr<fl::Dataset> TokenDecodeMaster::decode(
+    const std::shared_ptr<fl::Dataset>& emissionDataset,
+    DecodeMasterLexiconFreeOptions opt) {
+  fl::lib::text::LexiconFreeDecoderOptions decoderOpt{
+      .beamSize = opt.beamSize,
+      .beamSizeToken = opt.beamSizeToken,
+      .beamThreshold = opt.beamThreshold,
+      .lmWeight = opt.lmWeight,
+      .silScore = opt.silScore,
+      .logAdd = opt.logAdd,
+      .criterionType = fl::lib::text::CriterionType::CTC};
+  auto silIdx = tokenDict_.getIndex(opt.silToken);
+  auto blankIdx = tokenDict_.getIndex(opt.blankToken);
+  fl::lib::text::LexiconFreeDecoder decoder(
+      decoderOpt, lm_, silIdx, blankIdx, transition_);
+  return DecodeMaster::decode(emissionDataset, decoder);
+}
+
+std::shared_ptr<fl::Dataset> TokenDecodeMaster::decode(
+    const std::shared_ptr<fl::Dataset>& emissionDataset,
+    const fl::lib::text::LexiconMap& lexicon,
+    DecodeMasterLexiconOptions opt) {
+  auto trie = buildTrie(lexicon, opt.smearMode);
+  fl::lib::text::LexiconDecoderOptions decoderOpt{
+      .beamSize = opt.beamSize,
+      .beamSizeToken = opt.beamSizeToken,
+      .beamThreshold = opt.beamThreshold,
+      .lmWeight = opt.lmWeight,
+      .wordScore = opt.wordScore,
+      .unkScore = opt.unkScore,
+      .silScore = opt.silScore,
+      .logAdd = opt.logAdd,
+      .criterionType = fl::lib::text::CriterionType::CTC};
+  auto silIdx = tokenDict_.getIndex(opt.silToken);
+  auto blankIdx = tokenDict_.getIndex(opt.blankToken);
+  auto unkWordIdx = wordDict_.getIndex(fl::lib::text::kUnkToken);
+  fl::lib::text::LexiconDecoder decoder(
+      decoderOpt, trie, lm_, silIdx, blankIdx, unkWordIdx, transition_, true);
+  return DecodeMaster::decode(emissionDataset, decoder);
+}
+
+std::vector<std::string> TokenDecodeMaster::computeStringPred(
+    const std::vector<int>& tokenIdxSeq) {
+  return tknPrediction2Ltr(
+      tokenIdxSeq,
+      tokenDict_,
+      "ctc",
+      trainOpt_.surround,
+      false, // eosToken
+      trainOpt_.repLabel,
+      trainOpt_.wordSepIsPartOfToken,
+      trainOpt_.wordSep);
+}
+
+std::vector<std::string> TokenDecodeMaster::computeStringTarget(
+    const std::vector<int>& tokenIdxSeq) {
+  return tknTarget2Ltr(
+      tokenIdxSeq,
+      tokenDict_,
+      "ctc",
+      trainOpt_.surround,
+      false, // eosToken
+      trainOpt_.repLabel,
+      trainOpt_.wordSepIsPartOfToken,
+      trainOpt_.wordSep);
+}
+
+WordDecodeMaster::WordDecodeMaster(
+    const std::shared_ptr<fl::Module> net,
+    const std::shared_ptr<fl::lib::text::LM> lm,
+    const std::vector<float>& transition,
+    const fl::lib::text::Dictionary& tokenDict,
+    const fl::lib::text::Dictionary& wordDict,
+    const DecodeMasterTrainOptions& trainOpt)
+    : DecodeMaster(net, lm, false, tokenDict, wordDict, trainOpt),
+      transition_(transition) {}
+
+std::shared_ptr<fl::Dataset> WordDecodeMaster::decode(
+    const std::shared_ptr<fl::Dataset>& emissionDataset,
+    const fl::lib::text::LexiconMap& lexicon,
+    DecodeMasterLexiconOptions opt) {
+  auto trie = buildTrie(lexicon, opt.smearMode);
+  fl::lib::text::LexiconDecoderOptions decoderOpt{
+      .beamSize = opt.beamSize,
+      .beamSizeToken = opt.beamSizeToken,
+      .beamThreshold = opt.beamThreshold,
+      .lmWeight = opt.lmWeight,
+      .wordScore = opt.wordScore,
+      .unkScore = opt.unkScore,
+      .silScore = opt.silScore,
+      .logAdd = opt.logAdd,
+      .criterionType = fl::lib::text::CriterionType::CTC};
+  auto silIdx = tokenDict_.getIndex(opt.silToken);
+  auto blankIdx = tokenDict_.getIndex(opt.blankToken);
+  auto unkWordIdx = wordDict_.getIndex(opt.unkToken);
+  fl::lib::text::LexiconDecoder decoder(
+      decoderOpt, trie, lm_, silIdx, blankIdx, unkWordIdx, transition_, false);
+  return DecodeMaster::decode(emissionDataset, decoder);
+}
+
+std::vector<std::string> WordDecodeMaster::computeStringPred(
+    const std::vector<int>& tokenIdxSeq) {
+  return tknPrediction2Ltr(
+      tokenIdxSeq,
+      tokenDict_,
+      "ctc",
+      trainOpt_.surround,
+      false, // eosToken
+      trainOpt_.repLabel,
+      trainOpt_.wordSepIsPartOfToken,
+      trainOpt_.wordSep);
+}
+
+std::vector<std::string> WordDecodeMaster::computeStringTarget(
+    const std::vector<int>& tokenIdxSeq) {
+  return tknTarget2Ltr(
+      tokenIdxSeq,
+      tokenDict_,
+      "ctc",
+      trainOpt_.surround,
+      false, // eosToken
+      trainOpt_.repLabel,
+      trainOpt_.wordSepIsPartOfToken,
+      trainOpt_.wordSep);
+}
+
+} // namespace asr
+} // namespace app
+} // namespace fl

--- a/flashlight/app/asr/decoder/DecodeMaster.h
+++ b/flashlight/app/asr/decoder/DecodeMaster.h
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "flashlight/ext/common/Utils-inl.h"
+#include "flashlight/fl/dataset/datasets.h"
+#include "flashlight/fl/nn/nn.h"
+#include "flashlight/lib/text/decoder/Decoder.h"
+#include "flashlight/lib/text/decoder/Trie.h"
+#include "flashlight/lib/text/decoder/lm/LM.h"
+#include "flashlight/lib/text/dictionary/Dictionary.h"
+#include "flashlight/lib/text/dictionary/Utils.h"
+
+namespace fl {
+namespace app {
+namespace asr {
+
+struct DecodeMasterLexiconFreeOptions {
+  int beamSize;
+  int beamSizeToken;
+  double beamThreshold;
+  double lmWeight;
+  double silScore;
+  bool logAdd;
+  std::string silToken;
+  std::string blankToken;
+};
+
+struct DecodeMasterLexiconOptions {
+  int beamSize;
+  int beamSizeToken;
+  double beamThreshold;
+  double lmWeight;
+  double silScore;
+  double wordScore;
+  double unkScore;
+  bool logAdd;
+  std::string silToken;
+  std::string blankToken;
+  std::string unkToken;
+  fl::lib::text::SmearingMode smearMode;
+};
+
+struct DecodeMasterTrainOptions {
+  int repLabel;
+  bool wordSepIsPartOfToken;
+  std::string surround;
+  std::string wordSep;
+  int32_t targetPadIdx;
+};
+
+class DecodeMaster {
+ public:
+  explicit DecodeMaster(
+      const std::shared_ptr<fl::Module> net,
+      const std::shared_ptr<fl::lib::text::LM> lm,
+      bool isTokenLM,
+      const fl::lib::text::Dictionary& tokenDict,
+      const fl::lib::text::Dictionary& wordDict,
+      const DecodeMasterTrainOptions& trainOpt);
+
+  // compute emissions
+  virtual std::shared_ptr<fl::Dataset> forward(
+      const std::shared_ptr<fl::Dataset>& ds);
+
+  // decode emissions with an existing decoder
+  std::shared_ptr<fl::Dataset> decode(
+      const std::shared_ptr<fl::Dataset>& eds,
+      fl::lib::text::Decoder& decoder);
+
+  // returns LER and WER
+  std::pair<std::vector<double>, std::vector<double>> computeMetrics(
+      const std::shared_ptr<fl::Dataset>& pds);
+
+  // convert tokens indices predictions into letters string
+  virtual std::vector<std::string> computeStringPred(
+      const std::vector<int>& tokenIdxSeq) = 0;
+
+  // convert tokens indices predictions into letters string
+  virtual std::vector<std::string> computeStringTarget(
+      const std::vector<int>& tokenIdxSeq) = 0;
+
+  virtual ~DecodeMaster() = default;
+
+ protected:
+  std::shared_ptr<fl::lib::text::Trie> buildTrie(
+      const fl::lib::text::LexiconMap& lexicon,
+      fl::lib::text::SmearingMode smearMode) const;
+
+  std::shared_ptr<fl::Module> net_;
+  std::shared_ptr<fl::lib::text::LM> lm_;
+  bool isTokenLM_;
+  fl::lib::text::Dictionary tokenDict_;
+  fl::lib::text::Dictionary wordDict_;
+  DecodeMasterTrainOptions trainOpt_;
+};
+
+// token-based CTC/ASG decoder (lexicon or lexicon-free)
+class TokenDecodeMaster : public DecodeMaster {
+ public:
+  explicit TokenDecodeMaster(
+      const std::shared_ptr<fl::Module> net,
+      const std::shared_ptr<fl::lib::text::LM> lm,
+      const std::vector<float>& transition,
+      const fl::lib::text::Dictionary& tokenDict,
+      const fl::lib::text::Dictionary& wordDict,
+      const DecodeMasterTrainOptions& trainOpt);
+
+  // compute predictions from emissions for lexicon free case
+  std::shared_ptr<fl::Dataset> decode(
+      const std::shared_ptr<fl::Dataset>& eds,
+      DecodeMasterLexiconFreeOptions opt);
+
+  // compute predictions from emissions for lexicon case
+  std::shared_ptr<fl::Dataset> decode(
+      const std::shared_ptr<fl::Dataset>& eds,
+      const fl::lib::text::LexiconMap& lexicon,
+      DecodeMasterLexiconOptions opt);
+
+  // convert tokens indices predictions into letters string
+  virtual std::vector<std::string> computeStringPred(
+      const std::vector<int>& tokenIdxSeq) override;
+
+  // convert tokens indices predictions into letters string
+  virtual std::vector<std::string> computeStringTarget(
+      const std::vector<int>& tokenIdxSeq) override;
+
+ private:
+  std::vector<float> transition_;
+};
+
+// word-based CTC/ASG decoder (lexicon or lexicon-free)
+class WordDecodeMaster : public DecodeMaster {
+ public:
+  explicit WordDecodeMaster(
+      const std::shared_ptr<fl::Module> net,
+      const std::shared_ptr<fl::lib::text::LM> lm,
+      const std::vector<float>& transition,
+      const fl::lib::text::Dictionary& tokenDict,
+      const fl::lib::text::Dictionary& wordDict,
+      const DecodeMasterTrainOptions& trainOpt);
+
+  // compute predictions from emissions
+  std::shared_ptr<fl::Dataset> decode(
+      const std::shared_ptr<fl::Dataset>& eds,
+      const fl::lib::text::LexiconMap& lexicon,
+      DecodeMasterLexiconOptions opt);
+
+  // convert tokens indices predictions into letters string
+  virtual std::vector<std::string> computeStringPred(
+      const std::vector<int>& tokenIdxSeq) override;
+
+  // convert tokens indices predictions into letters string
+  virtual std::vector<std::string> computeStringTarget(
+      const std::vector<int>& tokenIdxSeq) override;
+
+ private:
+  std::vector<float> transition_;
+};
+} // namespace asr
+} // namespace app
+} // namespace fl

--- a/flashlight/app/asr/runtime/Logger.cpp
+++ b/flashlight/app/asr/runtime/Logger.cpp
@@ -22,6 +22,7 @@ namespace app {
 namespace asr {
 std::pair<std::string, std::string> getStatus(
     TrainMeters& meters,
+    std::unordered_map<std::string, double>& validDecoderWer,
     int64_t epoch,
     int64_t nupdates,
     double lr,
@@ -69,6 +70,7 @@ std::pair<std::string, std::string> getStatus(
     insertItem(
         v.first + "-" + errtype, format("%5.2f", v.second.tknEdit.errorRate()[0]));
     insertItem(v.first + "-WER", format("%5.2f", v.second.wrdEdit.errorRate()[0]));
+    insertItem(v.first + "-WER-decoded", format("%5.2f", validDecoderWer[v.first]));
   }
   auto stats = meters.stats.value();
   auto numsamples = std::max<int64_t>(stats[4], 1);

--- a/flashlight/app/asr/runtime/Logger.h
+++ b/flashlight/app/asr/runtime/Logger.h
@@ -46,6 +46,7 @@ struct TestMeters {
 
 std::pair<std::string, std::string> getStatus(
     TrainMeters& meters,
+    std::unordered_map<std::string, double>& dmErrs,
     int64_t epoch,
     int64_t nupdates,
     double lr,


### PR DESCRIPTION
Summary:
- Add DecodeMaster into training loop
- Save checkpoint by the best decoded wer, not viterbi
- Set -1 pad token for word targets instead of unk

Differential Revision: D24826144

