### PR TITLE
[sfx] add makefile support for augmentation library

### DIFF
--- a/cmake/TestUtils.cmake
+++ b/cmake/TestUtils.cmake
@@ -11,10 +11,7 @@ else()
   set(GTEST_LIBRARIES ${GTEST_BOTH_LIBRARIES})
 endif()
 
-function(build_test SRCFILE LINK_LIBRARIES PREPROC_DEFS)
-  get_filename_component(src_name ${SRCFILE} NAME_WE)
-  set(target "${src_name}")
-  add_executable(${target} ${SRCFILE})
+function(build_test_common target LINK_LIBRARIES)
   if (TARGET gtest)
     add_dependencies(${target} gtest) # make sure gtest is built first
   endif()
@@ -30,6 +27,13 @@ function(build_test SRCFILE LINK_LIBRARIES PREPROC_DEFS)
     ${PROJECT_SOURCE_DIR}
     ${GTEST_INCLUDE_DIRS}
     )
+endfunction(build_test_common)
+
+function(build_test SRCFILE LINK_LIBRARIES PREPROC_DEFS)
+  get_filename_component(src_name ${SRCFILE} NAME_WE)
+  set(target "${src_name}")
+  add_executable(${target} ${SRCFILE})
+  build_test_common(${target} "${LINK_LIBRARIES}")
   target_compile_definitions(
     ${target}
     PUBLIC
@@ -37,3 +41,10 @@ function(build_test SRCFILE LINK_LIBRARIES PREPROC_DEFS)
     )
   add_test(${target} ${target})
 endfunction(build_test)
+
+function(build_test_library SRCFILE LINK_LIBRARIES)
+  get_filename_component(src_name ${SRCFILE} NAME_WE)
+  set(target "${src_name}")
+  add_library(${target} ${SRCFILE})
+  build_test_common(${target} "${LINK_LIBRARIES}")
+endfunction(build_test_library)

--- a/flashlight/app/asr/CMakeLists.txt
+++ b/flashlight/app/asr/CMakeLists.txt
@@ -57,6 +57,9 @@ include(${CMAKE_CURRENT_LIST_DIR}/decoder/CMakeLists.txt)
 # Runtime
 include(${CMAKE_CURRENT_LIST_DIR}/runtime/CMakeLists.txt)
 
+# Augmentation
+include(${CMAKE_CURRENT_LIST_DIR}/augmentation/CMakeLists.txt)
+
 # ----------------------------- Binaries -----------------------------
 add_executable(fl_asr_train ${CMAKE_CURRENT_LIST_DIR}/Train.cpp)
 add_executable(fl_asr_test ${CMAKE_CURRENT_LIST_DIR}/Test.cpp)

--- a/flashlight/app/asr/augmentation/CMakeLists.txt
+++ b/flashlight/app/asr/augmentation/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.10)
+
+# ------------------------- Library -------------------------
+
+add_library(
+  flashlight-app-asr-sfx
+  ${CMAKE_CURRENT_LIST_DIR}/SoundEffect.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/SoundEffectConfig.cpp
+  )
+
+target_link_libraries(
+  flashlight-app-asr-sfx
+  PUBLIC
+  flashlight
+  )

--- a/flashlight/app/asr/test/CMakeLists.txt
+++ b/flashlight/app/asr/test/CMakeLists.txt
@@ -37,3 +37,12 @@ build_test(
   )
 # Runtime
 build_test(${DIR}/runtime/RuntimeTest.cpp ${LIBS} "")
+# Augmentation
+build_test_library(${DIR}/augmentation/SoundTestUtil.cpp "${LIBS}")
+set(SFX_LIBS
+    ${LIBS}
+    SoundTestUtil
+    flashlight-app-asr-sfx
+    )
+build_test(${DIR}/augmentation/SoundEffectTest.cpp "${SFX_LIBS}" "")
+build_test(${DIR}/augmentation/SoundEffectConfigTest.cpp "${SFX_LIBS}" "")

--- a/flashlight/app/asr/test/augmentation/SoundTestUtil.h
+++ b/flashlight/app/asr/test/augmentation/SoundTestUtil.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <vector>
+#include <cstdlib>
 
 namespace fl {
 namespace app {


### PR DESCRIPTION
    flashlight/app/asr/test/SoundEffectTest 
    [==========] Running 6 tests from 1 test suite.
    [----------] Global test environment set-up.
    [----------] 6 tests from SoundEffect
    [ RUN      ] SoundEffect.ClampAmplitude
    [       OK ] SoundEffect.ClampAmplitude (13 ms)
    [ RUN      ] SoundEffect.NormalizeTooHigh
    [       OK ] SoundEffect.NormalizeTooHigh (13 ms)
    [ RUN      ] SoundEffect.NoNormalizeTooLow
    [       OK ] SoundEffect.NoNormalizeTooLow (0 ms)
    [ RUN      ] SoundEffect.NormalizeTooLow
    [       OK ] SoundEffect.NormalizeTooLow (13 ms)
    [ RUN      ] SoundEffect.Amplify
    [       OK ] SoundEffect.Amplify (1370 ms)
    [ RUN      ] SoundEffect.SfxChain
    [       OK ] SoundEffect.SfxChain (15 ms)
    [----------] 6 tests from SoundEffect (1424 ms total)

    [----------] Global test environment tear-down
    [==========] 6 tests from 1 test suite ran. (1424 ms total)
    [  PASSED  ] 6 tests.`
