### PR TITLE
Add experimental advanced indexing operator in flashlight (#27)

### DIFF
--- a/flashlight/fl/autograd/CMakeLists.txt
+++ b/flashlight/fl/autograd/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(
 if (FL_USE_CPU)
   set(
     AUTOGRAD_CPU_SOURCES
+    ${CMAKE_CURRENT_LIST_DIR}/backend/cpu/operators/AdvancedIndex.cpp
     ${CMAKE_CURRENT_LIST_DIR}/backend/cpu/Conv2D.cpp
     ${CMAKE_CURRENT_LIST_DIR}/backend/cpu/Pool2D.cpp
     ${CMAKE_CURRENT_LIST_DIR}/backend/cpu/RNN.cpp
@@ -59,6 +60,7 @@ if (FL_USE_CUDA)
 
   set(
     AUTOGRAD_CUDA_SOURCES
+    ${CMAKE_CURRENT_LIST_DIR}/backend/cuda/operators/AdvancedIndex.cu
     ${CMAKE_CURRENT_LIST_DIR}/backend/cuda/BatchNorm.cpp
     ${CMAKE_CURRENT_LIST_DIR}/backend/cuda/Conv2D.cpp
     ${CMAKE_CURRENT_LIST_DIR}/backend/cuda/CudnnUtils.h

--- a/flashlight/fl/autograd/Functions.h
+++ b/flashlight/fl/autograd/Functions.h
@@ -941,7 +941,8 @@ Variable relativePositionalEmbeddingRotate(const Variable& input);
  * @param posEmb if non empty then compute relative
  * positional embedding in additon to standard computations
  * @param mask mask or not future in the computations
- * if non-empty then don't use future (for exmaple for autoregressive language models
+ * if non-empty then don't use future (for exmaple for autoregressive language
+ * models
  * or for decoder part in the encoder-decoder transformer models)
  * @param nHeads number of heads
  * @param pDropout dropout probability
@@ -956,6 +957,28 @@ Variable multiheadAttention(
     const int32_t nHeads,
     const double pDropout,
     const int32_t offset = 0);
+
+/**
+ * This function computes the gradient of an indexing operator
+ * when the af::index variable is an array (advanced indexing)
+ * @param inp The input Variable which is the gradient of output of index
+ * operator
+ * @param idxStart The starting index of each dimension of index operator
+ * @param idxEnd The ending index of each dimension of index operator
+ * @param outDims The dimensions of output Variable which is the input of index
+ * oeprator
+ * @param idxArr The pointer to the advanced index of every dimension of index
+ * operator
+ * @param out The output Varible which is the gradient of input of index
+ * operator
+ */
+void gradAdvancedIndex(
+    const Variable& inp,
+    const af::dim4 idxStart,
+    const af::dim4 idxEnd,
+    const af::dim4 outDims,
+    const std::vector<af::array>& idxArr,
+    Variable& out);
 
 /** @} */
 

--- a/flashlight/fl/autograd/Variable.h
+++ b/flashlight/fl/autograd/Variable.h
@@ -104,13 +104,16 @@ class Variable {
    * @param[in] s1 sequence of indices along second dimension
    * @param[in] s2 sequence of indices along third dimension
    * @param[in] s3 sequence of indices along fourth dimension
+   * @param[in] unique boolean to specify whether all dimensions contain unique
+   * indices
    * @return Variable storing the result after indexing operation
    */
   Variable operator()(
       const af::index& s0,
       const af::index& s1 = af::span,
       const af::index& s2 = af::span,
-      const af::index& s3 = af::span) const;
+      const af::index& s3 = af::span,
+      bool unique = false) const;
 
   /**
    * @return a reference to the underlying Arrayfire array.

--- a/flashlight/fl/autograd/backend/cpu/operators/AdvancedIndex.cpp
+++ b/flashlight/fl/autograd/backend/cpu/operators/AdvancedIndex.cpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <af/array.h>
+#include <cstdio>
+#include "flashlight/fl/autograd/Variable.h"
+
+namespace fl {
+
+void gradAdvancedIndex(
+    const Variable& inp,
+    const af::dim4 idxStart,
+    const af::dim4 idxEnd,
+    const af::dim4 outDims,
+    const std::vector<af::array>& idxArr,
+    Variable& out) {
+  throw std::runtime_error("gradAdvancedIndex not implemented for cpu");
+}
+
+} // namespace fl

--- a/flashlight/fl/autograd/backend/cuda/operators/AdvancedIndex.cu
+++ b/flashlight/fl/autograd/backend/cuda/operators/AdvancedIndex.cu
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <af/array.h>
+#include <cstdio>
+#include "flashlight/fl/autograd/Variable.h"
+#include "flashlight/fl/common/CudaUtils.h"
+#include "flashlight/fl/common/DevicePtr.h"
+
+#define GRID_SIZE 32
+#define BLOCK_SIZE 256
+
+template <class Float>
+__global__ void gradAdvancedIndexKernel(
+    const Float* inp,
+    const dim_t* idxStart,
+    const dim_t* idxEnd,
+    const dim_t* outDims,
+    const dim_t* idxArr,
+    Float* out) {
+  // Compute striding information for
+  // the input and output tensors
+  dim_t dims[4], strides[4];
+  dim_t outStrides[4];
+  for (int i = 0; i < 4; i++) {
+    dims[i] = idxEnd[i] - idxStart[i];
+  }
+  strides[0] = 1;
+  outStrides[0] = 1;
+  // arrayfire dimensions are inverted compared to numpy
+  // hence, stride computation starts from 1 to 4
+  for (int i = 1; i < 4; i++) {
+    strides[i] = strides[i - 1] * dims[i - 1];
+    outStrides[i] = outStrides[i - 1] * outDims[i - 1];
+  }
+
+  // Map CUDA thread to an element in the input array
+  for (dim_t tid = threadIdx.x + blockIdx.x * BLOCK_SIZE;
+       tid < (strides[3] * dims[3]);
+       tid += (GRID_SIZE * BLOCK_SIZE)) {
+    // Compute input array index for CUDA thread
+    dim_t index[4];
+    dim_t cursor = tid;
+    for (int i = 3; i >= 0; i--) {
+      index[i] = cursor / strides[i];
+      cursor = cursor % strides[i];
+    }
+
+    dim_t inpIdx = tid;
+    dim_t outIdx = 0;
+    for (int i = 0; i < 4; i++) {
+      // If indexing array specified, use it
+      if (idxArr[i]) {
+        auto idxArrPtr = (dim_t*)idxArr[i];
+        outIdx += idxArrPtr[index[i]] * outStrides[i];
+      } else {
+        outIdx += (idxStart[i] + index[i]) * outStrides[i];
+      }
+    }
+    // atomic addition is done to ensure correct
+    // gradient computation for repeated indices
+    atomicAdd(&out[outIdx], inp[inpIdx]);
+  }
+}
+
+namespace fl {
+
+void gradAdvancedIndex(
+    const Variable& inp,
+    const af::dim4 idxStart,
+    const af::dim4 idxEnd,
+    const af::dim4 outDims,
+    const std::vector<af::array>& idxArr,
+    Variable& out) {
+  auto inpType = inp.type();
+  auto outType = out.type();
+
+  if ((inpType != f32) && (inpType != f16)) {
+    throw std::invalid_argument("Input type must be f16/f32");
+  }
+  if ((outType != f32) && (outType != f16)) {
+    throw std::invalid_argument("Output type must be f16/f32");
+  }
+
+  DevicePtr idxArrRaw[4];
+  void* idxPtr[4];
+  // Extract raw device pointers for dimensions
+  // that have an array as af::index variable
+  for (int i = 0; i < 4; i++) {
+    idxPtr[i] = NULL;
+    if (!idxArr[i].isempty()) {
+      auto idxType = idxArr[i].type();
+      if ((idxType != s64) && (idxType != s32)) {
+        throw std::invalid_argument("Index type must be s32/s64");
+      }
+      if (idxType == s32) {
+        idxArrRaw[i] = DevicePtr(idxArr[i].as(s64));
+      } else {
+        idxArrRaw[i] = DevicePtr(idxArr[i]);
+      }
+      idxPtr[i] = idxArrRaw[i].get();
+    }
+  }
+  if (outType == f16) {
+    out = out.as(f32);
+  }
+  DevicePtr inpRaw(inp.array());
+  DevicePtr outRaw(out.array());
+  if (inpType == f16) {
+    inpRaw = DevicePtr(inp.as(f32).array());
+  }
+
+  cudaStream_t stream = cuda::getActiveStream();
+
+  af::array arrIdxStart(4, s64);
+  af::array arrIdxEnd(4, s64);
+  af::array arrOutDims(4, s64);
+  af::array arrIdxPtr(4, s64);
+  DevicePtr devIdxStart(arrIdxStart);
+  DevicePtr devIdxEnd(arrIdxEnd);
+  DevicePtr devOutDims(arrOutDims);
+  DevicePtr devIdxPtr(arrIdxPtr);
+
+  // Transformer indexing information to device
+  FL_CUDA_CHECK(cudaMemcpyAsync(
+      devIdxStart.get(),
+      idxStart.get(),
+      4 * sizeof(dim_t),
+      cudaMemcpyHostToDevice,
+      stream));
+  FL_CUDA_CHECK(cudaMemcpyAsync(
+      devIdxEnd.get(),
+      idxEnd.get(),
+      4 * sizeof(dim_t),
+      cudaMemcpyHostToDevice,
+      stream));
+  FL_CUDA_CHECK(cudaMemcpyAsync(
+      devOutDims.get(),
+      outDims.get(),
+      4 * sizeof(dim_t),
+      cudaMemcpyHostToDevice,
+      stream));
+  FL_CUDA_CHECK(cudaMemcpyAsync(
+      devIdxPtr.get(),
+      reinterpret_cast<dim_t*>(idxPtr),
+      4 * sizeof(dim_t),
+      cudaMemcpyHostToDevice,
+      stream));
+
+  gradAdvancedIndexKernel<<<GRID_SIZE, BLOCK_SIZE, 0, stream>>>(
+      static_cast<const float*>(inpRaw.get()),
+      static_cast<const dim_t*>(devIdxStart.get()),
+      static_cast<const dim_t*>(devIdxEnd.get()),
+      static_cast<const dim_t*>(devOutDims.get()),
+      static_cast<const dim_t*>(devIdxPtr.get()),
+      static_cast<float*>(outRaw.get()));
+  FL_CUDA_CHECK(cudaPeekAtLastError());
+
+  if (outType == f16) {
+    out = out.as(f16);
+  }
+}
+
+} // namespace fl


### PR DESCRIPTION
Summary:
This PR adds an advanced indexing operator that is able to provide the correct gradient when indices are repeated in the input to the operator. The operator is limited in the sense that is only able to apply advanced indexing to the second dimension for a 2-dimension tensor.

Pull Request resolved: https://github.com/fairinternal/flashlight/pull/27

Reviewed By: tlikhomanenko

Differential Revision: D24936310

Pulled By: chaitan3

