### PR TITLE
Make KenLM, CBLAS lib properties private, add FFTW3 to public build interface

### DIFF
--- a/flashlight/lib/audio/feature/CMakeLists.txt
+++ b/flashlight/lib/audio/feature/CMakeLists.txt
@@ -62,8 +62,14 @@ target_link_libraries(
   FFTW3::fftw3
   )
 
-target_include_directories(
+target_link_libraries(
   fl-libraries
   PUBLIC
+  $<BUILD_INTERFACE:FFTW3::fftw3>
+  )
+
+target_include_directories(
+  fl-libraries
+  PRIVATE
   ${CBLAS_INCLUDE_DIR}
   )

--- a/flashlight/lib/text/decoder/lm/CMakeLists.txt
+++ b/flashlight/lib/text/decoder/lm/CMakeLists.txt
@@ -27,20 +27,23 @@ if (FL_LIBRARIES_USE_KENLM)
 
   target_link_libraries(
     fl-libraries
-    PUBLIC
+    PRIVATE
     ${KENLM_LIBRARIES}
     ${LIBLZMA_LIBRARIES}
     ${BZIP2_LIBRARIES}
     ${ZLIB_LIBRARIES}
     )
 
-  target_include_directories(
-    fl-libraries
-    PUBLIC
-    ${KENLM_INCLUDE_DIRS}
+  set(KENLM_AND_DEP_INCLUDE_DIRS
     ${LIBLZMA_INCLUDE_DIRS}
     ${BZIP2_INCLUDE_DIRS}
     ${ZLIB_INCLUDE_DIRS}
+    )
+
+  target_include_directories(
+    fl-libraries
+    PUBLIC
+    $<BUILD_INTERFACE:${KENLM_INCLUDE_DIRS}>
     )
 
   target_compile_definitions(


### PR DESCRIPTION
Summary:
KenLM, compression lib, and BLAS headers should be private since they aren't included by any tests or downstream things.

Since FFTW is included in `PowerSpectrum.h`, it needs to be in the public build interface since tests that transitively include it will fail to build since the FFTW3 header won't be found.

Differential Revision: D25293284

