### PR TITLE
Overhaul CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,8 @@ commands:
       - run:
           name: "Install and setup gcc 7"
           command: |
+            sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+            sudo apt update || true
             sudo apt install gcc-7 g++-7 -y --no-install-recommends
             sudo rm /usr/bin/gcc /usr/bin/g++
             sudo ln -s /usr/bin/gcc-7 /usr/bin/gcc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,11 +24,12 @@ commands:
   install_gcc_7:
     steps:
       - run:
-          name: "Install gcc 7"
+          name: "Install and setup gcc 7"
           command: |
-            sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-            sudo apt update
             sudo apt install gcc-7 g++-7 -y --no-install-recommends
+            sudo rm /usr/bin/gcc /usr/bin/g++
+            sudo ln -s /usr/bin/gcc-7 /usr/bin/gcc
+            sudo ln -s /usr/bin/g++-7 /usr/bin/g++
   build_vcpkg:
     steps:
       - run:
@@ -42,7 +43,7 @@ commands:
       - run:
           name: "Install vcpkg prerequisites"
           command: |
-            sudo apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --no-install-recommends gperf automake gcc-7 g++-7
+            DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --no-install-recommends gperf automake gcc-7 g++-7
       - run:
           name: "Install vcpkg dependencies"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,62 +1,49 @@
- # Copyright (c) Facebook, Inc. and its affiliates.
- # All rights reserved.
- #
- # This source code is licensed under the BSD-style license found in the
- # LICENSE file in the root directory of this source tree.
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
 
-version: 2.0
+version: 2.1
 
 gpu: &gpu
   machine:
-    image: ubuntu-1604:201903-01
+    image: ubuntu-1604-cuda-10.1:201909-23
   resource_class: gpu.small
 
-jobs:
-  build-cuda:
-    <<: *gpu
+commands:
+  authenticate_docker:
     steps:
-      - checkout
       - run:
-          name: Setup Docker and nvidia-docker
-          command: |
-            # Install CUDA 10.0
-            wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_10.0.130-1_amd64.deb
-            sudo dpkg -i cuda-repo-ubuntu1604_10.0.130-1_amd64.deb
-            sudo apt-get update || true
-            sudo apt-get --yes --force-yes install cuda
-            nvidia-smi
-            # Install Docker
-            sudo apt-get update
-            sudo apt-get install \
-            apt-transport-https \
-            ca-certificates \
-            curl \
-            software-properties-common
-            curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-            sudo apt-key fingerprint 0EBFCD88
-            sudo add-apt-repository \
-            "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-            $(lsb_release -cs) \
-            stable"
-            sudo apt-get update
-            sudo apt-get install docker-ce
-            # Install nvidia-docker
-            curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | \
-            sudo apt-key add -
-            distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
-            curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | \
-            sudo tee /etc/apt/sources.list.d/nvidia-docker.list
-            sudo apt-get update
-            # Install nvidia-docker2 and reload the Docker daemon configuration
-            sudo apt-get install -y nvidia-docker2
-            sudo pkill -SIGHUP dockerd
-      - run:
-          name: Build flashlight with CUDA backend inside nvidia-docker
+          name: "Authenticate Docker"
           command: |
             if [ ! -z "$DOCKER_USERNAME" ]
             then
                 sudo docker login -u=$DOCKER_USERNAME -p=$DOCKER_PASSWORD
             fi
+  install_cuda_linux:
+    parameters:
+      version:
+        default: "10.0"
+        type: string
+    steps:
+      - run:
+          name: Install CUDA 10.0
+          command: |
+            wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_10.0.130-1_amd64.deb
+            sudo dpkg -i cuda-repo-ubuntu1604_10.0.130-1_amd64.deb
+            sudo apt-get update || true
+            sudo apt-get --yes --force-yes install cuda
+            nvidia-smi
+jobs:
+  ubuntu_1604_gcc5_cuda_10_1_docker:
+    <<: *gpu
+    steps:
+      - checkout
+      - authenticate_docker
+      - run:
+          name: Build flashlight with CUDA backend inside nvidia-docker
+          command: |
             sudo docker run --runtime=nvidia --rm -itd --ipc=host --name flashlight flml/flashlight:cuda-base-consolidation-latest
             sudo docker exec -it flashlight bash -c "mkdir /flashlight"
             sudo docker cp . flashlight:/flashlight
@@ -89,5 +76,5 @@ workflows:
   version: 2
   build_and_install:
     jobs:
-      - build-cuda
+      - ubuntu_1604_gcc5_cuda_10_1_docker
       - build-cpu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,11 @@ commands:
             then
                 sudo docker login -u=$DOCKER_USERNAME -p=$DOCKER_PASSWORD
             fi
+  install_nvidia_docker:
+    steps:
+      - run:
+          name: "Install NVIDIA Docker"
+          command: sudo apt-get install -y --no-install-recommends nvidia-docker
   install_gcc_7:
     steps:
       - run:
@@ -45,19 +50,33 @@ commands:
       - run:
           name: "Install vcpkg prerequisites"
           command: |
-            DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --no-install-recommends gperf automake gcc-7 g++-7
+            DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --no-install-recommends gperf automake
   install_vcpkg_deps:
     steps:
       - run:
           name: "Install vcpkg dependencies"
           command: |
-            ./vcpkg/vcpkg install \
+            MKLROOT=/opt/intel/mkl ./vcpkg/vcpkg install \
                 cuda intel-mkl fftw3 cub kenlm            \
                 arrayfire[cuda] cudnn nccl openmpi cereal \
                 gflags                                    \
                 libsndfile                                \
                 stb                                       \
                 gtest
+  install_mkl_linux:
+    parameters:
+      mkl_version:
+        default: "intel-mkl-64bit-2020.0-088"
+        type: string
+    steps:
+      - run:
+          name: "Install MKL"
+          command: |
+            cd /tmp
+            wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB
+            sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB
+            sudo sh -c 'echo deb https://apt.repos.intel.com/mkl all main > /etc/apt/sources.list.d/intel-mkl.list'
+            apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt install << parameters.mkl_version >>
   install_cuda_linux:
     parameters:
       version:
@@ -78,7 +97,9 @@ jobs:
     steps:
       - install_vcpkg_prereqs
       - build_vcpkg
+      - install_mkl_linux
       - install_vcpkg_deps
+      - install_mkl_linux
       - checkout
       - run:
           name: "Install flashlight-cuda libraries with vcpkg"
@@ -122,11 +143,12 @@ jobs:
   #         command: |
   #           ./vcpkg install flashlight-cuda[imgclass]
 
-  ubuntu_1604_gcc5_cuda_10_1_docker:
+  ubuntu_1604_gcc5_cuda_10_1_docker_lib:
     <<: *gpu
     steps:
       - checkout
       - authenticate_docker
+      - install_nvidia_docker
       - run:
           name: Build flashlight with CUDA backend inside nvidia-docker
           command: |
@@ -158,12 +180,15 @@ jobs:
             mkdir -p build && cd build
             cmake .. -DFL_BACKEND=CPU -DFL_LIBRARIES_USE_CUDA=OFF
             make -j1 && make install
+
 workflows:
   version: 2
   vcpkg_test_source_build:
     jobs:
       - ubuntu_1604_gcc5_cuda_10_1_vcpkg_flashlight_lib
+  cuda_build_and_install:
+    jobs:
+      - ubuntu_1604_gcc5_cuda_10_1_docker_lib
   build_and_install:
     jobs:
-      - ubuntu_1604_gcc5_cuda_10_1_docker
       - build-cpu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,17 +57,16 @@ commands:
           name: "Build and Install Flashlight inside of NVIDIA Docker"
           command: |
             sudo docker exec -it flashlight bash -c "\
-                apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gcc-5 g++-5 && \
-                cd /flashlight && pwd && ls && mkdir -p build && cd build && \
-                export CC=/usr/bin/gcc-5 && export CXX=/usr/bin/g++-5 && \
-                export MKLROOT=/opt/intel/mkl && export KENLM_ROOT=/root/kenlm && \
-                cmake .. \
-                    -DFL_BACKEND=<< parameters.fl_backend >> \
-                    -DFL_BUILD_fl_CORE=<< parameters.fl_build_fl_core >> \
-                    -DFL_BUILD_APP_ASR=<< parameters.fl_build_app_asr >> \
-                    -DFL_BUILD_APP_IMG_CLASS=<< parameters.fl_build_app_img_class >> \
-                && \
-                make -j$(nproc) && make install"
+            apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gcc-5 g++-5 && \
+            cd /flashlight && pwd && ls && mkdir -p build && cd build && \
+            export CC=/usr/bin/gcc-5 && export CXX=/usr/bin/g++-5 && \
+            export MKLROOT=/opt/intel/mkl && export KENLM_ROOT=/root/kenlm && \
+            cmake .. \
+                -DFL_BACKEND=<< parameters.fl_backend >> \
+                -DFL_BUILD_fl_CORE=<< parameters.fl_build_fl_core >> \
+                -DFL_BUILD_APP_ASR=<< parameters.fl_build_app_asr >> \
+                -DFL_BUILD_APP_IMG_CLASS=<< parameters.fl_build_app_img_class >> && \
+            make -j$(nproc) && make install"
   test_flashlight_inside_nvidia_docker:
     parameters:
       fl_test_apex_dir:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,7 +152,7 @@ commands:
             wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB
             sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB
             sudo sh -c 'echo deb https://apt.repos.intel.com/mkl all main > /etc/apt/sources.list.d/intel-mkl.list'
-            apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt install << parameters.mkl_version >>
+            sudo apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt install << parameters.mkl_version >>
   ubuntu_install_cuda10_0:
     parameters:
       version:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,16 +41,12 @@ commands:
   build_flashlight_inside_nvidia_docker:
     parameters:
       fl_backend:
-        default: "CUDA"
         type: string
       fl_build_fl_core:
-        default: "OFF"
         type: string
       fl_build_app_asr:
-        default: "OFF"
         type: string
       fl_build_app_img_class:
-        default: "OFF"
         type: string
     steps:
       - run:
@@ -63,14 +59,13 @@ commands:
             export MKLROOT=/opt/intel/mkl && export KENLM_ROOT=/root/kenlm && \
             cmake .. \
                 -DFL_BACKEND=<< parameters.fl_backend >> \
-                -DFL_BUILD_fl_CORE=<< parameters.fl_build_fl_core >> \
+                -DFL_BUILD_CORE=<< parameters.fl_build_fl_core >> \
                 -DFL_BUILD_APP_ASR=<< parameters.fl_build_app_asr >> \
                 -DFL_BUILD_APP_IMG_CLASS=<< parameters.fl_build_app_img_class >> && \
             make -j$(nproc) && make install"
   test_flashlight_inside_nvidia_docker:
     parameters:
       fl_test_apex_dir:
-        default: "."
         type: string
     steps:
       - run:
@@ -105,19 +100,46 @@ commands:
           command: |
             DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --no-install-recommends gperf automake
   install_vcpkg_deps:
+    parameters:
+      vcpkg_deps:
+        type: string
     steps:
       - run:
           name: "Install vcpkg dependencies"
           command: |
-            MKLROOT=/opt/intel/mkl ./vcpkg/vcpkg install \
-                cuda intel-mkl fftw3 cub kenlm            \
-                arrayfire[cuda] cudnn nccl openmpi cereal \
-                gflags                                    \
-                libsndfile                                \
-                stb                                       \
-                gtest
+            MKLROOT=/opt/intel/mkl ./vcpkg/vcpkg install << parameters.vcpkg_deps >>
+  flashlight_source_build_with_vcpkg:
+    parameters:
+      fl_build_fl_core:
+        type: string
+      fl_build_app_asr:
+        type: string
+      fl_build_app_img_class:
+        type: string
+    steps:
+      - run:
+          name: "Build Flashlight CUDA from source with vcpkg dependencies"
+          command: |
+            cd $HOME/project && mkdir -p build && cd build
+            cmake .. \
+              -DFL_BACKEND=CUDA \
+              -DFL_BUILD_CORE=<< parameters.fl_build_fl_core >> \
+              -DFL_BUILD_APP_ASR=<< parameters.fl_build_app_asr >> \
+              -DFL_BUILD_APP_IMG_CLASS=<< parameters.fl_build_app_img_class >> && \
+              -DCMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake
+  flashlight_source_test_with_vcpkg:
+    parameters:
+      fl_test_apex_dir:
+        type: string
+    steps:
+      - run:
+          name: "Run Flashlight CUDA tests for in-source build with vcpkg dependencies"
+          command: |
+            cd $HOME/project/build/<< parameters.fl_test_apex_dir >>
+            ctest
+
   ############################ Dependency Commands ############################
-  install_mkl_linux:
+  ubuntu_install_mkl:
     parameters:
       mkl_version:
         default: "intel-mkl-64bit-2020.0-088"
@@ -131,10 +153,9 @@ commands:
             sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB
             sudo sh -c 'echo deb https://apt.repos.intel.com/mkl all main > /etc/apt/sources.list.d/intel-mkl.list'
             apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt install << parameters.mkl_version >>
-  install_cuda_linux:
+  ubuntu_install_cuda10_0:
     parameters:
       version:
-        default: "10.0"
         type: string
     steps:
       - run:
@@ -145,57 +166,27 @@ commands:
             sudo apt-get update || true
             sudo apt-get --yes --force-yes install cuda
             nvidia-smi
+
+############################ Jobs ############################
 jobs:
   ubuntu1604_gcc5_cuda_10_1_vcpkg_flashlight_lib:
     <<: *gpu
     steps:
+      - ubuntu_install_mkl
       - install_vcpkg_prereqs
       - build_vcpkg
-      - install_mkl_linux
-      - install_vcpkg_deps
-      - install_mkl_linux
+      - install_vcpkg_deps:
+          vcpkg_deps: "intel-mkl fftw3 cub kenlm"
       - checkout
-      - run:
-          name: "Install flashlight-cuda libraries with vcpkg"
-          command: |
-            cd $HOME/project && mkdir -p build && cd build && \
-            cmake .. \
-              -DFL_BACKEND=CUDA -DFL_BUILD_CORE=OFF -DFL_BUILD_APP_ASR=OFF -DFL_BUILD_APP_IMG_CLASS=OFF \
-              -DCMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake
-      - run:
-          name: "Run flashlight-cuda libraries tests"
-          command: |
-            cd $HOME/project/build/flashlight/lib/test && ctest
-  # ubuntu1604_gcc5_cuda_10_1_vcpkg_flashlight_fl_core:
-  #   <<: *gpu
-  #   steps:
-  #     - checkout
-  #     - build_vcpkg
-  #     - install_vcpkg_prereqs
-  #     - run:
-  #         name: "Install flashlight-cuda fl core with vcpkg"
-  #         command: |
-  #           ./vcpkg install flashlight-cuda[fl]
-  # ubuntu1604_gcc5_cuda_10_1_vcpkg_flashlight_app_asr:
-  #   <<: *gpu
-  #   steps:
-  #     - checkout
-  #     - build_vcpkg
-  #     - install_vcpkg_prereqs
-  #     - run:
-  #         name: "Install flashlight-cuda fl core with vcpkg"
-  #         command: |
-  #           ./vcpkg install flashlight-cuda[asr]
-  # ubuntu1604_gcc5_cuda_10_1_vcpkg_flashlight_app_imgclass:
-  #   <<: *gpu
-  #   steps:
-  #     - checkout
-  #     - build_vcpkg
-  #     - install_vcpkg_prereqs
-  #     - run:
-  #         name: "Install flashlight-cuda fl core with vcpkg"
-  #         command: |
-  #           ./vcpkg install flashlight-cuda[imgclass]
+      - flashlight_source_build_with_vcpkg:
+          fl_build_fl_core: "OFF"
+          fl_build_app_asr: "OFF"
+          fl_build_app_img_class: "OFF"
+      - flashlight_source_test_with_vcpkg:
+          fl_test_apex_dir: "flashlight/lib/test"
+  # TODO(jacobkahn): add jobs forversions for the fl core and apps
+  # once https://github.com/microsoft/vcpkg/issues/14864 is merged
+  # and forge can be built on Xenial
 
   ubuntu1804_gcc5_cuda10_0_docker_flashlight_lib:
     <<: *gpu
@@ -256,7 +247,7 @@ jobs:
           fl_build_app_img_class: "ON"
       # TODO (jacobkahn/padentomasello): add the below once we have tests inside imgclass
       # - test_flashlight_inside_nvidia_docker:
-      #     fl_test_apex_dir: "flashlight/app/asr/test"
+      #     fl_test_apex_dir: "flashlight/app/imgclass/test"
 
   build-cpu:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,6 @@ commands:
       - run:
           name: "Install gcc 7"
           command: |
-            sudo apt-get install -y --no-install-recommends software-properties-common
             sudo add-apt-repository ppa:ubuntu-toolchain-r/test
             sudo apt update
             sudo apt install gcc-7 g++-7 -y --no-install-recommends

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ commands:
       - run:
           name: "Install vcpkg prerequisites"
           command: |
-            DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gperf automake gcc-7 g++-7
+            sudo apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --no-install-recommends gperf automake gcc-7 g++-7
       - run:
           name: "Install vcpkg dependencies"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,13 +39,15 @@ commands:
           command: |
             git clone https://github.com/microsoft/vcpkg
             ./vcpkg/bootstrap-vcpkg.sh
-  install_vcpkg_deps:
+  install_vcpkg_prereqs:
     steps:
       - install_gcc_7
       - run:
           name: "Install vcpkg prerequisites"
           command: |
             DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --no-install-recommends gperf automake gcc-7 g++-7
+  install_vcpkg_deps:
+    steps:
       - run:
           name: "Install vcpkg dependencies"
           command: |
@@ -74,8 +76,9 @@ jobs:
   ubuntu_1604_gcc5_cuda_10_1_vcpkg_flashlight_lib:
     <<: *gpu
     steps:
-      - install_vcpkg_deps
+      - install_vcpkg_prereqs
       - build_vcpkg
+      - install_vcpkg_deps
       - checkout
       - run:
           name: "Install flashlight-cuda libraries with vcpkg"
@@ -93,7 +96,7 @@ jobs:
   #   steps:
   #     - checkout
   #     - build_vcpkg
-  #     - install_vcpkg_deps
+  #     - install_vcpkg_prereqs
   #     - run:
   #         name: "Install flashlight-cuda fl core with vcpkg"
   #         command: |
@@ -103,7 +106,7 @@ jobs:
   #   steps:
   #     - checkout
   #     - build_vcpkg
-  #     - install_vcpkg_deps
+  #     - install_vcpkg_prereqs
   #     - run:
   #         name: "Install flashlight-cuda fl core with vcpkg"
   #         command: |
@@ -113,7 +116,7 @@ jobs:
   #   steps:
   #     - checkout
   #     - build_vcpkg
-  #     - install_vcpkg_deps
+  #     - install_vcpkg_prereqs
   #     - run:
   #         name: "Install flashlight-cuda fl core with vcpkg"
   #         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,6 +139,23 @@ commands:
             ctest
 
   ############################ Dependency Commands ############################
+  ubuntu_install_and_setup_cmake:
+    parameters:
+      version:
+        default: "3.10"
+        type: string
+      version_build:
+        default: "1"
+        type: string
+    steps:
+      - run:
+          name: ""
+          command: |
+            cd /tmp
+            wget https://cmake.org/files/v<< parameters.version >>/cmake-<< parameters.version >>.<< parameters.version_build >>-Linux-x86_64.sh
+            sudo mkdir /opt/cmake
+            sudo sh cmake-<< parameters.version >>.<< parameters.version_build >>-Linux-x86_64.sh --prefix=/opt/cmake --skip-license
+            sudo ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake
   ubuntu_install_mkl:
     parameters:
       mkl_version:
@@ -178,6 +195,7 @@ jobs:
       - build_vcpkg
       - install_vcpkg_deps:
           vcpkg_deps: "intel-mkl fftw3 cub kenlm"
+      - ubuntu_install_and_setup_cmake
       - flashlight_source_build_with_vcpkg:
           fl_build_fl_core: "OFF"
           fl_build_app_asr: "OFF"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,7 +199,7 @@ jobs:
           fl_build_core: "OFF"
           fl_build_app_asr: "OFF"
           fl_build_app_img_class: "OFF"
-          fl_test_apex_dir: "OFF"
+          fl_test_apex_dir: "flashlight/lib/test"
   build-cpu:
     docker:
       - image: flml/flashlight:cpu-base-consolidation-latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,7 +291,7 @@ jobs:
             export MKLROOT=/opt/intel/mkl && export KENLM_ROOT=/root/kenlm
             mkdir -p build && cd build
             cmake .. -DFL_BACKEND=CPU -DFL_LIBRARIES_USE_CUDA=OFF
-            make -j$(nproc) && make install
+            make -j16 && make install
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,7 +291,7 @@ jobs:
             export MKLROOT=/opt/intel/mkl && export KENLM_ROOT=/root/kenlm
             mkdir -p build && cd build
             cmake .. -DFL_BACKEND=CPU -DFL_LIBRARIES_USE_CUDA=OFF
-            make -j12 && make install
+            make -j8 && make install
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,17 +33,17 @@ commands:
       - run:
           name: "Install vcpkg prerequisites"
           command: |
-            DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gperf automake
+            DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gperf automake gcc-7 g++-7
       - run:
           name: "Install vcpkg dependencies"
           command: |
             ./vcpkg/vcpkg install \
-                cuda intel-mkl fftw3 cub kenlm            \ # for flashlight libraries
-                arrayfire[cuda] cudnn nccl openmpi cereal \ # for the flashlight neural net library
-                gflags                                    \ # for flashlight application libraries
-                libsndfile                                \ # for the flashlight asr application
-                stb                                       \ # for the flashlight imgclass application
-                gtest                                       # optional, if building tests
+                cuda intel-mkl fftw3 cub kenlm            \
+                arrayfire[cuda] cudnn nccl openmpi cereal \
+                gflags                                    \
+                libsndfile                                \
+                stb                                       \
+                gtest
   install_cuda_linux:
     parameters:
       version:
@@ -62,8 +62,8 @@ jobs:
   ubuntu_1604_gcc5_cuda_10_1_vcpkg_flashlight_lib:
     <<: *gpu
     steps:
-      - build_vcpkg
       - install_vcpkg_deps
+      - build_vcpkg
       - checkout
       - run:
           name: "Install flashlight-cuda libraries with vcpkg"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,8 @@ gpu: &gpu
   resource_class: gpu.small
 
 commands:
+  ############################### Docker Commands ###############################
+  # Docker commands
   authenticate_docker:
     steps:
       - run:
@@ -31,17 +33,17 @@ commands:
   start_nvidia_docker_and_copy_flashlight_source:
     steps:
       - run:
-          name: "Start NVIDIA Docker 2 and Copy flashlight source"
+          name: "Start NVIDIA Docker and Copy Flashlight source"
           command: |
             sudo docker run --runtime=nvidia --rm -itd --ipc=host --name flashlight flml/flashlight:cuda-base-consolidation-latest
             sudo docker exec -it flashlight bash -c "mkdir /flashlight"
             sudo docker cp . flashlight:/flashlight
-  build_and_test_flashlight_inside_nvidia_docker:
+  build_flashlight_inside_nvidia_docker:
     parameters:
       fl_backend:
         default: "CUDA"
         type: string
-      fl_build_core:
+      fl_build_fl_core:
         default: "OFF"
         type: string
       fl_build_app_asr:
@@ -50,12 +52,9 @@ commands:
       fl_build_app_img_class:
         default: "OFF"
         type: string
-      fl_test_apex_dir:
-        default: "."
-        type: string
     steps:
       - run:
-          name: "Build and Test Flashlight inside of NVIDIA Docker"
+          name: "Build and Install Flashlight inside of NVIDIA Docker"
           command: |
             sudo docker exec -it flashlight bash -c "\
                 apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gcc-5 g++-5 && \
@@ -64,12 +63,23 @@ commands:
                 export MKLROOT=/opt/intel/mkl && export KENLM_ROOT=/root/kenlm && \
                 cmake .. \
                     -DFL_BACKEND=<< parameters.fl_backend >> \
-                    -DFL_BUILD_CORE=<< parameters.fl_build_core >> \
+                    -DFL_BUILD_fl_CORE=<< parameters.fl_build_fl_core >> \
                     -DFL_BUILD_APP_ASR=<< parameters.fl_build_app_asr >> \
-                    -DFL_BUILD_APP_IMG_CLASS=<< parameters.fl_build_app_img_class >> \
+                    -DFL_BUILD_APP_IMG_CLASS=<< parameters.fl_build_app_img_class >>
                 && \
-                make -j$(nproc) && make install && cd << parameters.fl_test_apex_dir >> && ctest"
-
+                make -j$(nproc) && make install
+  test_flashlight_inside_nvidia_docker:
+    parameters:
+      fl_test_apex_dir:
+        default: "."
+        type: string
+    steps:
+      - run:
+          name: "Test Flashlight inside of NVIDIA Docker"
+          command: |
+            sudo docker exec -it flashlight bash -c "\
+                cd /flashlight/build/<< parameters.fl_test_apex_dir >> && ctest"
+  ############################### vcpkg Commands ###############################
   install_gcc_7:
     steps:
       - run:
@@ -107,6 +117,7 @@ commands:
                 libsndfile                                \
                 stb                                       \
                 gtest
+  ############################ Dependency Commands ############################
   install_mkl_linux:
     parameters:
       mkl_version:
@@ -194,12 +205,60 @@ jobs:
       - install_nvidia_docker
       - checkout
       - start_nvidia_docker_and_copy_flashlight_source
-      - build_and_test_flashlight_inside_nvidia_docker:
+      - build_flashlight_inside_nvidia_docker:
           fl_backend: "CUDA"
-          fl_build_core: "OFF"
+          fl_build_fl_core: "OFF"
           fl_build_app_asr: "OFF"
           fl_build_app_img_class: "OFF"
+      - test_flashlight_inside_nvidia_docker:
           fl_test_apex_dir: "flashlight/lib/test"
+
+  ubuntu_1604_gcc5_cuda_10_0_docker_flashlight_fl_core:
+    <<: *gpu
+    steps:
+      - authenticate_docker
+      - install_nvidia_docker
+      - checkout
+      - start_nvidia_docker_and_copy_flashlight_source
+      - build_flashlight_inside_nvidia_docker:
+          fl_backend: "CUDA"
+          fl_build_fl_core: "ON"
+          fl_build_app_asr: "OFF"
+          fl_build_app_img_class: "OFF"
+      - test_flashlight_inside_nvidia_docker:
+          fl_test_apex_dir: "flashlight/fl/test"
+
+  ubuntu_1604_gcc5_cuda_10_0_docker_flashlight_app_asr:
+    <<: *gpu
+    steps:
+      - authenticate_docker
+      - install_nvidia_docker
+      - checkout
+      - start_nvidia_docker_and_copy_flashlight_source
+      - build_flashlight_inside_nvidia_docker:
+          fl_backend: "CUDA"
+          fl_build_fl_core: "ON"
+          fl_build_app_asr: "ON"
+          fl_build_app_img_class: "OFF"
+      - test_flashlight_inside_nvidia_docker:
+          fl_test_apex_dir: "flashlight/app/asr/test"
+
+  ubuntu_1604_gcc5_cuda_10_0_docker_flashlight_app_imgclass:
+    <<: *gpu
+    steps:
+      - authenticate_docker
+      - install_nvidia_docker
+      - checkout
+      - start_nvidia_docker_and_copy_flashlight_source
+      - build_flashlight_inside_nvidia_docker:
+          fl_backend: "CUDA"
+          fl_build_fl_core: "ON"
+          fl_build_app_asr: "OFF"
+          fl_build_app_img_class: "ON"
+      # TODO (jacobkahn/padentomasello): add the below once we have tests inside imgclass
+      # - test_flashlight_inside_nvidia_docker:
+      #     fl_test_apex_dir: "flashlight/app/asr/test"
+
   build-cpu:
     docker:
       - image: flml/flashlight:cpu-base-consolidation-latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,12 +172,12 @@ jobs:
   ubuntu1604_gcc5_cuda_10_1_vcpkg_flashlight_lib:
     <<: *gpu
     steps:
+      - checkout
       - ubuntu_install_mkl
       - install_vcpkg_prereqs
       - build_vcpkg
       - install_vcpkg_deps:
           vcpkg_deps: "intel-mkl fftw3 cub kenlm"
-      - checkout
       - flashlight_source_build_with_vcpkg:
           fl_build_fl_core: "OFF"
           fl_build_app_asr: "OFF"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,11 +21,19 @@ commands:
             then
                 sudo docker login -u=$DOCKER_USERNAME -p=$DOCKER_PASSWORD
             fi
-  install_nvidia_docker:
+  install_nvidia_docker2:
     steps:
       - run:
-          name: "Install NVIDIA Docker"
-          command: sudo apt-get install -y --no-install-recommends nvidia-docker
+          name: "Install NVIDIA Docker 2"
+          command: sudo apt-get install -y --no-install-recommends nvidia-docker2
+  start_nvidia_docker_and_copy_flashlight_source:
+    steps:
+      - run:
+          name: "Start NVIDIA Docker 2 and Copy flashlight source"
+          command: |
+            sudo docker run --runtime=nvidia --rm -itd --ipc=host --name flashlight2 flml/flashlight:cuda-base-consolidation-latest
+            sudo docker exec -it flashlight bash -c "mkdir /flashlight"
+            sudo docker cp . flashlight:/flashlight
   install_gcc_7:
     steps:
       - run:
@@ -143,25 +151,23 @@ jobs:
   #         command: |
   #           ./vcpkg install flashlight-cuda[imgclass]
 
-  ubuntu_1604_gcc5_cuda_10_1_docker_lib:
+  ubuntu_1604_gcc5_cuda_10_0_docker_flashlight_lib:
     <<: *gpu
     steps:
-      - checkout
       - authenticate_docker
-      - install_nvidia_docker
+      - install_nvidia_docker2
+      - checkout
+      - start_nvidia_docker_and_copy_flashlight_source
       - run:
-          name: Build flashlight with CUDA backend inside nvidia-docker
+          name: Build flashlight with CUDA backend inside nvidia-docker2
           command: |
-            sudo docker run --runtime=nvidia --rm -itd --ipc=host --name flashlight flml/flashlight:cuda-base-consolidation-latest
-            sudo docker exec -it flashlight bash -c "mkdir /flashlight"
-            sudo docker cp . flashlight:/flashlight
             sudo docker exec -it flashlight bash -c "\
-            apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gcc-5 g++-5 && \
-            cd /flashlight && pwd && ls && mkdir -p build && cd build && \
-            export CC=/usr/bin/gcc-5 && export CXX=/usr/bin/g++-5 && \
-            export MKLROOT=/opt/intel/mkl && export KENLM_ROOT=/root/kenlm && \
-            cmake .. -DFL_BACKEND=CUDA && \
-            make -j$(nproc) && make install && make test"
+                apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gcc-5 g++-5 && \
+                cd /flashlight && pwd && ls && mkdir -p build && cd build && \
+                export CC=/usr/bin/gcc-5 && export CXX=/usr/bin/g++-5 && \
+                export MKLROOT=/opt/intel/mkl && export KENLM_ROOT=/root/kenlm && \
+                cmake .. -DFL_BACKEND=CUDA -DFL_BUILD_CORE=OFF -DFL_BUILD_APP_ASR=OFF -DFL_BUILD_APP_IMG_CLASS=OFF
+                make -j$(nproc) && make install && cd flashlight/lib/test && ctest"
   build-cpu:
     docker:
       - image: flml/flashlight:cpu-base-consolidation-latest
@@ -188,7 +194,7 @@ workflows:
       - ubuntu_1604_gcc5_cuda_10_1_vcpkg_flashlight_lib
   cuda_build_and_install:
     jobs:
-      - ubuntu_1604_gcc5_cuda_10_1_docker_lib
+      - ubuntu_1604_gcc5_cuda_10_0_docker_flashlight_lib
   build_and_install:
     jobs:
       - build-cpu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,15 @@ commands:
             then
                 sudo docker login -u=$DOCKER_USERNAME -p=$DOCKER_PASSWORD
             fi
+  install_gcc_7:
+    steps:
+      - run:
+          name: "Install gcc 7"
+          command: |
+            sudo apt-get install -y --no-install-recommends software-properties-common
+            sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+            sudo apt update
+            sudo apt install gcc-7 g++-7 -y --no-install-recommends
   build_vcpkg:
     steps:
       - run:
@@ -30,6 +39,7 @@ commands:
             ./vcpkg/bootstrap-vcpkg.sh
   install_vcpkg_deps:
     steps:
+      - install_gcc_7
       - run:
           name: "Install vcpkg prerequisites"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,11 +21,13 @@ commands:
             then
                 sudo docker login -u=$DOCKER_USERNAME -p=$DOCKER_PASSWORD
             fi
-  install_nvidia_docker2:
+  install_nvidia_docker:
     steps:
       - run:
-          name: "Install NVIDIA Docker 2"
-          command: sudo apt-get install -y --no-install-recommends nvidia-docker2
+          name: "Install NVIDIA Docker"
+          command: |
+            sudo apt-get install -y --no-install-recommends nvidia-docker2
+            sudo pkill -SIGHUP dockerd
   start_nvidia_docker_and_copy_flashlight_source:
     steps:
       - run:
@@ -155,7 +157,7 @@ jobs:
     <<: *gpu
     steps:
       - authenticate_docker
-      - install_nvidia_docker2
+      - install_nvidia_docker
       - checkout
       - start_nvidia_docker_and_copy_flashlight_source
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,12 +273,13 @@ jobs:
       # - test_flashlight_inside_nvidia_docker:
       #     fl_test_apex_dir: "flashlight/app/imgclass/test"
 
-  build-cpu:
+  ubuntu1804_gcc5_docker_flashlight_all:
     docker:
       - image: flml/flashlight:cpu-base-consolidation-latest
         auth:
           username: $DOCKER_USERNAME
           password: $DOCKER_PASSWORD
+    resource_class: 2xlarge
     steps:
       - checkout:
           path: flashlight
@@ -290,19 +291,19 @@ jobs:
             export MKLROOT=/opt/intel/mkl && export KENLM_ROOT=/root/kenlm
             mkdir -p build && cd build
             cmake .. -DFL_BACKEND=CPU -DFL_LIBRARIES_USE_CUDA=OFF
-            make -j1 && make install
+            make -j$(nproc) && make install
 
 workflows:
   version: 2
-  vcpkg_test_source_build:
+  vcpkg_cuda_test_source_build_and_test:
     jobs:
       - ubuntu1604_gcc5_cuda_10_1_vcpkg_flashlight_lib
-  docker_cuda_build_and_install:
+  docker_cuda_build_test_and_install:
     jobs:
       - ubuntu1804_gcc5_cuda10_0_docker_flashlight_lib
       - ubuntu1804_gcc5_cuda10_0_docker_flashlight_fl_core
       - ubuntu1804_gcc5_cuda10_0_docker_flashlight_app_asr
       - ubuntu1804_gcc5_cuda10_0_docker_flashlight_app_imgclass
-  build_and_install:
+  docker_cpu_build_test_and_install:
     jobs:
-      - build-cpu
+      - ubuntu1804_gcc5_docker_flashlight_all

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,7 @@ commands:
               -DFL_BACKEND=CUDA \
               -DFL_BUILD_CORE=<< parameters.fl_build_fl_core >> \
               -DFL_BUILD_APP_ASR=<< parameters.fl_build_app_asr >> \
-              -DFL_BUILD_APP_IMG_CLASS=<< parameters.fl_build_app_img_class >> && \
+              -DFL_BUILD_APP_IMG_CLASS=<< parameters.fl_build_app_img_class >> \
               -DCMAKE_TOOLCHAIN_FILE=$HOME/project/vcpkg/scripts/buildsystems/vcpkg.cmake
             make -j$(nproc)
   flashlight_source_test_with_vcpkg:
@@ -291,7 +291,7 @@ jobs:
             export MKLROOT=/opt/intel/mkl && export KENLM_ROOT=/root/kenlm
             mkdir -p build && cd build
             cmake .. -DFL_BACKEND=CPU -DFL_LIBRARIES_USE_CUDA=OFF
-            make -j8 && make install
+            make -j2 && make install
 
 workflows:
   version: 2
@@ -304,6 +304,6 @@ workflows:
       - ubuntu1804_gcc5_cuda10_0_docker_flashlight_fl_core
       - ubuntu1804_gcc5_cuda10_0_docker_flashlight_app_asr
       - ubuntu1804_gcc5_cuda10_0_docker_flashlight_app_imgclass
-  docker_cpu_build_test_and_install:
+  docker_cpu_build_and_install:
     jobs:
       - ubuntu1804_gcc5_cpu_docker_flashlight_all

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,6 +125,7 @@ commands:
           command: |
             cd $HOME/project && mkdir -p build && cd build
             export MKLROOT=/opt/intel/mkl
+            export CUDACXX=/usr/local/cuda/bin/nvcc
             cmake .. \
               -DFL_LIBRARIES_USE_MKL=OFF \
               -DFL_BACKEND=CUDA \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,9 +33,43 @@ commands:
       - run:
           name: "Start NVIDIA Docker 2 and Copy flashlight source"
           command: |
-            sudo docker run --runtime=nvidia --rm -itd --ipc=host --name flashlight2 flml/flashlight:cuda-base-consolidation-latest
+            sudo docker run --runtime=nvidia --rm -itd --ipc=host --name flashlight flml/flashlight:cuda-base-consolidation-latest
             sudo docker exec -it flashlight bash -c "mkdir /flashlight"
             sudo docker cp . flashlight:/flashlight
+  build_and_test_flashlight_inside_nvidia_docker:
+    parameters:
+      fl_backend:
+        default: "CUDA"
+        type: string
+      fl_build_core:
+        default: "OFF"
+        type: string
+      fl_build_app_asr:
+        default: "OFF"
+        type: string
+      fl_build_app_img_class:
+        default: "OFF"
+        type: string
+      fl_test_apex_dir:
+        default: "."
+        type: string
+    steps:
+      - run:
+          name: "Build and Test Flashlight inside of NVIDIA Docker"
+          command: |
+            sudo docker exec -it flashlight bash -c "\
+                apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gcc-5 g++-5 && \
+                cd /flashlight && pwd && ls && mkdir -p build && cd build && \
+                export CC=/usr/bin/gcc-5 && export CXX=/usr/bin/g++-5 && \
+                export MKLROOT=/opt/intel/mkl && export KENLM_ROOT=/root/kenlm && \
+                cmake .. \
+                    -DFL_BACKEND=<< parameters.fl_backend >> \
+                    -DFL_BUILD_CORE=<< parameters.fl_build_core >> \
+                    -DFL_BUILD_APP_ASR=<< parameters.fl_build_app_asr >> \
+                    -DFL_BUILD_APP_IMG_CLASS=<< parameters.fl_build_app_img_class >> \
+                && \
+                make -j$(nproc) && make install && cd << parameters.fl_test_apex_dir >> && ctest"
+
   install_gcc_7:
     steps:
       - run:
@@ -160,16 +194,12 @@ jobs:
       - install_nvidia_docker
       - checkout
       - start_nvidia_docker_and_copy_flashlight_source
-      - run:
-          name: Build flashlight with CUDA backend inside nvidia-docker2
-          command: |
-            sudo docker exec -it flashlight bash -c "\
-                apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gcc-5 g++-5 && \
-                cd /flashlight && pwd && ls && mkdir -p build && cd build && \
-                export CC=/usr/bin/gcc-5 && export CXX=/usr/bin/g++-5 && \
-                export MKLROOT=/opt/intel/mkl && export KENLM_ROOT=/root/kenlm && \
-                cmake .. -DFL_BACKEND=CUDA -DFL_BUILD_CORE=OFF -DFL_BUILD_APP_ASR=OFF -DFL_BUILD_APP_IMG_CLASS=OFF
-                make -j$(nproc) && make install && cd flashlight/lib/test && ctest"
+      - build_and_test_flashlight_inside_nvidia_docker:
+          fl_backend: "CUDA"
+          fl_build_core: "OFF"
+          fl_build_app_asr: "OFF"
+          fl_build_app_img_class: "OFF"
+          fl_test_apex_dir: "OFF"
   build-cpu:
     docker:
       - image: flml/flashlight:cpu-base-consolidation-latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ commands:
                     -DFL_BACKEND=<< parameters.fl_backend >> \
                     -DFL_BUILD_fl_CORE=<< parameters.fl_build_fl_core >> \
                     -DFL_BUILD_APP_ASR=<< parameters.fl_build_app_asr >> \
-                    -DFL_BUILD_APP_IMG_CLASS=<< parameters.fl_build_app_img_class >>
+                    -DFL_BUILD_APP_IMG_CLASS=<< parameters.fl_build_app_img_class >> \
                 && \
                 make -j$(nproc) && make install
   test_flashlight_inside_nvidia_docker:
@@ -147,7 +147,7 @@ commands:
             sudo apt-get --yes --force-yes install cuda
             nvidia-smi
 jobs:
-  ubuntu_1604_gcc5_cuda_10_1_vcpkg_flashlight_lib:
+  ubuntu1604_gcc5_cuda_10_1_vcpkg_flashlight_lib:
     <<: *gpu
     steps:
       - install_vcpkg_prereqs
@@ -167,7 +167,7 @@ jobs:
           name: "Run flashlight-cuda libraries tests"
           command: |
             cd $HOME/project/build/flashlight/lib/test && ctest
-  # ubuntu_1604_gcc5_cuda_10_1_vcpkg_flashlight_fl_core:
+  # ubuntu1604_gcc5_cuda_10_1_vcpkg_flashlight_fl_core:
   #   <<: *gpu
   #   steps:
   #     - checkout
@@ -177,7 +177,7 @@ jobs:
   #         name: "Install flashlight-cuda fl core with vcpkg"
   #         command: |
   #           ./vcpkg install flashlight-cuda[fl]
-  # ubuntu_1604_gcc5_cuda_10_1_vcpkg_flashlight_app_asr:
+  # ubuntu1604_gcc5_cuda_10_1_vcpkg_flashlight_app_asr:
   #   <<: *gpu
   #   steps:
   #     - checkout
@@ -187,7 +187,7 @@ jobs:
   #         name: "Install flashlight-cuda fl core with vcpkg"
   #         command: |
   #           ./vcpkg install flashlight-cuda[asr]
-  # ubuntu_1604_gcc5_cuda_10_1_vcpkg_flashlight_app_imgclass:
+  # ubuntu1604_gcc5_cuda_10_1_vcpkg_flashlight_app_imgclass:
   #   <<: *gpu
   #   steps:
   #     - checkout
@@ -198,7 +198,7 @@ jobs:
   #         command: |
   #           ./vcpkg install flashlight-cuda[imgclass]
 
-  ubuntu_1604_gcc5_cuda_10_0_docker_flashlight_lib:
+  ubuntu1604_gcc5_cuda10_0_docker_flashlight_lib:
     <<: *gpu
     steps:
       - authenticate_docker
@@ -213,7 +213,7 @@ jobs:
       - test_flashlight_inside_nvidia_docker:
           fl_test_apex_dir: "flashlight/lib/test"
 
-  ubuntu_1604_gcc5_cuda_10_0_docker_flashlight_fl_core:
+  ubuntu1604_gcc5_cuda10_0_docker_flashlight_fl_core:
     <<: *gpu
     steps:
       - authenticate_docker
@@ -228,7 +228,7 @@ jobs:
       - test_flashlight_inside_nvidia_docker:
           fl_test_apex_dir: "flashlight/fl/test"
 
-  ubuntu_1604_gcc5_cuda_10_0_docker_flashlight_app_asr:
+  ubuntu1604_gcc5_cuda10_0_docker_flashlight_app_asr:
     <<: *gpu
     steps:
       - authenticate_docker
@@ -243,7 +243,7 @@ jobs:
       - test_flashlight_inside_nvidia_docker:
           fl_test_apex_dir: "flashlight/app/asr/test"
 
-  ubuntu_1604_gcc5_cuda_10_0_docker_flashlight_app_imgclass:
+  ubuntu1604_gcc5_cuda10_0_docker_flashlight_app_imgclass:
     <<: *gpu
     steps:
       - authenticate_docker
@@ -282,10 +282,13 @@ workflows:
   version: 2
   vcpkg_test_source_build:
     jobs:
-      - ubuntu_1604_gcc5_cuda_10_1_vcpkg_flashlight_lib
-  cuda_build_and_install:
+      - ubuntu1604_gcc5_cuda_10_1_vcpkg_flashlight_lib
+  docker_cuda_build_and_install:
     jobs:
-      - ubuntu_1604_gcc5_cuda_10_0_docker_flashlight_lib
+      - ubuntu1604_gcc5_cuda10_0_docker_flashlight_lib
+      - ubuntu1604_gcc5_cuda10_0_docker_flashlight_fl_core
+      - ubuntu1604_gcc5_cuda10_0_docker_flashlight_app_asr
+      - ubuntu1604_gcc5_cuda10_0_docker_flashlight_app_imgclass
   build_and_install:
     jobs:
       - build-cpu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,9 @@ commands:
           name: "Install vcpkg dependencies"
           command: |
             MKLROOT=/opt/intel/mkl ./vcpkg/vcpkg install << parameters.vcpkg_deps >>
+  # FIXME(jacobkahn): investigate why we need to force MKL to be off here. It seems that
+  # in the CI env, MKL is found but not MKL's iomp5 components which means no OpenMP
+  # implementation is linked - which causes a linker failure with omp symbols.
   flashlight_source_build_with_vcpkg:
     parameters:
       fl_build_fl_core:
@@ -121,12 +124,15 @@ commands:
           name: "Build Flashlight CUDA from source with vcpkg dependencies"
           command: |
             cd $HOME/project && mkdir -p build && cd build
+            export MKLROOT=/opt/intel/mkl
             cmake .. \
+              -DFL_LIBRARIES_USE_MKL=OFF \
               -DFL_BACKEND=CUDA \
               -DFL_BUILD_CORE=<< parameters.fl_build_fl_core >> \
               -DFL_BUILD_APP_ASR=<< parameters.fl_build_app_asr >> \
               -DFL_BUILD_APP_IMG_CLASS=<< parameters.fl_build_app_img_class >> && \
-              -DCMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake
+              -DCMAKE_TOOLCHAIN_FILE=$HOME/project/vcpkg/scripts/buildsystems/vcpkg.cmake
+            make -j$(nproc)
   flashlight_source_test_with_vcpkg:
     parameters:
       fl_test_apex_dir:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ version: 2.1
 gpu: &gpu
   machine:
     image: ubuntu-1604-cuda-10.1:201909-23
-  resource_class: gpu.small
+  resource_class: gpu.medium
 
 commands:
   authenticate_docker:
@@ -21,6 +21,29 @@ commands:
             then
                 sudo docker login -u=$DOCKER_USERNAME -p=$DOCKER_PASSWORD
             fi
+  build_vcpkg:
+    steps:
+      - run:
+          name: "Clone and Build vcpkg"
+          command: |
+            git clone https://github.com/microsoft/vcpkg
+            ./vcpkg/bootstrap-vcpkg.sh
+  install_vcpkg_deps:
+    steps:
+      - run:
+          name: "Install vcpkg prerequisites"
+          command: |
+            DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gperf automake
+      - run:
+          name: "Install vcpkg dependencies"
+          command: |
+            ./vcpkg/vcpkg install \
+                cuda intel-mkl fftw3 cub kenlm            \ # for flashlight libraries
+                arrayfire[cuda] cudnn nccl openmpi cereal \ # for the flashlight neural net library
+                gflags                                    \ # for flashlight application libraries
+                libsndfile                                \ # for the flashlight asr application
+                stb                                       \ # for the flashlight imgclass application
+                gtest                                       # optional, if building tests
   install_cuda_linux:
     parameters:
       version:
@@ -36,6 +59,54 @@ commands:
             sudo apt-get --yes --force-yes install cuda
             nvidia-smi
 jobs:
+  ubuntu_1604_gcc5_cuda_10_1_vcpkg_flashlight_lib:
+    <<: *gpu
+    steps:
+      - build_vcpkg
+      - install_vcpkg_deps
+      - checkout
+      - run:
+          name: "Install flashlight-cuda libraries with vcpkg"
+          command: |
+            cd $HOME/project && mkdir -p build && cd build && \
+            cmake .. \
+              -DFL_BACKEND=CUDA -DFL_BUILD_CORE=OFF -DFL_BUILD_APP_ASR=OFF -DFL_BUILD_APP_IMG_CLASS=OFF \
+              -DCMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake
+      - run:
+          name: "Run flashlight-cuda libraries tests"
+          command: |
+            cd $HOME/project/build/flashlight/lib/test && ctest
+  # ubuntu_1604_gcc5_cuda_10_1_vcpkg_flashlight_fl_core:
+  #   <<: *gpu
+  #   steps:
+  #     - checkout
+  #     - build_vcpkg
+  #     - install_vcpkg_deps
+  #     - run:
+  #         name: "Install flashlight-cuda fl core with vcpkg"
+  #         command: |
+  #           ./vcpkg install flashlight-cuda[fl]
+  # ubuntu_1604_gcc5_cuda_10_1_vcpkg_flashlight_app_asr:
+  #   <<: *gpu
+  #   steps:
+  #     - checkout
+  #     - build_vcpkg
+  #     - install_vcpkg_deps
+  #     - run:
+  #         name: "Install flashlight-cuda fl core with vcpkg"
+  #         command: |
+  #           ./vcpkg install flashlight-cuda[asr]
+  # ubuntu_1604_gcc5_cuda_10_1_vcpkg_flashlight_app_imgclass:
+  #   <<: *gpu
+  #   steps:
+  #     - checkout
+  #     - build_vcpkg
+  #     - install_vcpkg_deps
+  #     - run:
+  #         name: "Install flashlight-cuda fl core with vcpkg"
+  #         command: |
+  #           ./vcpkg install flashlight-cuda[imgclass]
+
   ubuntu_1604_gcc5_cuda_10_1_docker:
     <<: *gpu
     steps:
@@ -74,6 +145,9 @@ jobs:
             make -j1 && make install
 workflows:
   version: 2
+  vcpkg_test_source_build:
+    jobs:
+      - ubuntu_1604_gcc5_cuda_10_1_vcpkg_flashlight_lib
   build_and_install:
     jobs:
       - ubuntu_1604_gcc5_cuda_10_1_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ version: 2.1
 gpu: &gpu
   machine:
     image: ubuntu-1604-cuda-10.1:201909-23
-  resource_class: gpu.medium
+  resource_class: gpu.small
 
 commands:
   authenticate_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,13 +273,13 @@ jobs:
       # - test_flashlight_inside_nvidia_docker:
       #     fl_test_apex_dir: "flashlight/app/imgclass/test"
 
-  ubuntu1804_gcc5_docker_flashlight_all:
+  ubuntu1804_gcc5_cpu_docker_flashlight_all:
     docker:
       - image: flml/flashlight:cpu-base-consolidation-latest
         auth:
           username: $DOCKER_USERNAME
           password: $DOCKER_PASSWORD
-    resource_class: 2xlarge
+    resource_class: 2xlarge+
     steps:
       - checkout:
           path: flashlight
@@ -306,4 +306,4 @@ workflows:
       - ubuntu1804_gcc5_cuda10_0_docker_flashlight_app_imgclass
   docker_cpu_build_test_and_install:
     jobs:
-      - ubuntu1804_gcc5_docker_flashlight_all
+      - ubuntu1804_gcc5_cpu_docker_flashlight_all

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ commands:
                     -DFL_BUILD_APP_ASR=<< parameters.fl_build_app_asr >> \
                     -DFL_BUILD_APP_IMG_CLASS=<< parameters.fl_build_app_img_class >> \
                 && \
-                make -j$(nproc) && make install
+                make -j$(nproc) && make install"
   test_flashlight_inside_nvidia_docker:
     parameters:
       fl_test_apex_dir:
@@ -198,7 +198,7 @@ jobs:
   #         command: |
   #           ./vcpkg install flashlight-cuda[imgclass]
 
-  ubuntu1604_gcc5_cuda10_0_docker_flashlight_lib:
+  ubuntu1804_gcc5_cuda10_0_docker_flashlight_lib:
     <<: *gpu
     steps:
       - authenticate_docker
@@ -213,7 +213,7 @@ jobs:
       - test_flashlight_inside_nvidia_docker:
           fl_test_apex_dir: "flashlight/lib/test"
 
-  ubuntu1604_gcc5_cuda10_0_docker_flashlight_fl_core:
+  ubuntu1804_gcc5_cuda10_0_docker_flashlight_fl_core:
     <<: *gpu
     steps:
       - authenticate_docker
@@ -228,7 +228,7 @@ jobs:
       - test_flashlight_inside_nvidia_docker:
           fl_test_apex_dir: "flashlight/fl/test"
 
-  ubuntu1604_gcc5_cuda10_0_docker_flashlight_app_asr:
+  ubuntu1804_gcc5_cuda10_0_docker_flashlight_app_asr:
     <<: *gpu
     steps:
       - authenticate_docker
@@ -243,7 +243,7 @@ jobs:
       - test_flashlight_inside_nvidia_docker:
           fl_test_apex_dir: "flashlight/app/asr/test"
 
-  ubuntu1604_gcc5_cuda10_0_docker_flashlight_app_imgclass:
+  ubuntu1804_gcc5_cuda10_0_docker_flashlight_app_imgclass:
     <<: *gpu
     steps:
       - authenticate_docker
@@ -285,10 +285,10 @@ workflows:
       - ubuntu1604_gcc5_cuda_10_1_vcpkg_flashlight_lib
   docker_cuda_build_and_install:
     jobs:
-      - ubuntu1604_gcc5_cuda10_0_docker_flashlight_lib
-      - ubuntu1604_gcc5_cuda10_0_docker_flashlight_fl_core
-      - ubuntu1604_gcc5_cuda10_0_docker_flashlight_app_asr
-      - ubuntu1604_gcc5_cuda10_0_docker_flashlight_app_imgclass
+      - ubuntu1804_gcc5_cuda10_0_docker_flashlight_lib
+      - ubuntu1804_gcc5_cuda10_0_docker_flashlight_fl_core
+      - ubuntu1804_gcc5_cuda10_0_docker_flashlight_app_asr
+      - ubuntu1804_gcc5_cuda10_0_docker_flashlight_app_imgclass
   build_and_install:
     jobs:
       - build-cpu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,7 @@ commands:
         type: string
     steps:
       - run:
-          name: ""
+          name: "Install and Setup CMake"
           command: |
             cd /tmp
             wget https://cmake.org/files/v<< parameters.version >>/cmake-<< parameters.version >>.<< parameters.version_build >>-Linux-x86_64.sh
@@ -182,7 +182,7 @@ commands:
         type: string
     steps:
       - run:
-          name: Install CUDA 10.0
+          name: "Install CUDA 10.0"
           command: |
             wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_10.0.130-1_amd64.deb
             sudo dpkg -i cuda-repo-ubuntu1604_10.0.130-1_amd64.deb
@@ -291,7 +291,7 @@ jobs:
             export MKLROOT=/opt/intel/mkl && export KENLM_ROOT=/root/kenlm
             mkdir -p build && cd build
             cmake .. -DFL_BACKEND=CPU -DFL_LIBRARIES_USE_CUDA=OFF
-            make -j16 && make install
+            make -j12 && make install
 
 workflows:
   version: 2


### PR DESCRIPTION
Completely overhaul our CI. This was due for quite a while. The net efficiency gain over ~2 months ago given recent changes are a 70%+ reduction in time  - once we have larger instances available for the CPU build, that will improve another 20%. It now takes ~10 minutes to build all of flashlight for all backends and run all tests for testable backends, and this scales very well with future work across the core and applications.

Our CI config is also cleaned up and overhauled to use parameterized test and dependency install commands that make things very easy to extend and change. There is now one source of truth for each component of CI that's reused across a variety of configurations.

CI results are now broken into three categories:
- CUDA, NVIDIA Docker-based builds + tests
  - Incrementally build features and tests for each feature to better-parallelize them.
- vcpkg-based builds + tests
  - flashlight lib only for now until bugs in `fontconfig` can be fixed such that things build properly on Ubuntu 16.04 -- see https://github.com/microsoft/vcpkg/issues/14864.
- CPU, Docker-based builds

These categories make it easier to see what's broken and to get more granular signals for various build components. They'll also allow us to eventually test across environments with more ease.

What things look like now:

<img width="1415" alt="Screen Shot 2020-12-03 at 12 08 50 AM" src="https://user-images.githubusercontent.com/7871817/100971183-ffeba100-34fb-11eb-8a3c-5a31a858f38c.png">
<img width="890" alt="Screen Shot 2020-12-03 at 12 09 09 AM" src="https://user-images.githubusercontent.com/7871817/100971188-011cce00-34fc-11eb-97dd-3760bf81bcd4.png">
