### PR TITLE
Move flashlight to C++14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(CMakeDependentOption)
 # ----------------------------- Setup -----------------------------
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Default directories for installation
@@ -101,7 +101,7 @@ if (FL_BUILD_CORE)
     flashlight
     PROPERTIES
     LINKER_LANGUAGE CXX
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     )
 
   # Link libraries to flashlight core

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -192,7 +192,7 @@ We can link flashlight with the following CMake configuration:
   # CMake 3.5.1+ is required
   cmake_minimum_required(VERSION 3.5.1)
   # C++ 11 is required
-  set(CMAKE_CXX_STANDARD 11)
+  set(CMAKE_CXX_STANDARD 14)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
   find_package(flashlight REQUIRED)

--- a/flashlight/app/asr/data/Dataset.cpp
+++ b/flashlight/app/asr/data/Dataset.cpp
@@ -28,7 +28,7 @@ Dataset::Dataset(
       batchSize_(batchsize),
       worldRank_(worldrank),
       worldSize_(worldsize),
-      threadpool_(fl::cpp::make_unique<fl::ThreadPool>(FLAGS_nthread)) {
+      threadpool_(std::make_unique<fl::ThreadPool>(FLAGS_nthread)) {
   if (batchSize_ < 1 || worldRank_ < 0 || worldSize_ < 1 ||
       worldRank_ >= worldSize_) {
     FL_LOG(fl::FATAL) << "Invalid arguments!";

--- a/flashlight/app/asr/experimental/inference/CMakeLists.txt
+++ b/flashlight/app/asr/experimental/inference/CMakeLists.txt
@@ -28,7 +28,7 @@ set_property(
   PROPERTY STRINGS
   ${AVAILABLE_INFERENCE_BACKENDS}
 )
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_library(wav2letter-inference "")

--- a/flashlight/app/asr/experimental/inference/inference/examples/CMakeLists.txt
+++ b/flashlight/app/asr/experimental/inference/inference/examples/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5.1)
 project(StreamingInferenceExamples)
 add_library(StreamingInferenceExamples INTERFACE)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_library(util_example

--- a/flashlight/fl/autograd/Variable.cpp
+++ b/flashlight/fl/autograd/Variable.cpp
@@ -19,11 +19,11 @@
 #include <algorithm>
 #include <cassert>
 #include <functional>
+#include <memory>
 #include <stdexcept>
 #include <unordered_set>
 #include <utility>
 
-#include "flashlight/fl/common/CppBackports.h"
 #include "flashlight/fl/common/Utils.h"
 
 namespace fl {
@@ -185,7 +185,7 @@ void Variable::addGrad(const Variable& childGrad) {
       // Prevent increment of array refcount to avoid a copy
       // if getting a device pointer. See
       // https://git.io/fp9oM for more
-      sharedGrad_->grad = cpp::make_unique<Variable>(
+      sharedGrad_->grad = std::make_unique<Variable>(
           sharedGrad_->grad->array() + childGrad.array(), false);
       // Eval the JIT as a temporary workaround for
       // https://github.com/arrayfire/arrayfire/issues/2281
@@ -194,7 +194,7 @@ void Variable::addGrad(const Variable& childGrad) {
       // Copy the childGrad Variable so as to share a reference
       // to the underlying childGrad.array() rather than copying
       // the array into a new variable
-      sharedGrad_->grad = cpp::make_unique<Variable>(childGrad);
+      sharedGrad_->grad = std::make_unique<Variable>(childGrad);
     }
   }
 }

--- a/flashlight/fl/common/CppBackports.h
+++ b/flashlight/fl/common/CppBackports.h
@@ -8,13 +8,12 @@
 /**
  * @file common/CppBackports.h
  *
- * Backports of simple post-C++11 features.
+ * Backports of simple post-C++14 features.
  */
 
 #include <cstddef>
 #include <functional>
 #include <memory>
-#include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -23,87 +22,6 @@
 
 namespace fl {
 namespace cpp {
-
-// ========== type_traits convenience ==========
-
-template <class T>
-using remove_const_t = typename std::remove_const<T>::type;
-template <class T>
-using remove_volatile_t = typename std::remove_volatile<T>::type;
-template <class T>
-using remove_cv_t = typename std::remove_cv<T>::type;
-template <class T>
-using add_const_t = typename std::add_const<T>::type;
-template <class T>
-using add_volatile_t = typename std::add_volatile<T>::type;
-template <class T>
-using add_cv_t = typename std::add_cv<T>::type;
-
-template <class T>
-using remove_reference_t = typename std::remove_reference<T>::type;
-template <class T>
-using add_lvalue_reference_t = typename std::add_lvalue_reference<T>::type;
-template <class T>
-using add_rvalue_reference_t = typename std::add_rvalue_reference<T>::type;
-
-template <class T>
-using make_signed_t = typename std::make_signed<T>::type;
-template <class T>
-using make_unsigned_t = typename std::make_unsigned<T>::type;
-
-template <class T>
-using remove_extent_t = typename std::remove_extent<T>::type;
-template <class T>
-using remove_all_extents_t = typename std::remove_all_extents<T>::type;
-
-template <class T>
-using remove_pointer_t = typename std::remove_pointer<T>::type;
-template <class T>
-using add_pointer_t = typename std::add_pointer<T>::type;
-
-template <class T>
-using decay_t = typename std::decay<T>::type;
-template <bool b, class T = void>
-using enable_if_t = typename std::enable_if<b, T>::type;
-template <bool b, class T, class F>
-using conditional_t = typename std::conditional<b, T, F>::type;
-template <class... T>
-using common_type_t = typename std::common_type<T...>::type;
-template <class T>
-using underlying_type_t = typename std::underlying_type<T>::type;
-template <class T>
-using result_of_t = typename std::result_of<T>::type;
-
-// ========== make_unique ==========
-
-template <class T>
-struct _unique_if {
-  using _single_object = std::unique_ptr<T>;
-};
-
-template <class T>
-struct _unique_if<T[]> {
-  using _unknown_bound = std::unique_ptr<T[]>;
-};
-
-template <class T, std::size_t N>
-struct _unique_if<T[N]> {
-  using _known_bound = void;
-};
-
-template <class T, class... Args>
-typename _unique_if<T>::_single_object make_unique(Args&&... args) {
-  return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
-}
-
-template <class T>
-typename _unique_if<T>::_unknown_bound make_unique(std::size_t n) {
-  using U = remove_extent_t<T>;
-  return std::unique_ptr<T>(new U[n]());
-}
-
-template <class T, class... Args>
-typename _unique_if<T>::_known_bound make_unique(Args&&...) = delete;
 
 // ========== enum hashing ==========
 

--- a/flashlight/fl/common/Serialization-inl.h
+++ b/flashlight/fl/common/Serialization-inl.h
@@ -11,9 +11,8 @@
  */
 
 #include <stdexcept>
+#include <type_traits>
 #include <utility>
-
-#include "flashlight/fl/common/CppBackports.h"
 
 #pragma once
 
@@ -39,7 +38,7 @@ struct Versioned {
 
 template <typename S, typename T>
 struct SerializeAs {
-  using T0 = cpp::decay_t<T>;
+  using T0 = std::decay_t<T>;
   T&& ref;
   std::function<S(const T0&)> saveConverter;
   std::function<T0(S)> loadConverter;
@@ -68,7 +67,7 @@ template <
     typename Archive,
     typename S,
     typename T,
-    cpp::enable_if_t<IsOutputArchive<Archive>::value, int> = 0>
+    std::enable_if_t<IsOutputArchive<Archive>::value, int> = 0>
 void applyArchive(Archive& ar, const uint32_t version, SerializeAs<S, T> arg) {
   if (arg.saveConverter) {
     applyArchive(ar, version, arg.saveConverter(arg.ref));
@@ -82,9 +81,9 @@ template <
     typename Archive,
     typename S,
     typename T,
-    cpp::enable_if_t<IsInputArchive<Archive>::value, int> = 0>
+    std::enable_if_t<IsInputArchive<Archive>::value, int> = 0>
 void applyArchive(Archive& ar, const uint32_t version, SerializeAs<S, T> arg) {
-  using T0 = cpp::remove_reference_t<T>;
+  using T0 = std::remove_reference_t<T>;
   S s;
   applyArchive(ar, version, s);
   if (arg.loadConverter) {

--- a/flashlight/fl/dataset/PrefetchDataset.cpp
+++ b/flashlight/fl/dataset/PrefetchDataset.cpp
@@ -5,9 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <memory>
 #include <stdexcept>
 
-#include "flashlight/fl/common/CppBackports.h"
 #include "flashlight/fl/common/Serialization.h"
 #include "flashlight/fl/dataset/PrefetchDataset.h"
 
@@ -30,7 +30,7 @@ PrefetchDataset::PrefetchDataset(
   }
   if (numThreads_ > 0) {
     auto deviceId = af::getDevice();
-    threadPool_ = cpp::make_unique<ThreadPool>(
+    threadPool_ = std::make_unique<ThreadPool>(
         numThreads_,
         [deviceId](int /* threadId */) { af::setDevice(deviceId); });
   }

--- a/flashlight/fl/distributed/backend/cpu/DistributedBackend.cpp
+++ b/flashlight/fl/distributed/backend/cpu/DistributedBackend.cpp
@@ -19,7 +19,6 @@
 #include <gloo/transport/tcp/device.h>
 #include <mpi.h>
 
-#include "flashlight/fl/common/CppBackports.h"
 #include "flashlight/fl/common/DevicePtr.h"
 #include "flashlight/fl/distributed/LRUCache.h"
 
@@ -57,7 +56,7 @@ inline void allreduceGloo(T* ptr, size_t s) {
     using Allreduce = gloo::AllreduceHalvingDoubling<T>;
     algorithm = glooCache_.put(
         key,
-        cpp::make_unique<Allreduce>(
+        std::make_unique<Allreduce>(
             globalContext(),
             std::vector<T*>({ptr}),
             s,

--- a/flashlight/fl/examples/CMakeLists.txt
+++ b/flashlight/fl/examples/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5.1)
 project(flashlight-examples)
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # If building in source, we already have these targets.

--- a/flashlight/fl/examples/Xor.cpp
+++ b/flashlight/fl/examples/Xor.cpp
@@ -13,7 +13,6 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
-#include "flashlight/fl/common/CppBackports.h"
 #include "flashlight/fl/nn/nn.h"
 #include "flashlight/fl/optim/optim.h"
 
@@ -60,11 +59,11 @@ int main(int argc, const char** argv) {
   std::unique_ptr<FirstOrderOptimizer> optim;
 
   if (optimizer_arg == "--rmsprop") {
-    optim = cpp::make_unique<RMSPropOptimizer>(model.params(), lr);
+    optim = std::make_unique<RMSPropOptimizer>(model.params(), lr);
   } else if (optimizer_arg == "--adam") {
-    optim = cpp::make_unique<AdamOptimizer>(model.params(), lr);
+    optim = std::make_unique<AdamOptimizer>(model.params(), lr);
   } else {
-    optim = cpp::make_unique<SGDOptimizer>(model.params(), lr, mu);
+    optim = std::make_unique<SGDOptimizer>(model.params(), lr, mu);
   }
 
   Variable result, l;

--- a/flashlight/fl/experimental/memory/allocator/ConfigurableMemoryAllocator.cpp
+++ b/flashlight/fl/experimental/memory/allocator/ConfigurableMemoryAllocator.cpp
@@ -73,7 +73,7 @@ std::unique_ptr<MemoryAllocator> CreateMemoryAllocator(
       });
 
   auto compositeAllocator =
-      fl::cpp::make_unique<CompositeMemoryAllocator>(config.name_);
+      std::make_unique<CompositeMemoryAllocator>(config.name_);
 
   size_t avaialableBytes = arenaSizeInBytes;
   for (size_t i : subArenaReverseRelativeSizeSorting) {
@@ -106,7 +106,7 @@ std::unique_ptr<MemoryAllocator> CreateMemoryAllocator(
 
     std::unique_ptr<MemoryAllocator> subAllocator;
     if (subArenaConfig.blockSize_ < subArenaConfig.maxAllocationSize_) {
-      subAllocator = fl::cpp::make_unique<FreeList>(
+      subAllocator = std::make_unique<FreeList>(
           subArenaConfig.name_,
           subArenaAddress,
           subAreanClumpedSize,
@@ -114,7 +114,7 @@ std::unique_ptr<MemoryAllocator> CreateMemoryAllocator(
           subArenaConfig.allocatedRatioJitThreshold_,
           logLevel);
     } else {
-      subAllocator = fl::cpp::make_unique<MemoryPool>(
+      subAllocator = std::make_unique<MemoryPool>(
           subArenaConfig.name_,
           subArenaAddress,
           subAreanClumpedSize,

--- a/flashlight/fl/experimental/memory/optimizer/Optimizer.cpp
+++ b/flashlight/fl/experimental/memory/optimizer/Optimizer.cpp
@@ -551,7 +551,7 @@ orderMemoryAllocatorConfigByLoss(
         return;
       }
       haystackOrder->stats =
-          fl::cpp::make_unique<MemoryAllocator::Stats>(allocator->getStats());
+          std::make_unique<MemoryAllocator::Stats>(allocator->getStats());
       haystackOrder->loss = memoryAllocatorStatsLossFunction(
           true, *haystackOrder->stats, 0, 0, optimizerConfig);
       haystackOrder->completedWithSuccess = true;

--- a/flashlight/fl/experimental/tests/CompositeMemoryAllocatorTest.cpp
+++ b/flashlight/fl/experimental/tests/CompositeMemoryAllocatorTest.cpp
@@ -43,21 +43,21 @@ TEST(FreeList, MaxAllocationSizeRepeatedly) {
   const size_t maxAllocationSize3 = 100 * blockSize;
   const size_t numAllocations = nIterations * allocCntPerIteration;
 
-  auto freelist1 = fl::cpp::make_unique<FreeList>(
+  auto freelist1 = std::make_unique<FreeList>(
       "small-freelist",
       address1,
       numAllocations * maxAllocationSize1,
       blockSize,
       kAllocatedRatioJitThreshold,
       kLogLevel);
-  auto freelist2 = fl::cpp::make_unique<FreeList>(
+  auto freelist2 = std::make_unique<FreeList>(
       "medium-freelist",
       address2,
       numAllocations * maxAllocationSize2,
       blockSize,
       kAllocatedRatioJitThreshold,
       kLogLevel);
-  auto freelist3 = fl::cpp::make_unique<FreeList>(
+  auto freelist3 = std::make_unique<FreeList>(
       "large-freelist",
       address3,
       numAllocations * maxAllocationSize3,
@@ -125,21 +125,21 @@ TEST(FreeList, ExponentialDistribution) {
       nIterations * allocCntPerIteration * (1.0 - perIterationFreeRatio);
   const int multiplier = maxAllocationSize2; // yields values that fall within
   // all three allocators.
-  auto freelist1 = fl::cpp::make_unique<FreeList>(
+  auto freelist1 = std::make_unique<FreeList>(
       "small-freelist",
       address1,
       numAllocations * maxAllocationSize1,
       blockSize,
       kAllocatedRatioJitThreshold,
       kLogLevel);
-  auto freelist2 = fl::cpp::make_unique<FreeList>(
+  auto freelist2 = std::make_unique<FreeList>(
       "medium-freelist",
       address2,
       numAllocations * maxAllocationSize2,
       blockSize,
       kAllocatedRatioJitThreshold,
       kLogLevel);
-  auto freelist3 = fl::cpp::make_unique<FreeList>(
+  auto freelist3 = std::make_unique<FreeList>(
       "large-freelist",
       address3,
       numAllocations * maxAllocationSize2 *
@@ -241,21 +241,21 @@ TEST(FreeList, InternalFragmentation) {
   const size_t alloc3Size =
       maxAllocationSize2 + blockSize * partOfBlockToAllocate;
 
-  auto freelist1 = fl::cpp::make_unique<FreeList>(
+  auto freelist1 = std::make_unique<FreeList>(
       "small-freelist",
       address1,
       maxAllocationSize1,
       blockSize,
       kAllocatedRatioJitThreshold,
       kLogLevel);
-  auto freelist2 = fl::cpp::make_unique<FreeList>(
+  auto freelist2 = std::make_unique<FreeList>(
       "medium-freelist",
       address2,
       maxAllocationSize2,
       blockSize,
       kAllocatedRatioJitThreshold,
       kLogLevel);
-  auto freelist3 = fl::cpp::make_unique<FreeList>(
+  auto freelist3 = std::make_unique<FreeList>(
       "large-freelist",
       address3,
       maxAllocationSize2 * 2, // This size seems to be just enough.
@@ -326,21 +326,21 @@ TEST(FreeList, ExternalFragmentation) {
   const size_t maxAllocationSize2 = 10 * blockSize;
   const size_t maxAllocationSize3 = SIZE_MAX; // Catch all size
 
-  auto freelist1 = fl::cpp::make_unique<FreeList>(
+  auto freelist1 = std::make_unique<FreeList>(
       "small-freelist",
       address1,
       maxAllocationSize1 * numberBlocksPerAllocator,
       blockSize,
       kAllocatedRatioJitThreshold,
       kLogLevel);
-  auto freelist2 = fl::cpp::make_unique<FreeList>(
+  auto freelist2 = std::make_unique<FreeList>(
       "medium-freelist",
       address2,
       maxAllocationSize2 * numberBlocksPerAllocator,
       blockSize,
       kAllocatedRatioJitThreshold,
       kLogLevel);
-  auto freelist3 = fl::cpp::make_unique<FreeList>(
+  auto freelist3 = std::make_unique<FreeList>(
       "large-freelist",
       address3,
       maxAllocationSize2 * numberBlocksPerAllocator *

--- a/flashlight/fl/test/common/SerializationTest.cpp
+++ b/flashlight/fl/test/common/SerializationTest.cpp
@@ -211,7 +211,7 @@ struct WeirdTransform {
 
   template <class Archive>
   void load(Archive& ar) {
-    fl::cpp::decay_t<T> y;
+    std::decay_t<T> y;
     ar(y);
     x = y + 3;
   }

--- a/flashlight/fl/test/memory/CachingMemoryManagerTest.cpp
+++ b/flashlight/fl/test/memory/CachingMemoryManagerTest.cpp
@@ -14,7 +14,6 @@
 #include <arrayfire.h>
 #include <gtest/gtest.h>
 
-#include "flashlight/fl/common/CppBackports.h"
 #include "flashlight/fl/memory/memory.h"
 
 class CachingMemoryManagerTest : public ::testing::Test {
@@ -23,7 +22,7 @@ class CachingMemoryManagerTest : public ::testing::Test {
     deviceInterface_ = std::make_shared<fl::MemoryManagerDeviceInterface>();
     adapter_ = std::make_shared<fl::CachingMemoryManager>(
         af::getDeviceCount(), deviceInterface_);
-    installer_ = fl::cpp::make_unique<fl::MemoryManagerInstaller>(adapter_);
+    installer_ = std::make_unique<fl::MemoryManagerInstaller>(adapter_);
     installer_->setAsMemoryManager();
   }
 

--- a/flashlight/fl/test/memory/MemoryFrameworkTest.cpp
+++ b/flashlight/fl/test/memory/MemoryFrameworkTest.cpp
@@ -16,7 +16,6 @@
 #include <arrayfire.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include "flashlight/fl/common/CppBackports.h"
 #include "flashlight/fl/memory/memory.h"
 
 using namespace fl;
@@ -281,7 +280,7 @@ TEST(MemoryFramework, AdapterInstallerDeviceInterfaceTest) {
         memoryManager, deviceInterface, &mockLogStream);
 
     auto installer =
-        cpp::make_unique<MemoryManagerInstaller>(mockMemoryManager);
+        std::make_unique<MemoryManagerInstaller>(mockMemoryManager);
     // initialize should only be called once while the custom memory
     // manager was set
     EXPECT_CALL(*mockMemoryManager, initialize()).Times(Exactly(1));


### PR DESCRIPTION
Summary:
Upgrade to C++ 14.

We've been talking about this for some time; I think it's time to make the transition.

To be honest, moving to C++17 may not be a bad step in the near future, but making incremental changes will make this transition easier.

For now, this change only removes backports for `make_unique` and various `type_traits`, and leaves other things as they are for now.

### General Thoughts
- Staying >= 4 years behind the standard (2020 - 2014), to me, is extremely reasonable
- ArrayFire already requires C++14 to build from source
- gcc >= 5 has solid support for C++14 already, and that's our compiler recommendation as is since we use some "advanced" C++11 features.
- PyTorch has a C++14 minimum for its C++ API to build from source, so this is consistent with other competing frameworks frameworks

### What's new in C++14?
A light summary here — there are a wealth of new features that make life better:
- `std::make_unique<T>` (enough said)
- Removal of a bunch of awful type trait backports
  - `std::remove_const_t` and friends
  - `decay_t`!
- `auto` as a return type for functions
- `auto` lambda params!
```
auto fun = [](auto v) { return v + 1; };
```
- Move capture rather than reference in a persistent pointer!
```
auto _myFoo = std::make_unique<Foo>();
auto fun = [myFoo = std::move(_myFoo)]() { ... }
```
- Compile time literals for a bunch of stuff (datetime, string)
```
using namespace std::chrono_literals;
auto week = 168h;
```

Differential Revision: D25037733

