### PR TITLE
fix dataset bug in case of empty target transcription in the list file

### DIFF
--- a/flashlight/app/asr/data/FeatureTransforms.cpp
+++ b/flashlight/app/asr/data/FeatureTransforms.cpp
@@ -119,6 +119,10 @@ fl::Dataset::DataTransformFunction targetFeatures(
     if (config.eosToken_) {
       tgtVec.emplace_back(tokenDict.getIndex(kEosToken));
     }
+    if (tgtVec.size() == 0) {
+      // support empty target
+      return af::array().as(s32);
+    }
     return af::array(tgtVec.size(), tgtVec.data());
   };
 }
@@ -129,6 +133,10 @@ fl::Dataset::DataTransformFunction wordFeatures(const Dictionary& wrdDict) {
         static_cast<char*>(data), static_cast<char*>(data) + dims.elements());
     auto words = splitOnWhitespace(transcript, true);
     auto wrdVec = wrdDict.mapEntriesToIndices(words);
+    if (wrdVec.size() == 0) {
+      // support empty target
+      return af::array().as(s32);
+    }
     return af::array(wrdVec.size(), wrdVec.data());
   };
 }

--- a/flashlight/app/asr/data/ListFileDataset.cpp
+++ b/flashlight/app/asr/data/ListFileDataset.cpp
@@ -45,7 +45,10 @@ ListFileDataset::ListFileDataset(
     }
     auto splits = splitOnWhitespace(line, true);
     if (splits.size() < 3) {
-      throw std::runtime_error("Invalid columns in line: " + line);
+      throw std::runtime_error(
+          "File " + filename +
+          " has invalid columns in line (expected 3 columns at least): " +
+          line);
     }
 
     ids_.emplace_back(std::move(splits[kIdIdx]));

--- a/flashlight/fl/nn/Utils.cpp
+++ b/flashlight/fl/nn/Utils.cpp
@@ -104,7 +104,8 @@ af::array join(
   if (inputs.empty()) {
     return af::array();
   }
-  af::dim4 maxDims;
+  // if empty arrays are provided then we just return padded matrix for them
+  af::dim4 maxDims = af::dim4(1, 1, 1, 1);
   af::dtype type = inputs[0].type();
   for (const auto& in : inputs) {
     for (int d = 0; d < AF_MAX_DIMS; ++d) {
@@ -129,7 +130,9 @@ af::array join(
       sel[d] = af::seq(inputs[i].dims(d));
     }
     sel[batchDim] = af::seq(i, i);
-    padSeq(sel[0], sel[1], sel[2], sel[3]) = inputs[i];
+    if (!inputs[i].isempty()) {
+      padSeq(sel[0], sel[1], sel[2], sel[3]) = inputs[i];
+    }
   }
   return padSeq;
 }


### PR DESCRIPTION
Summary:
i) fix creation of target if it is empty (no af exception on empty data)
ii) fix join operation (for batching) when the whole batch has empty transcription - in this case just create the whole pad matrix

We need to have this solution because depending on the mapping with lexicon some targets can become empty and filtering this out is not comfortable with list filtering. Either we add in future their filtering or have solution with putting pad token for such samples and processing pad token by loss in a right way.

Differential Revision: D25157814

