### PR TITLE
Fix non MKL build linking with OpenMP

### DIFF
--- a/flashlight/lib/audio/feature/CMakeLists.txt
+++ b/flashlight/lib/audio/feature/CMakeLists.txt
@@ -48,10 +48,17 @@ target_sources(
   ${CMAKE_CURRENT_LIST_DIR}/Windowing.cpp
   )
 
+if (NOT FL_LIBRARIES_USE_MKL)
+  # openmp required by PowerSpectrum: provided by iomp if MKL ON
+  # Not using the target OpenMP::OpenMP_CXX: it does add fopenmp to nvcc which does not understand it
+  set(OMPLIB ${OpenMP_CXX_LIBRARIES})
+endif()
+
 target_link_libraries(
   fl-libraries
   PRIVATE
   ${CBLAS_LIBRARIES}
+  ${OMPLIB}
   FFTW3::fftw3
   )
 


### PR DESCRIPTION
Fix non MKL build linking with OpenMP

**Original Issue**: 
closes #283
https://github.com/facebookresearch/flashlight/issues/283

### Summary
Linking failure when MKL OFF

### Test Plan (required)
cmake -DFL_LIBRARIES_USE_MKL=OFF
make
make test
