### PR TITLE
fix bug introduced for target generator config

### DIFF
--- a/flashlight/app/asr/data/FeatureTransforms.h
+++ b/flashlight/app/asr/data/FeatureTransforms.h
@@ -31,7 +31,8 @@ struct TargetGenerationConfig {
       bool skipUnk,
       bool fallbackToLetterWordSepLeft,
       bool fallbackToLetterWordSepRight)
-      : targetSamplePct_(targetSamplePct),
+      : wordSeparator_(wordSeparator),
+	targetSamplePct_(targetSamplePct),
         criterion_(criterion),
         surround_(surround),
         eosToken_(eosToken),


### PR DESCRIPTION
### Summary
return back wordseparator init list in the TargetGenerationConfig

### Test Plan (required)
Model training now looks fine with 10 words in the lexicon, so OOVs are processed correctly with adding the word separator between
