### PR TITLE
Fix stb image search, link gflags, conditionally build imagenet34 example

### DIFF
--- a/cmake/BuildStb.cmake
+++ b/cmake/BuildStb.cmake
@@ -18,9 +18,9 @@ ExternalProject_Add(
 )
 
 ExternalProject_Get_Property(stb SOURCE_DIR)
-set(STB_SOURCE_DIR ${SOURCE_DIR})
+set(stb_SOURCE_DIR ${SOURCE_DIR})
 
 set(stb_INCLUDE_DIRS
   $<BUILD_INTERFACE:${SOURCE_DIR}/>
-  $<INSTALL_INTERFACE:${STB_INSTALL_PATH}>
+  $<INSTALL_INTERFACE:${stb_INSTALL_PATH}>
   )

--- a/cmake/FindGFLAGS.cmake
+++ b/cmake/FindGFLAGS.cmake
@@ -18,7 +18,7 @@ find_path(GFLAGS_INCLUDE_DIR gflags/gflags.h
 
 find_library(GFLAGS_LIBRARY NAMES gflags gflags_debug)
 
-find_package_handle_standard_args(GFlags DEFAULT_MSG GFLAGS_INCLUDE_DIR GFLAGS_LIBRARY)
+find_package_handle_standard_args(GFLAGS DEFAULT_MSG GFLAGS_INCLUDE_DIR GFLAGS_LIBRARY)
 
 if(GFLAGS_FOUND)
   set(GFLAGS_INCLUDE_DIRS ${GFLAGS_INCLUDE_DIR})

--- a/cmake/Findstb.cmake
+++ b/cmake/Findstb.cmake
@@ -1,0 +1,14 @@
+#
+# Find stb headers
+#
+# Sets:
+#  stb_INCLUDE_DIRS - location of headers
+#  stb_FOUND        - truthy if stb was found.
+#
+
+find_path(stb_INCLUDE_DIRS stb_image.h PATH_SUFFIXES include PATHS ${stb_BASE_DIR})
+
+mark_as_advanced(stb_INCLUDE_DIRS)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(stb DEFAULT_MSG stb_INCLUDE_DIRS)

--- a/cmake/InternalUtils.cmake
+++ b/cmake/InternalUtils.cmake
@@ -51,6 +51,7 @@ function(setup_install_headers HEADER_DIR DEST_DIR)
     DESTINATION ${DEST_DIR}
     FILES_MATCHING # preserve directory structure
     PATTERN  "*.h"
+    PATTERN  "*.hpp"
     PATTERN "*.cuh" # TODO: make this conditional, e.g. $<IF:FLASHLIGHT_USE_CUDA,"*.cuh","a^">
     PATTERN "test*" EXCLUDE
     PATTERN "tests" EXCLUDE
@@ -58,6 +59,7 @@ function(setup_install_headers HEADER_DIR DEST_DIR)
     PATTERN "examples" EXCLUDE
     PATTERN "third_party" EXCLUDE
     PATTERN "experimental" EXCLUDE
+    PATTERN ".git" EXCLUDE
     )
 endfunction(setup_install_headers)
 

--- a/flashlight/app/imclass/CMakeLists.txt
+++ b/flashlight/app/imclass/CMakeLists.txt
@@ -5,11 +5,18 @@ add_library(
   ""
   )
 
+# Find GFlags
+find_package(GFLAGS REQUIRED)
+if (GFLAGS_FOUND)
+  message(STATUS "GFLAGS found")
+else()
+  message(FATAL_ERROR "GFLAGS not found")
+endif()
+
 target_link_libraries(
   flashlight-app-imclass
   PUBLIC
   ${GFLAGS_LIBRARIES}
-  ${GLOG_LIBRARIES}
   flashlight
   )
 
@@ -17,12 +24,15 @@ target_include_directories(
   flashlight-app-imclass
   PUBLIC
   ${GFLAGS_INCLUDE_DIRS}
-  ${GLOG_INCLUDE_DIRS}
   )
 
 include(${CMAKE_CURRENT_LIST_DIR}/dataset/CMakeLists.txt)
 
-
-add_executable(imageNetResnet34
-${CMAKE_CURRENT_LIST_DIR}/examples/ImageNetResnet34.cpp)
-target_link_libraries(imageNetResnet34 flashlight-app-imclass)
+if (FL_BUILD_EXAMPLES)
+  add_executable(imageNetResnet34
+    ${CMAKE_CURRENT_LIST_DIR}/examples/ImageNetResnet34.cpp)
+  target_link_libraries(
+    imageNetResnet34
+    flashlight-app-imclass
+    )
+endif()

--- a/flashlight/ext/image/af/CMakeLists.txt
+++ b/flashlight/ext/image/af/CMakeLists.txt
@@ -1,30 +1,19 @@
 cmake_minimum_required(VERSION 3.10)
 
-set(STB_INSTALL_PATH ${FL_INSTALL_INC_DIR}/stb)
-find_path(STB_IMAGE_PATH "stb_image.h")
-if(${STB_IMAGE_PATH})
-  message(STATUS "stb_image.h found: (include: ${STB_IMAGE_PATH})")
-  get_filename_component(STB_SOURCE_DIR ${STB_IMAGE_PATH} DIRECTORY)
-  set(stb_INCLUDE_DIRS
-    $<BUILD_INTERFACE:${STB_SOURCE_DIR}/>
-    $<INSTALL_INTERFACE:${STB_INSTALL_PATH}>
-    )
-else()
+# stb_image
+set(stb_INSTALL_PATH ${FL_INSTALL_INC_DIR}/stb)
+find_package(stb)
+if(NOT stb_FOUND)
   message(STATUS "Could not find stb_image.h. Will download stb from github")
   include(${CMAKE_MODULE_PATH}/BuildStb.cmake)
   add_dependencies(flashlight stb)
+
+  # Move stb headers at install time only if they weren't already found
+  setup_install_headers(${stb_SOURCE_DIR} ${stb_INSTALL_PATH})
+  setup_install_find_module(${CMAKE_MODULE_PATH}/Findstb.cmake)
+else()
+  message(STATUS "stb_image.h found: (include: ${stb_INCLUDE_DIRS})")
 endif()
-
-# Move stb headers at install time
-install(DIRECTORY ${STB_SOURCE_DIR}
-   DESTINATION ${STB_INSTALL_PATH}
-   COMPONENT stb
-   FILES_MATCHING
-   PATTERN "*.hpp"
-   PATTERN "*.h"
-   PATTERN ".git" EXCLUDE
-)
-
 target_include_directories(flashlight PRIVATE ${stb_INCLUDE_DIRS})
 
 target_sources(


### PR DESCRIPTION
Summary:
For whatever reason, the `find_path` call to find the `stb_image.h` header is never truthy - even when the path is found by CMake with a `vcpkg` build. I have no idea why, but using `find_package_handle_standard_args` in a separate module and `stb_FOUND` fixes the problem.

Also makes sure that the gflags library and include dir variables are defined if building `imgclass` only.

Also gates building the resnet34 example with `FL_BUILD_EXAMPLES` (open to removing this)

Differential Revision: D25091576

