### PR TITLE
Move nvcc setup to before any CUDA libs are added

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,20 @@ set(INSTALLABLE_TARGETS "")
 set(FL_ROOT_DIR ${PROJECT_SOURCE_DIR}/flashlight)
 set(FL_BUILD_BINARY_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/bin")
 
+# CUDA/nvcc setup
+if (FL_USE_CUDA)
+  enable_language(CUDA)
+  set(CMAKE_CUDA_STANDARD 14)
+  set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+  include(${CMAKE_MODULE_PATH}/CUDAUtils.cmake)
+  set_cuda_arch_nvcc_flags()
+
+  # remove me? add -fPIC to nvcc flags if needed
+  if (FL_LIBRARIES_BUILD_FOR_PYTHON OR CMAKE_POSITION_INDEPENDENT_CODE)
+    cuda_enable_position_independent_code()
+  endif ()
+endif()
+
 # ------------------------ Tests ------------------------
 
 if (FL_BUILD_TESTS)

--- a/flashlight/lib/CMakeLists.txt
+++ b/flashlight/lib/CMakeLists.txt
@@ -52,16 +52,6 @@ set(FL_LIBRARY_CUDA_SOURCES
 # A library containing CUDA targets within libraries that may need to be linked
 # in. Only build a CUDA lib of libraries that require CUDA kernels are built
 if (FL_LIBRARIES_USE_CUDA)
-  enable_language(CUDA)
-  set(CMAKE_CUDA_STANDARD 14)
-  set(CMAKE_CUDA_STANDARD_REQUIRED ON)
-  include(${CMAKE_MODULE_PATH}/CUDAUtils.cmake)
-  set_cuda_arch_nvcc_flags()
-
-  # hacky: add -fPIC to nvcc flags if needed
-  if (FL_LIBRARIES_BUILD_FOR_PYTHON OR CMAKE_POSITION_INDEPENDENT_CODE)
-    cuda_enable_position_independent_code()
-  endif ()
   # Qualify name because CUDA target is public
   target_sources(
     fl-libraries


### PR DESCRIPTION
Summary:
Fixes https://github.com/facebookresearch/flashlight/issues/270 with a good catch by WilliamTambellini -- we need to set `nvcc` flags before any calls to `add_library` since those freeze nvcc flags in place for those library. `-std=c++14` is now added to every nvcc invocation in fl given that setup and standard specification occurs earlier.

The existing code is technically a race between when global nvcc flags get set and when the libraries are added. This resolves that.

Differential Revision: D25304948

