### PR TITLE
Implement barrier() in distributed API

### DIFF
--- a/flashlight/fl/distributed/DistributedApi.cpp
+++ b/flashlight/fl/distributed/DistributedApi.cpp
@@ -45,6 +45,15 @@ void allReduceMultiple(
   }
 }
 
+void barrier() {
+  auto arr = af::constant(0, 1);
+  allReduce(arr, false);
+
+  // This hack is to make sure `arr` will not be optimized away from arrayfire
+  // JIT during allreduce().
+  af::sum<float>(arr);
+}
+
 namespace detail {
 /*  static */ DistributedInfo& DistributedInfo::getInstance() {
   static DistributedInfo dinfo;

--- a/flashlight/fl/distributed/DistributedApi.h
+++ b/flashlight/fl/distributed/DistributedApi.h
@@ -126,6 +126,11 @@ void allReduceMultiple(
  */
 void syncDistributed();
 
+/**
+ * Blocks until all CPU processes have reached this routine.
+ */
+void barrier();
+
 /** @} */
 
 namespace detail {


### PR DESCRIPTION
Summary:
- Implement barrier() to sync all CPU threads
- Avoid using MPI_BARRIER(), which will not be effective when MPI is not used in `distributedInit()`.
- Using a hacky `sum()` to avoid the `array` being optimized away by JIT.

Reviewed By: jacobkahn

Differential Revision: D25383931

