### PR TITLE
Fix cuda compilation failures with cmake 3.12+

### DIFF
--- a/flashlight/app/asr/criterion/CMakeLists.txt
+++ b/flashlight/app/asr/criterion/CMakeLists.txt
@@ -15,6 +15,8 @@ if (FL_USE_CUDA)
     flashlight-app-asr
     PRIVATE
     ${warpctc_SOURCES})
+  # Required with cmake 3.12+:
+  target_compile_options(flashlight-app-asr PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--std=c++14>)
   # cuRAND is required and linked below
   set(WARPCTC_INCLUDE_DIR ${WARPCTC_DIR}/include)
   target_include_directories(flashlight-app-asr PRIVATE ${WARPCTC_INCLUDE_DIR})

--- a/flashlight/lib/CMakeLists.txt
+++ b/flashlight/lib/CMakeLists.txt
@@ -56,6 +56,8 @@ if (FL_LIBRARIES_USE_CUDA)
   include(${CMAKE_MODULE_PATH}/CUDAUtils.cmake)
 
   set_cuda_cxx_compile_flags()
+  # Required when using cmake 3.12+ not using anymore CUDA_NVCC_FLAGS:
+  target_compile_options(fl-libraries PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--std=c++14>)
   set_cuda_arch_nvcc_flags()
 
   # hacky: add -fPIC to nvcc flags if needed


### PR DESCRIPTION
Cuda sources (CriterionUtils.cu,...) compilation failure
Recent cmake needs
target_compile_options(flashlight-app-asr
PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--std=c++14>)
closes #270

**Original Issue**: 
https://github.com/facebookresearch/flashlight/issues/270

### Summary
Cuda sources (CriterionUtils.cu,...) compilation failure

### Test Plan (required)
cmake & make & make test
