### PR TITLE
Unbreak build

### DIFF
--- a/flashlight/fl/contrib/modules/CMakeLists.txt
+++ b/flashlight/fl/contrib/modules/CMakeLists.txt
@@ -6,7 +6,7 @@ set(
   ${CMAKE_CURRENT_LIST_DIR}/AsymmetricConv1D.cpp
   ${CMAKE_CURRENT_LIST_DIR}/Conformer.cpp
   ${CMAKE_CURRENT_LIST_DIR}/PositionEmbedding.cpp
-  ${CMAKE_CURRENT_LIST_DIR}/RawWavSpecAugment.cpp"
+  ${CMAKE_CURRENT_LIST_DIR}/RawWavSpecAugment.cpp
   ${CMAKE_CURRENT_LIST_DIR}/Residual.cpp
   ${CMAKE_CURRENT_LIST_DIR}/SinusoidalPositionEmbedding.cpp
   ${CMAKE_CURRENT_LIST_DIR}/Transformer.cpp


### PR DESCRIPTION
Summary: Broken in D24765191 (https://github.com/facebookresearch/flashlight/commit/0cf72d04c18459f4e32802c64c32b72655671a58) with an extra `"` — https://github.com/facebookresearch/flashlight/blob/master/flashlight/fl/contrib/modules/CMakeLists.txt#L9. Please test your stuff :)

Reviewed By: xuqiantong

Differential Revision: D25260602

