### PR TITLE
Prepend unix username to the temporary files generated during unit test

### DIFF
--- a/flashlight/app/asr/test/augmentation/SoundEffectConfigTest.cpp
+++ b/flashlight/app/asr/test/augmentation/SoundEffectConfigTest.cpp
@@ -13,16 +13,6 @@
 #include "flashlight/lib/common/System.h"
 
 using namespace ::fl::app::asr::sfx;
-using ::fl::lib::pathsConcat;
-
-std::string getTmpPath(const std::string& key) {
-  char* user = getenv("USER");
-  std::string userstr = "unknown";
-  if (user != nullptr) {
-    userstr = std::string(user);
-  }
-  return std::string("/tmp/test_") + userstr + key + std::string(".json");
-}
 
 /**
  * Test creation of arbitrary sound effect chain configuration, writing of that
@@ -30,7 +20,7 @@ std::string getTmpPath(const std::string& key) {
  * configured sound effect chain.
  */
 TEST(SoundEffectConfigFile, ReadWriteJson) {
-  const std::string configFile = getTmpPath("sfxConfig");
+  const std::string configFile = fl::lib::getTmpPath("sfxConfig.json");
   // This log line alllows the user to ispect the config file or copy/paste
   // configuration.
   std::cout << "configFile=" << configFile << std::endl;

--- a/flashlight/app/asr/test/criterion/CriterionTest.cpp
+++ b/flashlight/app/asr/test/criterion/CriterionTest.cpp
@@ -12,6 +12,8 @@
 
 #include "flashlight/app/asr/criterion/criterion.h"
 
+#include "flashlight/lib/common/System.h"
+
 using namespace fl;
 using namespace fl::app::asr;
 
@@ -873,7 +875,7 @@ TEST(CriterionTest, AsgSerialization) {
   if (user != nullptr) {
     userstr = std::string(user);
   }
-  const std::string path = "/tmp/" + userstr + "_test.mdl";
+  const std::string path = fl::lib::getTmpPath("test.mdl");
   int N = 500;
 
   auto asg = std::make_shared<AutoSegmentationCriterion>(N);

--- a/flashlight/app/asr/test/criterion/Seq2SeqTest.cpp
+++ b/flashlight/app/asr/test/criterion/Seq2SeqTest.cpp
@@ -12,6 +12,7 @@
 
 #include "flashlight/app/asr/criterion/attention/attention.h"
 #include "flashlight/app/asr/criterion/criterion.h"
+#include "flashlight/lib/common/System.h"
 
 using namespace fl;
 using namespace fl::ext;
@@ -271,7 +272,7 @@ TEST(Seq2SeqTest, Serialization) {
   if (user != nullptr) {
     userstr = std::string(user);
   }
-  const std::string path = "/tmp/" + userstr + "_test.mdl";
+  const std::string path = fl::lib::getTmpPath("test.mdl");
 
   int N = 5, H = 8, B = 1, T = 10, U = 5, maxoutputlen = 100, nAttnRound = 2;
 

--- a/flashlight/app/asr/test/data/ListFileDatasetTest.cpp
+++ b/flashlight/app/asr/test/data/ListFileDatasetTest.cpp
@@ -35,7 +35,7 @@ auto letterToTarget = [](void* data, af::dim4 dims, af::dtype /* unused */) {
 
 TEST(ListFileDatasetTest, LoadData) {
   auto data = getFileContent(pathsConcat(loadPath, "data.lst"));
-  auto rootPath = "/tmp/data.lst";
+  const std::string rootPath = fl::lib::getTmpPath("data.lst");
   std::ofstream out(rootPath);
   for (auto& d : data) {
     replaceAll(d, "<TESTDIR>", loadPath);

--- a/flashlight/app/asr/test/data/SoundTest.cpp
+++ b/flashlight/app/asr/test/data/SoundTest.cpp
@@ -107,7 +107,7 @@ TEST(SoundTest, Stereo) {
 
 TEST(SoundTest, OggReadWrite) {
   auto audiopath = pathsConcat(loadPath, "test_stereo.wav");
-  auto outaudiopath = pathsConcat("/tmp", "test_stereo_out.ogg");
+  const std::string outaudiopath = getTmpPath("test.ogg");
   auto oggaudiopath = pathsConcat(loadPath, "test_stereo.ogg");
   auto info = loadSoundInfo(audiopath);
   auto vecShort = loadSound<short>(audiopath);

--- a/flashlight/app/asr/test/decoder/ConvLmModuleTest.cpp
+++ b/flashlight/app/asr/test/decoder/ConvLmModuleTest.cpp
@@ -74,7 +74,7 @@ TEST(ConvLmModuleTest, SerializationGCNN14BAdaptiveSoftmax) {
   if (user != nullptr) {
     userstr = std::string(user);
   }
-  const std::string path = "/tmp/" + userstr + "_test.mdl";
+  const std::string path = getTmpPath("test.mdl");
   const std::string archfile = pathsConcat(archDir, "gcnn_14B_lm_arch_as.txt");
 
   int nclass = 221452;

--- a/flashlight/app/asr/test/runtime/RuntimeTest.cpp
+++ b/flashlight/app/asr/test/runtime/RuntimeTest.cpp
@@ -21,7 +21,7 @@
 using namespace fl::app::asr;
 
 namespace {
-const std::string kPath = "/tmp/test.bin";
+const std::string kPath = fl::lib::getTmpPath("test.mdl");
 
 bool afEqual(const fl::Variable& a, const fl::Variable& b) {
   if (a.isCalcGrad() != b.isCalcGrad()) {

--- a/flashlight/ext/test/common/SequentialBuilderTest.cpp
+++ b/flashlight/ext/test/common/SequentialBuilderTest.cpp
@@ -48,7 +48,7 @@ TEST(SequentialBuilderTest, Serialization) {
   if (user != nullptr) {
     userstr = std::string(user);
   }
-  const std::string path = "/tmp/" + userstr + "_test.mdl";
+  const std::string path = fl::lib::getTmpPath("test.mdl");
   const std::string archfile = pathsConcat(archDir, "arch.txt");
 
   int C = 1, N = 5, B = 1, T = 10;

--- a/flashlight/fl/test/contrib/modules/ContribSerializationTest.cpp
+++ b/flashlight/fl/test/contrib/modules/ContribSerializationTest.cpp
@@ -15,20 +15,9 @@
 #include "flashlight/fl/contrib/modules/modules.h"
 #include "flashlight/fl/nn/nn.h"
 
+#include "flashlight/lib/common/System.h"
+
 using namespace fl;
-
-namespace {
-
-std::string getTmpPath(const std::string& key) {
-  char* user = getenv("USER");
-  std::string userstr = "unknown";
-  if (user != nullptr) {
-    userstr = std::string(user);
-  }
-  return std::string("/tmp/test_") + userstr + key + std::string(".mdl");
-}
-
-} // namespace
 
 TEST(ModuleTest, ResidualSerialization) {
   std::shared_ptr<Residual> model = std::make_shared<Residual>();
@@ -36,10 +25,11 @@ TEST(ModuleTest, ResidualSerialization) {
   model->add(Linear(6, 6));
   model->add(ReLU());
   model->addShortcut(1, 3);
-  save(getTmpPath("Residual"), model);
+  const std::string path = fl::lib::getTmpPath("Residual.mdl");
+  save(path, model);
 
   std::shared_ptr<Residual> loaded;
-  load(getTmpPath("Residual"), loaded);
+  load(path, loaded);
 
   auto input = Variable(af::randu(12, 10, 3, 4), false);
   auto output = model->forward(input);
@@ -53,10 +43,11 @@ TEST(ModuleTest, AsymmetricConv1DSerialization) {
   int c = 32;
   auto model = std::make_shared<AsymmetricConv1D>(c, c, 5, 1, -1, 0, 1);
 
-  save(getTmpPath("AsymmetricConv1D"), model);
+  const std::string path = fl::lib::getTmpPath("AsymmetricConv1D.mdl");
+  save(path, model);
 
   std::shared_ptr<AsymmetricConv1D> loaded;
-  load(getTmpPath("AsymmetricConv1D"), loaded);
+  load(path, loaded);
 
   auto input = Variable(af::randu(25, 10, c, 4), false);
   auto output = model->forward(input);
@@ -75,10 +66,12 @@ TEST(ModuleTest, TransformerSerialization) {
   auto model = std::make_shared<Transformer>(
     c, c / nheads, c, nheads, timesteps, 0.2, 0.1, false, false);
   model->eval();
-  save(getTmpPath("Transformer"), model);
+
+  const std::string path = fl::lib::getTmpPath("Transformer.mdl");
+  save(path, model);
 
   std::shared_ptr<Transformer> loaded;
-  load(getTmpPath("Transformer"), loaded);
+  load(path, loaded);
   loaded->eval();
 
   auto input = Variable(af::randu(c, timesteps, batchsize, 1), false);
@@ -98,10 +91,12 @@ TEST(ModuleTest, ConformerSerialization) {
   auto model = std::make_shared<Conformer>(
     c, c / nheads, c, nheads, timesteps, 33, 0.2, 0.1);
   model->eval();
-  save(getTmpPath("Conformer"), model);
+
+  const std::string path = fl::lib::getTmpPath("Conformer.mdl");
+  save(path, model);
 
   std::shared_ptr<Conformer> loaded;
-  load(getTmpPath("Conformer"), loaded);
+  load(path, loaded);
   loaded->eval();
 
   auto input = Variable(af::randu(c, timesteps, batchsize, 1), false);
@@ -116,10 +111,11 @@ TEST(ModuleTest, PositionEmbedding) {
   auto model = std::make_shared<PositionEmbedding>(128, 100, 0.1);
   model->eval();
 
-  save(getTmpPath("PositionEmbedding"), model);
+  const std::string path = fl::lib::getTmpPath("PositionEmbedding.mdl");
+  save(path, model);
 
   std::shared_ptr<PositionEmbedding> loaded;
-  load(getTmpPath("PositionEmbedding"), loaded);
+  load(path, loaded);
   loaded->eval();
 
   auto input = Variable(af::randu(128, 10, 5, 1), false);
@@ -133,10 +129,11 @@ TEST(ModuleTest, PositionEmbedding) {
 TEST(ModuleTest, SinusoidalPositionEmbedding) {
   auto model = std::make_shared<SinusoidalPositionEmbedding>(128, 2.);
 
-  save(getTmpPath("SinusoidalPositionEmbedding"), model);
+  const std::string path = fl::lib::getTmpPath("SinusoidalPositionEmbedding.mdl");
+  save(path, model);
 
   std::shared_ptr<SinusoidalPositionEmbedding> loaded;
-  load(getTmpPath("SinusoidalPositionEmbedding"), loaded);
+  load(path, loaded);
 
   auto input = Variable(af::randu(128, 10, 5, 1), false);
   auto output = model->forward({input});
@@ -150,10 +147,11 @@ TEST(ModuleTest, AdaptiveEmbedding) {
   std::vector<int> cutoff = {5, 10, 25};
   auto model = std::make_shared<AdaptiveEmbedding>(128, cutoff);
 
-  save(getTmpPath("AdaptiveEmbedding"), model);
+  const std::string path = fl::lib::getTmpPath("AdaptiveEmbedding.mdl");
+  save(path, model);
 
   std::shared_ptr<AdaptiveEmbedding> loaded;
-  load(getTmpPath("AdaptiveEmbedding"), loaded);
+  load(path, loaded);
 
   std::vector<int> values = {1, 4, 6, 2, 12, 7, 4, 21, 22, 18, 3, 23};
   auto input = Variable(af::array(af::dim4(6, 2), values.data()), false);
@@ -168,10 +166,11 @@ TEST(ModuleTest, RawWavSpecAugment) {
   auto model = std::make_shared<RawWavSpecAugment>(0, 1, 1, 0, 0, 0, 1, 2000, 6000, 16000, 20000);
   model->eval();
 
-  save(getTmpPath("RawWavSpecAugment"), model);
+  const std::string path = fl::lib::getTmpPath("RawWavSpecAugment.mdl");
+  save(path, model);
 
   std::shared_ptr<RawWavSpecAugment> loaded;
-  load(getTmpPath("RawWavSpecAugment"), loaded);
+  load(path, loaded);
   loaded->train();
 
   int T = 300;

--- a/flashlight/fl/test/dataset/DatasetTest.cpp
+++ b/flashlight/fl/test/dataset/DatasetTest.cpp
@@ -13,6 +13,8 @@
 
 #include "flashlight/fl/dataset/datasets.h"
 
+#include "flashlight/lib/common/System.h"
+
 using namespace fl;
 
 bool allClose(
@@ -202,7 +204,7 @@ TEST(DatasetTest, FileBlobDataset) {
 
   // check read-write capabilities
   {
-    FileBlobDataset blob("/tmp/data.blob", true, true);
+    FileBlobDataset blob(fl::lib::getTmpPath("data.blob"), true, true);
     fillup(blob);
     check(blob);
     fillup(blob);
@@ -215,7 +217,7 @@ TEST(DatasetTest, FileBlobDataset) {
     blob.writeIndex();
     check(blob);
 
-    FileBlobDataset blobcopy("/tmp/data-copy.blob", true, true);
+    FileBlobDataset blobcopy(fl::lib::getTmpPath("data-copy.blob"), true, true);
     blobcopy.add(blob);
     blobcopy.add(blob, 1048576);
     auto datadup = data;
@@ -249,14 +251,14 @@ TEST(DatasetTest, FileBlobDataset) {
 
   // check everything is correct after re-opening
   {
-    FileBlobDataset blob("/tmp/data.blob");
+    FileBlobDataset blob(fl::lib::getTmpPath("data.blob"));
     check(blob);
   }
 
   // multi-threaded read
   {
     std::vector<std::vector<af::array>> thdata(data.size());
-    auto blob = std::make_shared<FileBlobDataset>("/tmp/data.blob");
+    auto blob = std::make_shared<FileBlobDataset>(fl::lib::getTmpPath("data.blob"));
     std::vector<std::thread> workers;
     const int nworker = 4;
     int nperworker = data.size() / nworker;
@@ -295,7 +297,7 @@ TEST(DatasetTest, FileBlobDataset) {
     }
     {
       auto blob =
-          std::make_shared<FileBlobDataset>("/tmp/data.blob", true, true);
+          std::make_shared<FileBlobDataset>(fl::lib::getTmpPath("data.blob"), true, true);
       std::vector<std::thread> workers;
       const int nworker = 10;
       int nperworker = data.size() / nworker;
@@ -314,7 +316,7 @@ TEST(DatasetTest, FileBlobDataset) {
       blob->writeIndex();
     }
     {
-      auto blob = std::make_shared<FileBlobDataset>("/tmp/data.blob");
+      auto blob = std::make_shared<FileBlobDataset>(fl::lib::getTmpPath("data.blob"));
       ASSERT_EQ(data.size(), blob->size());
       for (int64_t i = 0; i < data.size(); i++) {
         auto blobSample = blob->get(i);

--- a/flashlight/fl/test/optim/OptimBenchmark.cpp
+++ b/flashlight/fl/test/optim/OptimBenchmark.cpp
@@ -12,6 +12,8 @@
 #include "flashlight/fl/common/common.h"
 #include "flashlight/fl/optim/optim.h"
 
+#include "flashlight/lib/common/System.h"
+
 using namespace fl;
 
 #define TIME(FUNC)                                           \

--- a/flashlight/fl/test/optim/OptimTest.cpp
+++ b/flashlight/fl/test/optim/OptimTest.cpp
@@ -10,6 +10,8 @@
 #include "flashlight/fl/common/common.h"
 #include "flashlight/fl/optim/optim.h"
 
+#include "flashlight/lib/common/System.h"
+
 using namespace fl;
 
 TEST(OptimTest, GradNorm) {
@@ -63,7 +65,7 @@ TEST(SerializationTest, OptimizerSerialize) {
   if (user != nullptr) {
     userstr = std::string(user);
   }
-  const std::string path = "/tmp/" + userstr + "_optm";
+  const std::string path = fl::lib::getTmpPath("optmizer.bin");
 
   std::vector<Variable> parameters;
   for (int i = 0; i < 5; i++) {

--- a/flashlight/lib/common/System.cpp
+++ b/flashlight/lib/common/System.cpp
@@ -7,13 +7,13 @@
 
 #include "flashlight/lib/common/System.h"
 
+#include <glob.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 #include <array>
 #include <cstdlib>
 #include <ctime>
 #include <functional>
-#include <glob.h>
-#include <sys/stat.h>
-#include <sys/types.h>
 
 #include "flashlight/lib/common/String.h"
 
@@ -168,6 +168,10 @@ std::string getCurrentTime() {
   std::array<char, 80> buf;
   strftime(buf.data(), buf.size(), "%X", tstruct);
   return std::string(buf.data());
+}
+
+std::string getTmpPath(const std::string& filename) {
+  return "/tmp/fl_tmp_" + getEnvVar("USER", "unknown") + "_" + filename;
 }
 
 std::vector<std::string> getFileContent(const std::string& file) {

--- a/flashlight/lib/common/System.h
+++ b/flashlight/lib/common/System.h
@@ -39,6 +39,8 @@ std::string getCurrentDate();
 
 std::string getCurrentTime();
 
+std::string getTmpPath(const std::string& filename);
+
 std::vector<std::string> getFileContent(const std::string& file);
 
 std::vector<std::string> fileGlob(const std::string& pat);


### PR DESCRIPTION
Summary:
- Prepend unix username to the temporary files generated during unit test.
- Avoid test failures due to developers running tests on a same machine.
- Will leave the OS to delete those files. (I don't want to write deletion logic for them again :/ )

Differential Revision: D25486993

