### PR TITLE
Use private source properties rather than build interface gen exps

### DIFF
--- a/flashlight/fl/autograd/CMakeLists.txt
+++ b/flashlight/fl/autograd/CMakeLists.txt
@@ -10,8 +10,8 @@ set(
 
 target_sources(
   flashlight
-  PUBLIC
-  $<BUILD_INTERFACE:${AUTOGRAD_SOURCES}>
+  PRIVATE
+  ${AUTOGRAD_SOURCES}
   )
 
 # ----------------------------- Autograd Backends -----------------------------
@@ -28,8 +28,8 @@ if (FLASHLIGHT_USE_CPU)
 
   target_sources(
     flashlight
-    PUBLIC
-    $<BUILD_INTERFACE:${AUTOGRAD_CPU_SOURCES}>
+    PRIVATE
+    ${AUTOGRAD_CPU_SOURCES}
     )
 
   target_link_libraries(
@@ -69,8 +69,8 @@ if (FLASHLIGHT_USE_CUDA)
 
   target_sources(
     flashlight
-    PUBLIC
-    $<BUILD_INTERFACE:${AUTOGRAD_CUDA_SOURCES}>
+    PRIVATE
+    ${AUTOGRAD_CUDA_SOURCES}
     )
 
   target_link_libraries(
@@ -108,8 +108,8 @@ if (FLASHLIGHT_USE_OPENCL)
 
   target_sources(
     flashlight
-    PUBLIC
-    $<BUILD_INTERFACE:${AUTOGRAD_OPENCL_SOURCES}>
+    PRIVATE
+    ${AUTOGRAD_OPENCL_SOURCES}
     )
 
   target_link_libraries(

--- a/flashlight/fl/common/CMakeLists.txt
+++ b/flashlight/fl/common/CMakeLists.txt
@@ -18,8 +18,8 @@ endif()
 
 target_sources(
   flashlight
-  PUBLIC
-  $<BUILD_INTERFACE:${COMMON_SRCS}>
+  PRIVATE
+  ${COMMON_SRCS}
 )
 
 # A native threading library is needed for ThreadPool

--- a/flashlight/fl/dataset/CMakeLists.txt
+++ b/flashlight/fl/dataset/CMakeLists.txt
@@ -20,6 +20,6 @@ set(
 
 target_sources(
   flashlight
-  PUBLIC
-  $<BUILD_INTERFACE:${DATASET_SOURCES}>
+  PRIVATE
+  ${DATASET_SOURCES}
   )

--- a/flashlight/fl/distributed/CMakeLists.txt
+++ b/flashlight/fl/distributed/CMakeLists.txt
@@ -13,8 +13,8 @@ set(
 if (FL_BUILD_DISTRIBUTED)
   target_sources(
     flashlight
-    PUBLIC
-    $<BUILD_INTERFACE:${DISTRIBUTED_SOURCES}>
+    PRIVATE
+    ${DISTRIBUTED_SOURCES}
     )
 endif()
 
@@ -91,8 +91,8 @@ if (USE_NCCL)
 
   target_sources(
     flashlight
-    PUBLIC
-    $<BUILD_INTERFACE:${DISTRIBUTED_NCCL_SOURCES}>
+    PRIVATE
+    ${DISTRIBUTED_NCCL_SOURCES}
     )
 
   target_link_libraries(
@@ -124,8 +124,8 @@ if (USE_GLOO)
 
   target_sources(
     flashlight
-    PUBLIC
-    $<BUILD_INTERFACE:${DISTRIBUTED_GLOO_SOURCES}>
+    PRIVATE
+    ${DISTRIBUTED_GLOO_SOURCES}
     )
 
   target_link_libraries(

--- a/flashlight/fl/memory/CMakeLists.txt
+++ b/flashlight/fl/memory/CMakeLists.txt
@@ -11,6 +11,6 @@ set(
 
 target_sources(
   flashlight
-  PUBLIC
-  $<BUILD_INTERFACE:${MEMORY_SOURCES}>
+  PRIVATE
+  ${MEMORY_SOURCES}
 )

--- a/flashlight/fl/meter/CMakeLists.txt
+++ b/flashlight/fl/meter/CMakeLists.txt
@@ -13,6 +13,6 @@ set(
 
 target_sources(
   flashlight
-  PUBLIC
-  $<BUILD_INTERFACE:${METER_SOURCES}>
+  PRIVATE
+  ${METER_SOURCES}
   )

--- a/flashlight/fl/nn/CMakeLists.txt
+++ b/flashlight/fl/nn/CMakeLists.txt
@@ -39,6 +39,6 @@ endif ()
 
 target_sources(
   flashlight
-  PUBLIC
-  $<BUILD_INTERFACE:${NN_SOURCES}>
+  PRIVATE
+  ${NN_SOURCES}
   )

--- a/flashlight/fl/optim/CMakeLists.txt
+++ b/flashlight/fl/optim/CMakeLists.txt
@@ -18,6 +18,6 @@ set(
 
 target_sources(
   flashlight
-  PUBLIC
-  $<BUILD_INTERFACE:${OPTIM_SOURCES}>
+  PRIVATE
+  ${OPTIM_SOURCES}
   )


### PR DESCRIPTION
Summary:
**tl;dr** - building with 8 threads is 4x faster and only 1.7x slower than building with 40/80 threads.

Don't use generator expressions because they get expanded per-target which is slow and means that source files can't be re-used in object form across targets with the same dependencies.

Make everything private instead. This used to be a problem when we used interface libraries because those libraries weren't in the export sets of installed targets which meant paths prefixed with the source directories couldn't be exported. This doesn't apply anymore given that we have single libs.

Differential Revision: D25008791

