### PR TITLE
Purge the need for KENLM_ROOT

### DIFF
--- a/.docker/Dockerfile-CPU
+++ b/.docker/Dockerfile-CPU
@@ -14,7 +14,7 @@ RUN mkdir /root/flashlight
 
 COPY . /root/flashlight
 
-RUN export MKLROOT=/opt/intel/mkl && export KENLM_ROOT=/root/kenlm && \
+RUN export MKLROOT=/opt/intel/mkl && \
     cd /root/flashlight && mkdir -p build && \
     cd build && cmake .. -DFL_BACKEND=CPU -DFL_LIBRARIES_USE_CUDA=OFF && \
     make -j$(nproc) && make install

--- a/.docker/Dockerfile-CPU-Base
+++ b/.docker/Dockerfile-CPU-Base
@@ -10,7 +10,7 @@
 # Gloo             b7e0906      (git)
 # libsndfile       4bdd741      (git)
 # FFTW             latest       (apt)
-# KenLM            e47088d      (git)
+# KenLM            d575cb3      (git)
 # GLOG             latest       (apt)
 # gflags           latest       (apt)
 # python           3.6          (apt)
@@ -137,7 +137,7 @@ RUN APT_INSTALL="apt-get install -y --no-install-recommends" && \
 # KenLM https://github.com/kpu/kenlm
 # ------------------------------------------------------------------
     cd /root && git clone https://github.com/kpu/kenlm.git && \
-    cd kenlm && git checkout e47088ddfae810a5ee4c8a9923b5f8071bed1ae8 && \
+    cd kenlm && git checkout 4a277534fd33da323205e6ec256e8fd0ff6ee6fa && \
     mkdir build && cd build && \
     cmake .. -DCMAKE_POSITION_INDEPENDENT_CODE=ON && \
     make -j$(nproc) && make install && \

--- a/.docker/Dockerfile-CUDA
+++ b/.docker/Dockerfile-CUDA
@@ -14,7 +14,7 @@ RUN mkdir /root/flashlight
 
 COPY . /root/flashlight
 
-RUN export MKLROOT=/opt/intel/mkl && export KENLM_ROOT=/root/kenlm && \
+RUN export MKLROOT=/opt/intel/mkl && \
     cd /root/flashlight && mkdir -p build && \ 
     cd build && cmake .. -DFL_BACKEND=CUDA && \
     make -j$(nproc) && make install

--- a/.docker/Dockerfile-CUDA-Base
+++ b/.docker/Dockerfile-CUDA-Base
@@ -10,7 +10,7 @@
 # libsndfile       4bdd741      (git)
 # MKL              2018.4.057   (apt)
 # FFTW             latest       (apt)
-# KenLM            e47088d      (git)
+# KenLM            d575cb3      (git)
 # GLOG             latest       (apt)
 # gflags           latest       (apt)
 # python           3.6          (apt)
@@ -125,7 +125,7 @@ RUN APT_INSTALL="apt-get install -y --no-install-recommends" && \
 # KenLM https://github.com/kpu/kenlm
 # ------------------------------------------------------------------
     cd /root && git clone https://github.com/kpu/kenlm.git && \
-    cd kenlm && git checkout e47088ddfae810a5ee4c8a9923b5f8071bed1ae8 && \
+    cd kenlm && git checkout 4a277534fd33da323205e6ec256e8fd0ff6ee6fa && \
     mkdir build && cd build && \
     cmake .. -DCMAKE_POSITION_INDEPENDENT_CODE=ON && \
     make -j$(nproc) && make install && \ 

--- a/cmake/Findkenlm.cmake
+++ b/cmake/Findkenlm.cmake
@@ -5,8 +5,9 @@
 #
 # The following are set after configuration is done:
 #  KENLM_FOUND
-#  KENLM_REQUIRED_HEADERS - only the needed headers
 #  KENLM_LIBRARIES
+#  KENLM_INCLUDE_DIRS
+#  KENLM_INCLUDE_DIRS_LM
 #
 
 message(STATUS "Looking for KenLM")
@@ -47,8 +48,11 @@ endif()
 
 # find a model header, then get the entire include directory. We need to do this because
 # cmake consistently confuses other things along this path
-find_file(KENLM_MODEL_HEADER
+find_path(KENLM_MODEL_HEADER
   model.hh
+  PATH_SUFFIXES
+    kenlm/lm
+    include/kenlm/lm
   HINTS
     ${KENLM_ROOT}/lm
     ${KENLM_ROOT}/include/kenlm/lm
@@ -66,7 +70,9 @@ get_filename_component(KENLM_INCLUDE_LM ${KENLM_MODEL_HEADER} DIRECTORY)
 get_filename_component(KENLM_INCLUDE_DIR ${KENLM_INCLUDE_LM} DIRECTORY)
 
 set(KENLM_LIBRARIES ${KENLM_LIB} ${KENLM_UTIL_LIB})
-set(KENLM_INCLUDE_DIRS ${KENLM_INCLUDE_DIR} )
+# Some KenLM include paths are relative to [include dir]/kenlm, not just [include dir] (bad)
+set(KENLM_INCLUDE_DIRS_LM ${KENLM_INCLUDE_LM})
+set(KENLM_INCLUDE_DIRS ${KENLM_INCLUDE_DIR})
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(kenlm DEFAULT_MSG KENLM_INCLUDE_DIRS KENLM_LIBRARIES)

--- a/docs/source/bindings/python.rst
+++ b/docs/source/bindings/python.rst
@@ -47,7 +47,6 @@ Once the dependencies are satisfied, simply run from wav2letter root:
 
 .. code-block:: shell
 
-    export KENLM_ROOT=<path/to>/kenlm
     cd bindings/python
     pip install -e .
 
@@ -71,7 +70,6 @@ Build inside docker container
   .. code-block:: shell
 
     pip install torch==1.2.0 packaging==19.1
-    export KENLM_ROOT=/root/kenlm && \
     cd /root/flashlight/bindings/python && pip install -e .
 
 
@@ -80,7 +78,7 @@ Build inside docker container
   .. code-block:: shell
 
     pip install torch==1.2.0 packaging==19.1
-    export USE_CUDA=0 && export KENLM_ROOT=/root/kenlm && \
+    export USE_CUDA=0 && \
     cd /root/flashlight/bindings/python && pip install -e .
 
 Python API

--- a/flashlight/lib/text/decoder/lm/CMakeLists.txt
+++ b/flashlight/lib/text/decoder/lm/CMakeLists.txt
@@ -44,6 +44,7 @@ if (FL_LIBRARIES_USE_KENLM)
     fl-libraries
     PUBLIC
     $<BUILD_INTERFACE:${KENLM_INCLUDE_DIRS}>
+    $<BUILD_INTERFACE:${KENLM_INCLUDE_DIRS_LM}>
     )
 
   target_compile_definitions(

--- a/flashlight/lib/text/decoder/lm/KenLM.cpp
+++ b/flashlight/lib/text/decoder/lm/KenLM.cpp
@@ -9,7 +9,7 @@
 
 #include <stdexcept>
 
-#include <lm/model.hh>
+#include <kenlm/lm/model.hh>
 
 namespace fl {
 namespace lib {

--- a/flashlight/lib/text/decoder/lm/KenLM.h
+++ b/flashlight/lib/text/decoder/lm/KenLM.h
@@ -10,7 +10,7 @@
 #include "flashlight/lib/text/decoder/lm/LM.h"
 #include "flashlight/lib/text/dictionary/Dictionary.h"
 
-#include <lm/model.hh>
+#include <kenlm/lm/model.hh>
 
 namespace fl {
 namespace lib {


### PR DESCRIPTION
Summary:
Remove the requirement to specify `KENLM_ROOT` with most flashlight/w2l builds. Improves how KenLM is found, bumps the commits in the Dockerfiles to use a new KenLM commit that supporst a `make install` that properly places headers in a directory that can easily be found.

Will push new base consolidation images shortly.

Also fix our fbcode build which was failing because warpctc CPU wasn't linked to OpenMP

Differential Revision: D25488319

