### PR TITLE
Fix CBLAS/MKL linking to build-time deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -318,7 +318,7 @@ jobs:
             export CC=/usr/bin/gcc-5 && export CXX=/usr/bin/g++-5
             export MKLROOT=/opt/intel/mkl && export KENLM_ROOT=/root/kenlm
             mkdir -p build && cd build
-            cmake .. -DFL_BACKEND=CPU -DFL_LIBRARIES_USE_CUDA=OFF -DFL_BUILD_TESTS=OFF
+            cmake .. -DFL_BACKEND=CPU -DFL_LIBRARIES_USE_CUDA=OFF
             make -j16 && make install
 
 workflows:

--- a/cmake/TestUtils.cmake
+++ b/cmake/TestUtils.cmake
@@ -13,8 +13,6 @@ if (NOT GTEST_FOUND)
   endif()
 else()
   message(STATUS "gtest found: (include: ${GTEST_INCLUDE_DIRS}, lib: ${GTEST_BOTH_LIBRARIES}")
-  # Try again with a config to make sure there isn't some broken module in the way
-  find_package(GTest CONFIG 1.10.0)
   if (TARGET GTest::GTest)
     # We found the differently-named CMake targets from FindGTest
     if (NOT TARGET GTest::Main)

--- a/flashlight/lib/audio/feature/CMakeLists.txt
+++ b/flashlight/lib/audio/feature/CMakeLists.txt
@@ -58,9 +58,9 @@ target_link_libraries(
   fl-libraries
   PUBLIC
     $<BUILD_INTERFACE:FFTW3::fftw3>
+    $<BUILD_INTERFACE:${CBLAS_LIBRARIES}>
   PRIVATE
     ${OMPLIB}
-    ${CBLAS_LIBRARIES}
   )
 
 target_include_directories(


### PR DESCRIPTION
- Fixes a continuation of the duplicate gtest/gmock target issue in #145
- Fixes the Docker CPU image build -- gives tests access CBLAS/MKL targets when invoked with an empty LD_LIBRARY_PATH as happens in test discovery
- Reenable building CPU tests in CPU CI