### PR TITLE
Fix some CMake issues

### DIFF
--- a/cmake/flashlightConfig.cmake.in
+++ b/cmake/flashlightConfig.cmake.in
@@ -49,9 +49,14 @@ if(NOT TARGET flashlight::fl-libraries)
   endif()
 endif()
 
+# Flashlight backend
+set(FL_USE_CPU @FL_USE_CPU@)
+set(FL_USE_CUDA @FL_USE_CUDA@)
+set(FL_USE_OPENCL @FL_USE_OPENCL@)
+
 # For legacy configurations
 # Libraries
-set(flashlight_LIBRARIES flashlight::fl-libraries flashlight::fl-libraries-cuda)
+set(flashlight_LIBRARIES flashlight::fl-libraries)
 if (@FL_BUILD_CORE@)
   set(flashlight_LIBRARIES ${flashlight_LIBRARIES} flashlight::flashlight)
 endif()
@@ -59,7 +64,7 @@ if (@FL_BUILD_APP_ASR@)
   set(flashlight_LIBRARIES ${flashlight_LIBRARIES} flashlight::flashlight-app-asr)
 endif()
 if (@FL_BUILD_APP_IMG_CLASS@)
-  set(flashlight_LIBRARIES ${flashlight_LIBRARIES} flashlight::flashlight-app-imclass)
+  set(flashlight_LIBRARIES ${flashlight_LIBRARIES} flashlight::flashlight-app-imgclass)
 endif()
 # Include dirs
 if (EXISTS @PACKAGE_INCLUDE_DIRS@)

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -195,8 +195,11 @@ We can link flashlight with the following CMake configuration:
   set(CMAKE_CXX_STANDARD 14)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-  find_package(flashlight REQUIRED)
-  find_package(ArrayFire REQUIRED)
+  find_package(flashlight CONFIG REQUIRED)
+
+  if (FL_USE_CUDA)
+    enable_language(CUDA)
+  endif()
   # ...
 
   add_executable(myProject project.cpp)


### PR DESCRIPTION
Summary:
- Make sure the name of the exported target is `imgclass`, not `imclass`
- Export some variables denoting flashlight backend
- Enable CUDA in example (and wav2letter) builds if fl is built with CUDA
- Bump minimum CMake version in wav2letter
- Bump w2l to C++14

Differential Revision: D25163993

