### PR TITLE
add additive noise sound effect

### DIFF
--- a/flashlight/app/asr/augmentation/AdditiveNoise.cpp
+++ b/flashlight/app/asr/augmentation/AdditiveNoise.cpp
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "flashlight/app/asr/augmentation/AdditiveNoise.h"
+
+#include <algorithm>
+#include <cmath>
+#include <fstream>
+#include <sstream>
+
+#include "flashlight/app/asr/data/Sound.h"
+
+namespace fl {
+namespace app {
+namespace asr {
+namespace sfx {
+
+std::string AdditiveNoise::Config::prettyString() const {
+  std::stringstream ss;
+  ss << "AdditiveNoise::Config{ratio=" << ratio << " minSnr_=" << minSnr_
+     << " maxSnr_=" << maxSnr_ << " nClipsMin_=" << nClipsMin_ << " nClipsMax_"
+     << nClipsMax_ << " listFilePath_=" << listFilePath_
+     << " dsetRndPolicy_=" << randomPolicyToString(dsetRndPolicy_)
+     << " randomSeed_=" << randomSeed_ << '}';
+  return ss.str();
+}
+
+std::string AdditiveNoise::prettyString() const {
+  std::stringstream ss;
+  ss << "AdditiveNoise{config={" << conf_.prettyString() << '}'
+     << " datasetRandomiser_={" << datasetRandomiser_->prettyString() << "}";
+  return ss.str();
+};
+
+AdditiveNoise::AdditiveNoise(const AdditiveNoise::Config& config)
+    : conf_(config),
+      randomEngine_(config.randomSeed_),
+      uniformDistribution_(0, std::numeric_limits<int>::max()),
+      randomNumClipsPerUtterance_(config.nClipsMin_, config.nClipsMax_),
+      randomSnr_(config.minSnr_, config.maxSnr_) {
+  std::ifstream listFile(conf_.listFilePath_);
+  if (!listFile) {
+    throw std::runtime_error(
+        "AdditiveNoise failed to open listFilePath_=" + conf_.listFilePath_);
+  }
+  std::vector<std::string> noiseFiles;
+  while (!listFile.eof()) {
+    try {
+      std::string filename;
+      std::getline(listFile, filename);
+      if (!filename.empty()) {
+        noiseFiles.push_back(filename);
+      }
+    } catch (std::exception& ex) {
+      throw std::runtime_error(
+          "AdditiveNoise failed to read listFilePath_=" + conf_.listFilePath_ +
+          " with error=" + ex.what());
+    }
+  }
+
+  DatasetRandomiser<std::string>::Config dsConf;
+  dsConf.policy_ = conf_.dsetRndPolicy_;
+  dsConf.randomSeed_ = conf_.randomSeed_;
+  datasetRandomiser_ = std::make_unique<DatasetRandomiser<std::string>>(
+      dsConf, std::move(noiseFiles));
+}
+
+namespace {
+
+float rootMeanSquare(const std::vector<float>& signal) {
+  float sumOfSquares = 0;
+  for (float i : signal) {
+    sumOfSquares += i * i;
+  }
+  return std::sqrt(sumOfSquares / static_cast<float>(signal.size()));
+}
+
+// Interval range is like that of a C loop. Inclusive of first and exclusive of
+// second. {0,0}, {10,10} are empty intervals.
+using Interval = std::pair<int, int>;
+int intervalSize(const Interval& interval) {
+  return interval.second - interval.first;
+}
+
+} // namespace
+
+void AdditiveNoise::apply(std::vector<float>& signal) {
+  const float signalRms = rootMeanSquare(signal);
+  const float snr = randomSnr_(randomEngine_);
+
+  // Generate random augmentation interval
+  Interval augInterval;
+  const int numAugSignalSamples =
+      static_cast<double>(signal.size()) * conf_.ratio;
+  if (numAugSignalSamples <= 0) {
+    return;
+  } else if (numAugSignalSamples == signal.size()) {
+    augInterval = {0UL, numAugSignalSamples};
+  } else {
+    const int augStart =
+        (uniformDistribution_(randomEngine_) %
+         (signal.size() - numAugSignalSamples));
+    augInterval = {augStart, augStart + numAugSignalSamples};
+  }
+
+  // Load random number of noise clips.
+  std::vector<std::vector<float>> noiseClips;
+  const int nClips = randomNumClipsPerUtterance_(randomEngine_);
+  while (noiseClips.size() < nClips) {
+    noiseClips.push_back(loadSound<float>(datasetRandomiser_->getRandom()));
+  }
+
+  // Sum the noise clips on the augmentation interval.
+  std::vector<float> mixedNoise(signal.size(), 0.0f);
+  for (const std::vector<float>& curNoise : noiseClips) {
+    int noiseShift = uniformDistribution_(randomEngine_) % curNoise.size();
+
+    for (int j = 0; j < intervalSize(augInterval); ++j) {
+      // tile the noise if shorter then augInterval.
+      mixedNoise.at(augInterval.first + j) =
+          curNoise.at((noiseShift + j) % curNoise.size());
+    }
+  }
+
+  const float noiseRms = rootMeanSquare(mixedNoise);
+  if (noiseRms > 0) {
+    // https://en.wikipedia.org/wiki/Signal-to-noise_ratio
+    const float noiseMult =
+        (signalRms / (noiseRms * std::sqrt(std::pow(10, snr / 20.0))));
+    for (int i = 0; i < signal.size(); ++i) {
+      signal.at(i) += mixedNoise.at(i) * noiseMult;
+    }
+  } else {
+    std::cerr << "AdditiveNoise::apply() invalid noiseRms=" << noiseRms;
+  }
+}
+
+} // namespace sfx
+} // namespace asr
+} // namespace app
+} // namespace fl

--- a/flashlight/app/asr/augmentation/AdditiveNoise.h
+++ b/flashlight/app/asr/augmentation/AdditiveNoise.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "flashlight/app/asr/augmentation/SoundEffect.h"
+
+#include <iostream>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "flashlight/app/asr/augmentation/SoundEffectUtil.h"
+
+namespace fl {
+namespace app {
+namespace asr {
+namespace sfx {
+/**
+ * The additive noise sound effect loads noise files and augments them to the
+ * signal with hyper parameters that are chosen randomly within a configured
+ * range, including:
+ * - number of noise clips that are augmented on the input.
+ * - noise shift. The noise clip is shifted with a random value. This means that
+ * we choose a random index of the noise and start there when adding it to
+ * input. We tile the noise to cover the augmentation interval if it is too
+ * short to do so.
+ * - augmentation interval location. When ratio < 1, an interval of that ratio
+ * of the input is augmented.
+ * - SNR: the noise is added with random SNR. In order to minimize change to the
+ * input we use the following formula. output = input + noise *
+ * rms(signal)/rms(noise) / snrDB. rms(signal) is calculated only on the
+ * augmented interval. rms(noise) is calculated on the sum of all noise clipse
+ * over the augmented interval.
+ */
+class AdditiveNoise : public SoundEffect {
+ public:
+  struct Config {
+    double ratio = 1.0;
+    double minSnr_ = 5;
+    double maxSnr_ = 30;
+    int nClipsMin_ = 0;
+    int nClipsMax_ = 3;
+    std::string listFilePath_;
+    unsigned int randomSeed_ = std::mt19937::default_seed;
+    RandomPolicy dsetRndPolicy_;
+    std::string prettyString() const;
+  };
+
+  explicit AdditiveNoise(const AdditiveNoise::Config& config);
+  ~AdditiveNoise() override = default;
+  void apply(std::vector<float>& signal) override;
+  std::string prettyString() const override;
+
+ private:
+  const AdditiveNoise::Config conf_;
+  std::mt19937 randomEngine_;
+  std::uniform_int_distribution<> uniformDistribution_;
+  std::uniform_int_distribution<> randomNumClipsPerUtterance_;
+  std::uniform_real_distribution<> randomSnr_;
+  std::unique_ptr<DatasetRandomiser<std::string>> datasetRandomiser_;
+};
+
+} // namespace sfx
+} // namespace asr
+} // namespace app
+} // namespace fl

--- a/flashlight/app/asr/augmentation/SoundEffectUtil.cpp
+++ b/flashlight/app/asr/augmentation/SoundEffectUtil.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "flashlight/app/asr/augmentation/SoundEffectUtil.h"
+
+#include <algorithm>
+#include <cmath>
+#include <sstream>
+
+namespace fl {
+namespace app {
+namespace asr {
+namespace sfx {
+
+std::string randomPolicyToString(RandomPolicy policy) {
+  switch (policy) {
+    case RandomPolicy::WITH_REPLACEMENT:
+      return "with_replacment";
+    case RandomPolicy::WITHOUT_REPLACEMENT:
+      return "without_replacment";
+    default:
+      throw std::invalid_argument("PolicyToString() invalid policy");
+  }
+}
+
+RandomPolicy stringToRandomPolicy(const std::string& policy) {
+  if (policy == "with_replacment") {
+    return RandomPolicy::WITH_REPLACEMENT;
+  } else if (policy == "without_replacment") {
+    return RandomPolicy::WITHOUT_REPLACEMENT;
+  } else {
+    throw std::invalid_argument("StringToPolicy() invalid policy=" + policy);
+  }
+}
+
+} // namespace sfx
+} // namespace asr
+} // namespace app
+} // namespace fl

--- a/flashlight/app/asr/augmentation/SoundEffectUtil.h
+++ b/flashlight/app/asr/augmentation/SoundEffectUtil.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <random>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace fl {
+namespace app {
+namespace asr {
+namespace sfx {
+
+enum RandomPolicy { WITH_REPLACEMENT, WITHOUT_REPLACEMENT };
+std::string randomPolicyToString(RandomPolicy policy);
+RandomPolicy stringToRandomPolicy(const std::string& policy);
+
+template <typename T>
+class DatasetRandomiser {
+ public:
+  struct Config {
+    RandomPolicy policy_ = WITH_REPLACEMENT;
+    unsigned int randomSeed_ = std::mt19937::default_seed;
+    std::string prettyString() const;
+  };
+
+  DatasetRandomiser(
+      const DatasetRandomiser::Config& config,
+      std::vector<T> dataset);
+
+  size_t size() const;
+  const T& getIndex(int index) const;
+  const T& getRandom();
+  std::string prettyString() const;
+
+ private:
+  Config conf_;
+  std::mt19937 randomEngine_;
+  std::uniform_int_distribution<> randomIndex_;
+  std::vector<T> dataset_;
+  std::vector<int> shuffle_;
+  int count_;
+};
+
+template <typename T>
+DatasetRandomiser<T>::DatasetRandomiser(
+    const DatasetRandomiser::Config& config,
+    std::vector<T> dataset)
+    : conf_(config),
+      randomEngine_(conf_.randomSeed_),
+      randomIndex_(0, dataset.size() - 1),
+      dataset_(std::move(dataset)),
+      shuffle_(dataset_.size()),
+      count_(0) {
+  if (conf_.policy_ == WITHOUT_REPLACEMENT) {
+    std::iota(shuffle_.begin(), shuffle_.end(), 0);
+    const int n = shuffle_.size();
+    // custom implementation of shuffle - https://stackoverflow.com/a/51931164
+    for (int i = n; i >= 1; --i) {
+      std::swap(shuffle_[i - 1], shuffle_[randomEngine_() % n]);
+    }
+  }
+}
+
+template <typename T>
+const T& DatasetRandomiser<T>::getIndex(int getIndex) const {
+  return dataset_[getIndex];
+}
+
+template <typename T>
+const T& DatasetRandomiser<T>::getRandom() {
+  if (conf_.policy_ == WITHOUT_REPLACEMENT) {
+    return getIndex(shuffle_[count_++ % shuffle_.size()]);
+  } else {
+    return getIndex(randomIndex_(randomEngine_));
+  }
+}
+
+template <typename T>
+size_t DatasetRandomiser<T>::size() const {
+  return dataset_.size();
+}
+
+template <typename T>
+std::string DatasetRandomiser<T>::prettyString() const {
+  std::stringstream ss;
+  ss << "DatasetRandomiser{conf_=" << conf_.prettyString()
+     << " dataset_.size()=" << dataset_.size() << " count_=" << count_ << "}";
+  return ss.str();
+}
+
+template <typename T>
+std::string DatasetRandomiser<T>::Config::prettyString() const {
+  return "DatasetRandomiser::Config{policy_=" + randomPolicyToString(policy_) +
+      " randomSeed_=" + std::to_string(randomSeed_) + "}";
+}
+
+} // namespace sfx
+} // namespace asr
+} // namespace app
+} // namespace fl

--- a/flashlight/app/asr/test/augmentation/AdditiveNoiseTest.cpp
+++ b/flashlight/app/asr/test/augmentation/AdditiveNoiseTest.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "flashlight/app/asr/augmentation/AdditiveNoise.h"
+#include "flashlight/app/asr/data/Sound.h"
+#include "flashlight/app/asr/test/augmentation/SoundTestUtil.h"
+#include "flashlight/lib/common/System.h"
+
+using namespace ::fl::app::asr::sfx;
+using ::fl::app::asr::saveSound;
+using ::fl::lib::dirCreateRecursive;
+using ::fl::lib::pathsConcat;
+using ::testing::Pointwise;
+
+const size_t sampleRate = 16000;
+
+MATCHER_P(FloatNearPointwise, tol, "Out of range") {
+  return (
+      std::get<0>(arg) > std::get<1>(arg) - tol &&
+      std::get<0>(arg) < std::get<1>(arg) + tol);
+}
+
+/**
+ * Test that noise is applied with correct SNR. The test generates signal and
+ * noise such that RMS of both is 1. The noise application ratio is set to cover
+ * the entire signal. All random ranges are set to zero (min random ==max
+ * random) for deterministic behaviour. After augmentation, the augmentation
+ * noise is extracted by subtracting the original sound from the augmented
+ * found. The test ensure that the extracted noise matches the original noise
+ * considering the SNR value.
+ */
+TEST(AdditiveNoise, Snr) {
+  const std::string tmpDir = std::tmpnam(nullptr);
+  dirCreateRecursive(tmpDir);
+  const std::string listFilePath = pathsConcat(tmpDir, "noise.lst");
+  const std::string noiseFilePath = pathsConcat(tmpDir, "noise.flac");
+
+  const float signalAmplitude = -1.0;
+  const int signalLen = 10;
+  std::vector<float> signal(signalLen, signalAmplitude);
+  const float noiseAmplitude = 1.0;
+  const int noiseLen = 10;
+  std::vector<float> noise(noiseLen, noiseAmplitude);
+
+  saveSound(
+      noiseFilePath,
+      noise,
+      sampleRate,
+      1,
+      fl::app::asr::SoundFormat::FLAC,
+      fl::app::asr::SoundSubFormat::PCM_16);
+
+  // Create test list file
+  {
+    std::ofstream listFile(listFilePath);
+    listFile << noiseFilePath;
+  }
+
+  for (float snr = 1; snr < 30; ++snr) {
+    AdditiveNoise::Config conf;
+    conf.ratio = 1.0;
+    conf.minSnr_ = snr;
+    conf.maxSnr_ = snr;
+    conf.nClipsMin_ = 1;
+    conf.nClipsMax_ = 1;
+    conf.listFilePath_ = listFilePath;
+
+    AdditiveNoise sfx(conf);
+    auto augmented = signal;
+    sfx.apply(augmented);
+
+    const float snrDb = std::sqrt(std::pow(10, snr / 20.0));
+    std::vector<float> extractNoise(augmented.size());
+    for (int i = 0; i < extractNoise.size(); ++i) {
+      extractNoise[i] = (augmented[i] - signal[i]) * snrDb;
+    }
+
+    EXPECT_THAT(extractNoise, Pointwise(FloatNearPointwise(0.1), noise));
+  }
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Summary:
The additive noise sound effect loads noise files and augments them to the signal with hyper parameters that are chosen randomly within a configured range, including:
 - number of noise clips that are augmented on the input.
 - noise shift. The noise clip is shifted with a random value. This means that we choose a random index of the noise and start there when adding it to input. We tile the noise to cover the augmentation interval if it is too short to do so.
 - augmentation interval location. When ratio < 1, an interval of that ratio of the input is augmented.
 - SNR: the noise is added with random SNR. In order to minimize change to the input we use the following formula. output = input + noise rms(signal)/rms(noise) / snrDB. rms(signal) is calculated only on the augmented interval. rms(noise) is calculated on the sum of all noise clipse over the augmented interval.

Differential Revision: D25392097

