### PR TITLE
Fix cpp std flags as passed to nvcc

### DIFF
--- a/cmake/CUDAUtils.cmake
+++ b/cmake/CUDAUtils.cmake
@@ -15,16 +15,6 @@ endif()
 # This line must be placed after find_package(CUDA)
 include(${CMAKE_MODULE_PATH}/select_compute_arch.cmake)
 
-### Set compilation flags
-# NVCC doesn't properly listen to cxx version flags, so manually override.
-# This MUST be done after CUDA is found, but before any cuda libs/binaries have
-# been created.
-function (set_cuda_cxx_compile_flags)
-  set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};-std=c++14" PARENT_SCOPE)
-  # Using host flags makes things bad - keep things clean
-  set(CUDA_PROPAGATE_HOST_FLAGS OFF)
-endfunction()
-
 ### Detect GPU architectures
 # Detect architectures (see select_compute_arch.cmake) and
 # add appropriate flags to nvcc for gencode/arch/ptx

--- a/flashlight/lib/CMakeLists.txt
+++ b/flashlight/lib/CMakeLists.txt
@@ -53,9 +53,9 @@ set(FL_LIBRARY_CUDA_SOURCES
 # in. Only build a CUDA lib of libraries that require CUDA kernels are built
 if (FL_LIBRARIES_USE_CUDA)
   enable_language(CUDA)
+  set(CMAKE_CUDA_STANDARD 14)
+  set(CMAKE_CUDA_STANDARD_REQUIRED ON)
   include(${CMAKE_MODULE_PATH}/CUDAUtils.cmake)
-
-  set_cuda_cxx_compile_flags()
   set_cuda_arch_nvcc_flags()
 
   # hacky: add -fPIC to nvcc flags if needed


### PR DESCRIPTION
Summary:
Closes https://github.com/facebookresearch/flashlight/issues/270#issuecomment-736814684.

This is the correct way to pass `-std` flags to nvcc for a given CMake version - using `target_compile_definitions` with a generator expression based on compiler language starts breaking in later versions of CMake where things are already added.

Reviewed By: vineelpratap

Differential Revision: D25253960

