### PR TITLE
fix attention for encoder-decoder by adding support of input sizes of encoder

### DIFF
--- a/flashlight/app/asr/Decode.cpp
+++ b/flashlight/app/asr/Decode.cpp
@@ -23,6 +23,7 @@
 #include "flashlight/app/asr/common/Flags.h"
 #include "flashlight/app/asr/criterion/criterion.h"
 #include "flashlight/app/asr/data/FeatureTransforms.h"
+#include "flashlight/app/asr/data/Utils.h"
 #include "flashlight/app/asr/decoder/ConvLmModule.h"
 #include "flashlight/app/asr/decoder/DecodeUtils.h"
 #include "flashlight/app/asr/decoder/Defines.h"
@@ -305,14 +306,9 @@ int main(int argc, char** argv) {
   featParams.useEnergy = false;
   featParams.usePower = false;
   featParams.zeroMeanFrame = false;
-  FeatureType featType = FeatureType::NONE;
-  if (FLAGS_pow) {
-    featType = FeatureType::POW_SPECTRUM;
-  } else if (FLAGS_mfsc) {
-    featType = FeatureType::MFSC;
-  } else if (FLAGS_mfcc) {
-    featType = FeatureType::MFCC;
-  }
+  FeatureType featType =
+      getFeaturesType(FLAGS_features_type, FLAGS_channels, featParams).second;
+
   TargetGenerationConfig targetGenConfig(
       FLAGS_wordseparator,
       FLAGS_sampletarget,
@@ -422,9 +418,8 @@ int main(int argc, char** argv) {
         fl::Variable rawEmission;
         if (usePlugin) {
           rawEmission = localNetwork
-                            ->forward(
-                                {fl::input(sample[kInputIdx]),
-                                 fl::noGrad(sample[kDurationIdx])})
+                            ->forward({fl::input(sample[kInputIdx]),
+                                       fl::noGrad(sample[kDurationIdx])})
                             .front();
         } else {
           rawEmission = fl::ext::forwardSequentialModuleWithPadMask(

--- a/flashlight/app/asr/Test.cpp
+++ b/flashlight/app/asr/Test.cpp
@@ -20,6 +20,7 @@
 #include "flashlight/app/asr/common/Flags.h"
 #include "flashlight/app/asr/criterion/criterion.h"
 #include "flashlight/app/asr/data/FeatureTransforms.h"
+#include "flashlight/app/asr/data/Utils.h"
 #include "flashlight/app/asr/decoder/Defines.h"
 #include "flashlight/app/asr/decoder/TranscriptionUtils.h"
 #include "flashlight/app/asr/runtime/runtime.h"
@@ -138,8 +139,8 @@ int main(int argc, char** argv) {
     LOG(INFO) << "Number of words: " << wordDict.indexSize();
   }
 
-  fl::lib::text::DictionaryMap dicts = {
-      {kTargetIdx, tokenDict}, {kWordIdx, wordDict}};
+  fl::lib::text::DictionaryMap dicts = {{kTargetIdx, tokenDict},
+                                        {kWordIdx, wordDict}};
 
   /* ===================== Create Dataset ===================== */
   fl::lib::audio::FeatureParams featParams(
@@ -156,14 +157,9 @@ int main(int argc, char** argv) {
   featParams.useEnergy = false;
   featParams.usePower = false;
   featParams.zeroMeanFrame = false;
-  FeatureType featType = FeatureType::NONE;
-  if (FLAGS_pow) {
-    featType = FeatureType::POW_SPECTRUM;
-  } else if (FLAGS_mfsc) {
-    featType = FeatureType::MFSC;
-  } else if (FLAGS_mfcc) {
-    featType = FeatureType::MFCC;
-  }
+  FeatureType featType =
+      getFeaturesType(FLAGS_features_type, FLAGS_channels, featParams).second;
+
   TargetGenerationConfig targetGenConfig(
       FLAGS_wordseparator,
       FLAGS_sampletarget,
@@ -291,9 +287,8 @@ int main(int argc, char** argv) {
       fl::Variable rawEmission;
       if (usePlugin) {
         rawEmission = localNetwork
-                          ->forward(
-                              {fl::input(sample[kInputIdx]),
-                               fl::noGrad(sample[kDurationIdx])})
+                          ->forward({fl::input(sample[kInputIdx]),
+                                     fl::noGrad(sample[kDurationIdx])})
                           .front();
       } else {
         rawEmission = fl::ext::forwardSequentialModuleWithPadMask(

--- a/flashlight/app/asr/Train.cpp
+++ b/flashlight/app/asr/Train.cpp
@@ -22,6 +22,7 @@
 #include "flashlight/app/asr/common/Flags.h"
 #include "flashlight/app/asr/criterion/criterion.h"
 #include "flashlight/app/asr/data/FeatureTransforms.h"
+#include "flashlight/app/asr/data/Utils.h"
 #include "flashlight/app/asr/decoder/DecodeMaster.h"
 #include "flashlight/app/asr/decoder/PlGenerator.h"
 #include "flashlight/app/asr/decoder/TranscriptionUtils.h"
@@ -268,18 +269,11 @@ int main(int argc, char** argv) {
   featParams.useEnergy = false;
   featParams.usePower = false;
   featParams.zeroMeanFrame = false;
-  int numFeatures = FLAGS_channels;
-  FeatureType featType = FeatureType::NONE;
-  if (FLAGS_pow) {
-    featType = FeatureType::POW_SPECTRUM;
-    numFeatures = featParams.powSpecFeatSz();
-  } else if (FLAGS_mfsc) {
-    featType = FeatureType::MFSC;
-    numFeatures = featParams.mfscFeatSz();
-  } else if (FLAGS_mfcc) {
-    featType = FeatureType::MFCC;
-    numFeatures = featParams.mfccFeatSz();
-  }
+  auto featureRes =
+      getFeaturesType(FLAGS_features_type, FLAGS_channels, featParams);
+  int numFeatures = featureRes.first;
+  FeatureType featType = featureRes.second;
+
   TargetGenerationConfig targetGenConfig(
       FLAGS_wordseparator,
       FLAGS_sampletarget,
@@ -419,12 +413,11 @@ int main(int argc, char** argv) {
           usePlugin,
           tokenDict,
           wordDict,
-          DecodeMasterTrainOptions{
-              .repLabel = int32_t(FLAGS_replabel),
-              .wordSepIsPartOfToken = FLAGS_usewordpiece,
-              .surround = FLAGS_surround,
-              .wordSep = FLAGS_wordseparator,
-              .targetPadIdx = targetpadVal});
+          DecodeMasterTrainOptions{.repLabel = int32_t(FLAGS_replabel),
+                                   .wordSepIsPartOfToken = FLAGS_usewordpiece,
+                                   .surround = FLAGS_surround,
+                                   .wordSep = FLAGS_wordseparator,
+                                   .targetPadIdx = targetpadVal});
     } else {
       throw std::runtime_error(
           "Other decoders are not supported yet during training");
@@ -807,9 +800,8 @@ int main(int argc, char** argv) {
       fl::Variable output;
       if (usePlugin) {
         output = ntwrk
-                     ->forward(
-                         {fl::input(batch[kInputIdx]),
-                          fl::noGrad(batch[kDurationIdx])})
+                     ->forward({fl::input(batch[kInputIdx]),
+                                fl::noGrad(batch[kDurationIdx])})
                      .front();
       } else {
         output = fl::ext::forwardSequentialModuleWithPadMask(
@@ -873,7 +865,7 @@ int main(int argc, char** argv) {
 
     std::shared_ptr<fl::Module> saug;
     if (FLAGS_saug_start_update >= 0) {
-      if (!(FLAGS_pow || FLAGS_mfsc || FLAGS_mfcc)) {
+      if (FLAGS_features_type == kFeaturesRaw) {
         saug = std::make_shared<fl::RawWavSpecAugment>(
             FLAGS_filterbanks,
             FLAGS_saug_fmaskf,

--- a/flashlight/app/asr/common/Defines.h
+++ b/flashlight/app/asr/common/Defines.h
@@ -54,6 +54,10 @@ constexpr const char* kSeq2SeqCriterion = "seq2seq";
 constexpr const char* kTransformerCriterion = "transformer";
 constexpr const char* kBatchStrategyNone = "none";
 constexpr const char* kBatchStrategyDynamic = "dynamic";
+constexpr const char* kFeaturesMFSC = "mfsc";
+constexpr const char* kFeaturesMFCC = "mfcc";
+constexpr const char* kFeaturesPow = "pow";
+constexpr const char* kFeaturesRaw = "raw";
 constexpr int kTargetPadValue = -1;
 
 // Feature params

--- a/flashlight/app/asr/common/Flags.cpp
+++ b/flashlight/app/asr/common/Flags.cpp
@@ -209,22 +209,13 @@ DEFINE_string(
     "supported ones 'sgd', 'adam', 'rmsprop', 'adadelta', 'adagrad', 'amsgrad', 'novograd'");
 
 // MFCC OPTIONS
-DEFINE_bool(
-    mfcc,
-    false,
-    "Use standard htk mfcc features as input by processing audio "
-    "(if 'mfcc', 'pow', 'mfsc' all false raw wave will be used as input)");
+DEFINE_string(
+    features_type,
+    "mfsc",
+    "Features type to compute input by processing audio. Could be "
+    "mfcc: standard htk mfcc features; mfsc: standard mfsc features; "
+    "pow: standard power spectrum; raw: raw wave");
 DEFINE_int64(mfcccoeffs, 13, "Number of mfcc coefficients");
-DEFINE_bool(
-    pow,
-    false,
-    "Use standard power spectrum as input by processing audio "
-    "(if 'mfcc', 'pow', 'mfsc' all false raw wave will be used as input)");
-DEFINE_bool(
-    mfsc,
-    false,
-    "Use standard mfsc features as input "
-    "(if 'mfcc', 'pow', 'mfsc' all false raw wave will be used as input)");
 DEFINE_double(melfloor, 1.0, "Specify optional mel floor for mfcc/mfsc/pow");
 DEFINE_int64(
     filterbanks,

--- a/flashlight/app/asr/common/Flags.h
+++ b/flashlight/app/asr/common/Flags.h
@@ -122,10 +122,8 @@ DECLARE_string(critoptim);
 
 /* ========== MFCC OPTIONS ========== */
 
-DECLARE_bool(mfcc);
-DECLARE_bool(pow);
+DECLARE_string(features_type);
 DECLARE_int64(mfcccoeffs);
-DECLARE_bool(mfsc);
 DECLARE_double(melfloor);
 DECLARE_int64(filterbanks);
 DECLARE_int64(devwin);

--- a/flashlight/app/asr/criterion/CMakeLists.txt
+++ b/flashlight/app/asr/criterion/CMakeLists.txt
@@ -73,6 +73,7 @@ target_sources(
   ${CMAKE_CURRENT_LIST_DIR}/attention/ContentAttention.cpp
   ${CMAKE_CURRENT_LIST_DIR}/attention/LocationAttention.cpp
   ${CMAKE_CURRENT_LIST_DIR}/attention/MultiHeadAttention.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/attention/Utils.cpp
   # Window
   ${CMAKE_CURRENT_LIST_DIR}/attention/MedianWindow.cpp
   ${CMAKE_CURRENT_LIST_DIR}/attention/SoftPretrainWindow.cpp

--- a/flashlight/app/asr/criterion/attention/AttentionBase.h
+++ b/flashlight/app/asr/criterion/attention/AttentionBase.h
@@ -13,48 +13,80 @@ namespace fl {
 namespace app {
 namespace asr {
 
+/**
+ * Attention base class for encoder-decoder: decoder attends to particular
+ * encoder part
+ */
 class AttentionBase : public fl::Container {
  public:
   AttentionBase() {}
 
-  std::vector<fl::Variable> forward(
-      const std::vector<fl::Variable>& inputs) override {
-    if (inputs.size() != 3 && inputs.size() != 4) {
-      throw std::invalid_argument("Invalid inputs size");
+  std::vector<Variable> forward(const std::vector<Variable>& inputs) override {
+    if (inputs.size() != 3 && inputs.size() != 4 && inputs.size() != 5) {
+      throw std::invalid_argument(
+          "Attention encoder-decoder: Invalid inputs size, should be 3, 4, or 5 arguments");
     }
 
-    auto attnWeight = inputs.size() == 4 ? inputs[3] : fl::Variable();
-    auto res = forward(inputs[0], inputs[1], inputs[2], attnWeight);
+    auto logAttnWeight = inputs.size() == 4 ? inputs[3] : Variable();
+    auto xEncodedSizes = inputs.size() == 5 ? inputs[4] : Variable();
+    auto res = forwardBase(
+        inputs[0], inputs[1], inputs[2], logAttnWeight, xEncodedSizes);
     return {res.first, res.second};
   }
 
-  std::pair<fl::Variable, fl::Variable> operator()(
-      const fl::Variable& state,
-      const fl::Variable& xEncoded,
-      const fl::Variable& prevAttn) {
-    return forward(state, xEncoded, prevAttn);
+  std::pair<Variable, Variable> forward(
+      const Variable& state,
+      const Variable& xEncoded,
+      const Variable& prevAttn) {
+    return forward(
+        state,
+        xEncoded,
+        prevAttn,
+        Variable() /* logAttnWeight */,
+        Variable() /* xEncodedSizes */);
   }
 
-  std::pair<fl::Variable, fl::Variable> forward(
-      const fl::Variable& state,
-      const fl::Variable& xEncoded,
-      const fl::Variable& prevAttn) {
-    return forward(state, xEncoded, prevAttn, fl::Variable() /* attnWeight */);
+  std::pair<Variable, Variable> forward(
+      const Variable& state,
+      const Variable& xEncoded,
+      const Variable& prevAttn,
+      const Variable& logAttnWeight) {
+    return forwardBase(
+        state,
+        xEncoded,
+        prevAttn,
+        logAttnWeight,
+        Variable() /* xEncodedSizes */);
   }
 
-  std::pair<fl::Variable, fl::Variable> operator()(
-      const fl::Variable& state,
-      const fl::Variable& xEncoded,
-      const fl::Variable& prevAttn,
-      const fl::Variable& attnWeight) {
-    return forward(state, xEncoded, prevAttn, attnWeight);
+  virtual std::pair<Variable, Variable> forward(
+      const Variable& state,
+      const Variable& xEncoded,
+      const Variable& prevAttn,
+      const Variable& logAttnWeight,
+      const Variable& xEncodedSizes) {
+    return forwardBase(state, xEncoded, prevAttn, logAttnWeight, xEncodedSizes);
   }
 
-  virtual std::pair<fl::Variable, fl::Variable> forward(
-      const fl::Variable& state,
-      const fl::Variable& xEncoded,
-      const fl::Variable& prevAttn,
-      const fl::Variable& attnWeight) = 0;
+ protected:
+  /**
+   * Forward pass
+   * @param state current decoder state
+   * @param xEncoded encoder output = decoder input
+   * @param prevAttn previous attention vector
+   * @param logAttnWeight attention weights to add: finalAttn =
+   * exp(logAttnWeight + logComputedAttn)
+   * @param xEncodedSizes encoder output actual sizes has (1, B) dims
+   * Returns <attention vector (sum = 1), summary> of sizes
+   * [targetlen, seqlen, batchsize] for attention,
+   * [hiddendim, targetlen, batchsize] for summary
+   */
+  virtual std::pair<Variable, Variable> forwardBase(
+      const Variable& state,
+      const Variable& xEncoded,
+      const Variable& prevAttn,
+      const Variable& logAttnWeight,
+      const Variable& xEncodedSizes) = 0;
 
  private:
   FL_SAVE_LOAD_WITH_BASE(fl::Container)

--- a/flashlight/app/asr/criterion/attention/ContentAttention.cpp
+++ b/flashlight/app/asr/criterion/attention/ContentAttention.cpp
@@ -7,37 +7,42 @@
 
 #include "flashlight/app/asr/criterion/attention/ContentAttention.h"
 #include <cmath>
+#include "flashlight/app/asr/criterion/attention/Utils.h"
 
 namespace fl {
 namespace app {
 namespace asr {
 
-std::pair<Variable, Variable> ContentAttention::forward(
+std::pair<Variable, Variable> ContentAttention::forwardBase(
     const Variable& state,
     const Variable& xEncoded,
     const Variable& /* unused */,
-    const Variable& attnWeight) {
+    const Variable& logAttnWeight,
+    const Variable& xEncodedSizes) {
   int dim = xEncoded.dims(0);
   if (dim != (1 + ((keyValue_) ? 1 : 0)) * state.dims(0)) {
-    throw std::invalid_argument("Invalid dimension for content attention");
+    throw std::invalid_argument(
+        "ContentAttention: Invalid dimension for content attention");
   }
-
   auto keys = keyValue_ ? xEncoded(af::seq(0, dim / 2 - 1)) : xEncoded;
   auto values = keyValue_ ? xEncoded(af::seq(dim / 2, dim - 1)) : xEncoded;
-
   // [targetlen, seqlen, batchsize]
   auto innerProd = matmulTN(state, keys) / std::sqrt(state.dims(0));
-
-  if (!attnWeight.isempty()) {
-    innerProd = innerProd + log(attnWeight);
+  if (!logAttnWeight.isempty()) {
+    if (logAttnWeight.dims() != innerProd.dims()) {
+      throw std::invalid_argument(
+          "ContentAttention: logAttnWeight has wong dimentions");
+    }
+    innerProd = innerProd + logAttnWeight;
   }
-
+  af::array padMask;
+  if (!xEncodedSizes.isempty()) {
+    innerProd = maskAttention(innerProd, xEncodedSizes);
+  }
   // [targetlen, seqlen, batchsize]
   auto attention = softmax(innerProd, 1);
-
   // [hiddendim, targetlen, batchsize]
   auto summaries = matmulNT(values, attention);
-
   return std::make_pair(attention, summaries);
 }
 
@@ -56,11 +61,12 @@ NeuralContentAttention::NeuralContentAttention(int dim, int layers /* = 1 */) {
   add(net);
 }
 
-std::pair<Variable, Variable> NeuralContentAttention::forward(
+std::pair<Variable, Variable> NeuralContentAttention::forwardBase(
     const Variable& state,
     const Variable& xEncoded,
     const Variable& /* unused */,
-    const Variable& attnWeight) {
+    const Variable& logAttnWeight,
+    const Variable& xEncodedSizes) {
   int U = state.dims(1);
   int H = xEncoded.dims(0);
   int T = xEncoded.dims(1);
@@ -68,23 +74,26 @@ std::pair<Variable, Variable> NeuralContentAttention::forward(
 
   auto tileHx = tile(moddims(xEncoded, {H, 1, T, B}), {1, U, 1, 1});
   auto tileHy = tile(moddims(state, {H, U, 1, B}), {1, 1, T, 1});
-
   // [hiddendim, targetlen, seqlen, batchsize]
   auto hidden = tileHx + tileHy;
-
   // [targetlen, seqlen, batchsize]
   auto nnOut = moddims(module(0)->forward({hidden}).front(), {U, T, B});
 
-  if (!attnWeight.isempty()) {
-    nnOut = nnOut + log(attnWeight);
+  if (!logAttnWeight.isempty()) {
+    if (logAttnWeight.dims() != nnOut.dims()) {
+      throw std::invalid_argument(
+          "ContentAttention: logAttnWeight has wong dimentions");
+    }
+    nnOut = nnOut + logAttnWeight;
   }
 
+  if (!xEncodedSizes.isempty()) {
+    nnOut = maskAttention(nnOut, xEncodedSizes);
+  }
   // [targetlen, seqlen, batchsize]
   auto attention = softmax(nnOut, 1);
-
   // [hiddendim, targetlen, batchsize]
   auto summaries = matmulNT(xEncoded, attention);
-
   return std::make_pair(attention, summaries);
 }
 

--- a/flashlight/app/asr/criterion/attention/ContentAttention.h
+++ b/flashlight/app/asr/criterion/attention/ContentAttention.h
@@ -17,11 +17,12 @@ class ContentAttention : public AttentionBase {
  public:
   ContentAttention(bool keyValue = false) : keyValue_(keyValue) {}
 
-  std::pair<fl::Variable, fl::Variable> forward(
-      const fl::Variable& state,
-      const fl::Variable& xEncoded,
-      const fl::Variable& prevAttn,
-      const fl::Variable& attnWeight) override;
+  std::pair<Variable, Variable> forwardBase(
+      const Variable& state,
+      const Variable& xEncoded,
+      const Variable& prevAttn,
+      const Variable& logAttnWeight,
+      const Variable& xEncodedSizes) override;
 
   std::string prettyString() const override;
 
@@ -36,11 +37,12 @@ class NeuralContentAttention : public AttentionBase {
   NeuralContentAttention() {}
   explicit NeuralContentAttention(int dim, int layers = 1);
 
-  std::pair<fl::Variable, fl::Variable> forward(
-      const fl::Variable& state,
-      const fl::Variable& xEncoded,
-      const fl::Variable& prevAttn,
-      const fl::Variable& attnWeight) override;
+  std::pair<Variable, Variable> forwardBase(
+      const Variable& state,
+      const Variable& xEncoded,
+      const Variable& prevAttn,
+      const Variable& logAttnWeight,
+      const Variable& xEncodedSizes) override;
 
   std::string prettyString() const override;
 

--- a/flashlight/app/asr/criterion/attention/LocationAttention.h
+++ b/flashlight/app/asr/criterion/attention/LocationAttention.h
@@ -17,11 +17,12 @@ class SimpleLocationAttention : public AttentionBase {
  public:
   explicit SimpleLocationAttention(int convKernel);
 
-  std::pair<fl::Variable, fl::Variable> forward(
-      const fl::Variable& state,
-      const fl::Variable& xEncoded,
-      const fl::Variable& prevAttn,
-      const fl::Variable& attnWeight) override;
+  std::pair<Variable, Variable> forwardBase(
+      const Variable& state,
+      const Variable& xEncoded,
+      const Variable& prevAttn,
+      const Variable& logAttnWeight,
+      const Variable& xEncodedSizes) override;
 
   std::string prettyString() const override;
 
@@ -35,11 +36,12 @@ class LocationAttention : public AttentionBase {
  public:
   LocationAttention(int encDim, int convKernel);
 
-  std::pair<fl::Variable, fl::Variable> forward(
-      const fl::Variable& state,
-      const fl::Variable& xEncoded,
-      const fl::Variable& prevAttn,
-      const fl::Variable& attnWeight) override;
+  std::pair<Variable, Variable> forwardBase(
+      const Variable& state,
+      const Variable& xEncoded,
+      const Variable& prevAttn,
+      const Variable& logAttnWeight,
+      const Variable& xEncodedSizes) override;
 
   std::string prettyString() const override;
 
@@ -57,11 +59,12 @@ class NeuralLocationAttention : public AttentionBase {
       int convChannel,
       int convKernel);
 
-  std::pair<fl::Variable, fl::Variable> forward(
-      const fl::Variable& state,
-      const fl::Variable& xEncoded,
-      const fl::Variable& prevAttn,
-      const fl::Variable& attnWeight) override;
+  std::pair<Variable, Variable> forwardBase(
+      const Variable& state,
+      const Variable& xEncoded,
+      const Variable& prevAttn,
+      const Variable& logAttnWeight,
+      const Variable& xEncodedSizes) override;
 
   std::string prettyString() const override;
 

--- a/flashlight/app/asr/criterion/attention/MultiHeadAttention.h
+++ b/flashlight/app/asr/criterion/attention/MultiHeadAttention.h
@@ -22,11 +22,12 @@ class MultiHeadContentAttention : public AttentionBase {
       bool keyValue = false,
       bool splitInput = false);
 
-  std::pair<fl::Variable, fl::Variable> forward(
-      const fl::Variable& state,
-      const fl::Variable& xEncoded,
-      const fl::Variable& prevAttn,
-      const fl::Variable& attnWeight) override;
+  std::pair<Variable, Variable> forwardBase(
+      const Variable& state,
+      const Variable& xEncoded,
+      const Variable& prevAttn,
+      const Variable& logAttnWeight,
+      const Variable& xEncodedSizes) override;
 
   std::string prettyString() const override;
 

--- a/flashlight/app/asr/criterion/attention/Utils.cpp
+++ b/flashlight/app/asr/criterion/attention/Utils.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "flashlight/app/asr/criterion/attention/Utils.h"
+
+#include "flashlight/fl/flashlight.h"
+
+namespace fl {
+namespace app {
+namespace asr {
+
+Variable maskAttention(const Variable& input, const Variable& sizes) {
+  int B = input.dims(2);
+  int T = input.dims(1);
+  // xEncodedSizes is (1, B) size
+  af::array inputNotPaddedSize =
+      af::ceil(sizes.array() / af::max<float>(sizes.array()) * T);
+  auto padMask = af::iota(af::dim4(T, 1), af::dim4(1, B)) >=
+      af::tile(inputNotPaddedSize, T, 1);
+  padMask =
+      af::tile(af::moddims(padMask, af::dim4(1, T, B)), input.dims(0), 1, 1);
+
+  af::array output = af::flat(input.array());
+  af::array flatPadMask = af::flat(padMask);
+  auto inputDims = input.dims();
+
+  output(flatPadMask) = kAttentionMaskValue;
+  output = af::moddims(output, inputDims);
+
+  auto gradFunc = [flatPadMask, inputDims](
+                      std::vector<Variable>& inputs,
+                      const Variable& gradOutput) {
+    af::array gradArray = af::flat(gradOutput.array());
+    gradArray(flatPadMask) = 0.;
+    auto grad = Variable(af::moddims(gradArray, inputDims), false);
+    inputs[0].addGrad(grad);
+  };
+  return Variable(output, {input.withoutData()}, gradFunc);
+}
+} // namespace asr
+} // namespace app
+} // namespace fl

--- a/flashlight/app/asr/criterion/attention/Utils.h
+++ b/flashlight/app/asr/criterion/attention/Utils.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "flashlight/app/asr/criterion/attention/Utils.h"
+
+#include "flashlight/fl/flashlight.h"
+
+namespace fl {
+namespace app {
+namespace asr {
+
+// to avoid nans when apply log to these var
+// which cannot be propagated correctly if we set -inf
+constexpr float kAttentionMaskValue = -10000;
+
+fl::Variable maskAttention(
+    const fl::Variable& input,
+    const fl::Variable& sizes);
+} // namespace asr
+} // namespace app
+} // namespace fl

--- a/flashlight/app/asr/data/Utils.cpp
+++ b/flashlight/app/asr/data/Utils.cpp
@@ -77,16 +77,15 @@ std::vector<std::string> wrd2Target(
     bool skipUnk /* = false */) {
   std::vector<std::string> res;
   for (auto w : words) {
-    auto w2tokens =
-        wrd2Target(
-          w,
-          lexicon,
-          dict,
-          wordSeparator,
-          targetSamplePct,
-          fallback2LtrWordSepLeft,
-          fallback2LtrWordSepRight,
-          skipUnk);
+    auto w2tokens = wrd2Target(
+        w,
+        lexicon,
+        dict,
+        wordSeparator,
+        targetSamplePct,
+        fallback2LtrWordSepLeft,
+        fallback2LtrWordSepRight,
+        skipUnk);
 
     if (w2tokens.size() == 0) {
       continue;
@@ -95,6 +94,27 @@ std::vector<std::string> wrd2Target(
   }
   return res;
 }
+
+std::pair<int, FeatureType> getFeaturesType(
+    const std::string& featuresType,
+    int channels,
+    const fl::lib::audio::FeatureParams& featParams) {
+  if (featuresType == kFeaturesPow) {
+    return std::make_pair(
+        featParams.powSpecFeatSz(), FeatureType::POW_SPECTRUM);
+  } else if (featuresType == kFeaturesMFSC) {
+    return std::make_pair(featParams.mfscFeatSz(), FeatureType::MFSC);
+  } else if (featuresType == kFeaturesMFSC) {
+    return std::make_pair(featParams.mfccFeatSz(), FeatureType::MFCC);
+  } else if (featuresType == kFeaturesRaw) {
+    return std::make_pair(channels, FeatureType::NONE);
+  } else {
+    throw std::runtime_error(
+        "Unsupported feature type for audio preprocessing '" + featuresType +
+        "'");
+  }
+}
+
 } // namespace asr
 } // namespace app
 } // namespace fl

--- a/flashlight/app/asr/data/Utils.h
+++ b/flashlight/app/asr/data/Utils.h
@@ -10,6 +10,8 @@
 #include <string>
 #include <vector>
 
+#include "flashlight/app/asr/data/FeatureTransforms.h"
+#include "flashlight/lib/audio/feature/FeatureParams.h"
 #include "flashlight/lib/text/dictionary/Dictionary.h"
 #include "flashlight/lib/text/dictionary/Utils.h"
 
@@ -36,6 +38,12 @@ std::vector<std::string> wrd2Target(
     bool fallback2LtrWordSepLeft = false,
     bool fallback2LtrWordSepRight = false,
     bool skipUnk = false);
+
+std::pair<int, FeatureType> getFeaturesType(
+    const std::string& featuresType,
+    int channels,
+    const fl::lib::audio::FeatureParams& featParams);
+
 } // namespace asr
 } // namespace app
 } // namespace fl

--- a/flashlight/app/asr/runtime/Logger.cpp
+++ b/flashlight/app/asr/runtime/Logger.cpp
@@ -78,7 +78,7 @@ std::string getLogString(
   auto tsztotal = stats[1];
   auto tszmax = stats[3];
   auto iszAvrFrames = isztotal / numsamples;
-  if (FLAGS_pow || FLAGS_mfcc || FLAGS_mfsc) {
+  if (FLAGS_features_type != kFeaturesRaw) {
     iszAvrFrames = iszAvrFrames / FLAGS_framestridems;
   } else {
     iszAvrFrames = iszAvrFrames / 1000 * FLAGS_samplerate;

--- a/flashlight/app/asr/runtime/Logger.h
+++ b/flashlight/app/asr/runtime/Logger.h
@@ -46,7 +46,7 @@ struct TestMeters {
 
 /*
  * Utility function to log results (learning rate, WER, TER, epoch, timing)
- * From gflags it uses FLAGS_batchsize, FLAGS_pow, FLAGS_mfcc, FLAGS_mfsc
+ * From gflags it uses FLAGS_batchsize, FLAGS_features_type
  * FLAGS_framestridems, FLAGS_samplerate
  */
 std::string getLogString(

--- a/flashlight/app/asr/test/criterion/attention/AttentionTest.cpp
+++ b/flashlight/app/asr/test/criterion/attention/AttentionTest.cpp
@@ -10,13 +10,52 @@
 #include <arrayfire.h>
 #include "flashlight/fl/flashlight.h"
 
+#include "flashlight/app/asr/criterion/attention/Utils.h"
 #include "flashlight/app/asr/criterion/attention/attention.h"
 
 using namespace fl;
 using namespace fl::app::asr;
 
 namespace {
-void sequential_test(std::shared_ptr<AttentionBase> attention, int H) {
+using JacobianFunc = std::function<Variable(Variable&)>;
+bool jacobianTestImpl(
+    const JacobianFunc& func,
+    Variable& input,
+    float precision = 1E-5,
+    float perturbation = 1E-4) {
+  auto fwdJacobian =
+      af::array(func(input).elements(), input.elements(), af::dtype::f32);
+
+  for (int i = 0; i < input.elements(); ++i) {
+    af::array orig = input.array()(i);
+    input.array()(i) = orig - perturbation;
+    auto outa = func(input).array();
+
+    input.array()(i) = orig + perturbation;
+    auto outb = func(input).array();
+    input.array()(i) = orig;
+
+    fwdJacobian(af::span, i) =
+        af::moddims((outb - outa), outa.elements()) * 0.5 / perturbation;
+  }
+
+  auto bwdJacobian =
+      af::array(func(input).elements(), input.elements(), af::dtype::f32);
+  auto dout =
+      Variable(af::constant(0, func(input).dims(), func(input).type()), false);
+  for (int i = 0; i < dout.elements(); ++i) {
+    dout.array()(i) = 1; // element in 1D view
+    input.zeroGrad();
+    auto out = func(input);
+    out.backward(dout);
+    bwdJacobian(i, af::span) =
+        af::moddims(input.grad().array(), input.elements());
+    dout.array()(i) = 0;
+  }
+  return allClose(fwdJacobian, bwdJacobian, precision);
+}
+
+void sequentialTest(std::shared_ptr<AttentionBase> attention, int H) {
   int B = 2, T = 10;
 
   Variable encodedx(af::randn(H, T, B), true);
@@ -29,20 +68,57 @@ void sequential_test(std::shared_ptr<AttentionBase> attention, int H) {
     ASSERT_EQ(alphas.dims(), af::dim4(1, T, B));
     ASSERT_EQ(summaries.dims(), af::dim4(H, 1, B));
 
-    auto alphasum = sum(alphas.array(), 1);
+    auto alphasum = af::sum(alphas.array(), 1);
     auto ones = af::constant(1.0, alphasum.dims(), alphasum.type());
     ASSERT_TRUE(allClose(alphasum, ones, 1e-5));
   }
 
-  Variable window_mask = Variable(af::constant(1.0, 1, T, B), false);
+  Variable windowMask = Variable(af::constant(0.0, 1, T, B), false);
   auto alphas1 =
-      std::get<0>(attention->forward(encodedy, encodedx, alphas, window_mask));
+      std::get<0>(attention->forward(encodedy, encodedx, alphas, windowMask));
   auto alphas2 = std::get<0>(attention->forward(encodedy, encodedx, alphas));
   ASSERT_TRUE(allClose(alphas1, alphas2, 1e-6));
 
-  Variable encodedy_invalid(af::randn(H, 10, B), true);
+  Variable encodedyInvalid(af::randn(H, 10, B), true);
   EXPECT_THROW(
-      attention->forward(encodedy_invalid, encodedx, alphas),
+      attention->forward(encodedyInvalid, encodedx, alphas),
+      std::invalid_argument);
+}
+
+void sequentialTestWithPad(std::shared_ptr<AttentionBase> attention, int H) {
+  int B = 2, T = 10;
+
+  Variable encodedx(af::randn(H, T, B), true);
+  std::vector<int> padRaw = {T / 2, T};
+  Variable pad = Variable(af::array(af::dim4(1, B), padRaw.data()), false);
+  Variable encodedy(af::randn(H, 1, B), true);
+
+  Variable alphas, summaries;
+  for (int step = 0; step < 3; ++step) {
+    std::tie(alphas, summaries) =
+        attention->forward(encodedy, encodedx, alphas, Variable(), pad);
+    ASSERT_EQ(alphas.dims(), af::dim4(1, T, B));
+    ASSERT_EQ(summaries.dims(), af::dim4(H, 1, B));
+
+    auto alphasum = af::sum(alphas.array(), 1);
+    auto ones = af::constant(1.0, alphasum.dims(), alphasum.type());
+    ASSERT_TRUE(allClose(alphasum, ones, 1e-5));
+    ASSERT_TRUE(
+        af::count<int>(
+            alphas.array()(af::span, af::seq(T - T / 2, T - 1), 0) == 0) ==
+        T / 2);
+  }
+
+  Variable windowMask = Variable(af::constant(0.0, 1, T, B), false);
+  auto alphas1 = std::get<0>(
+      attention->forward(encodedy, encodedx, alphas, windowMask, pad));
+  auto alphas2 = std::get<0>(
+      attention->forward(encodedy, encodedx, alphas, Variable{}, pad));
+  ASSERT_TRUE(allClose(alphas1, alphas2, 1e-6));
+
+  Variable encodedyInvalid(af::randn(H, 10, B), true);
+  EXPECT_THROW(
+      attention->forward(encodedyInvalid, encodedx, alphas),
       std::invalid_argument);
 }
 
@@ -55,57 +131,97 @@ TEST(AttentionTest, NeuralContentAttention) {
   Variable encodedx(af::randn(H, T, B), true);
   Variable encodedy(af::randn(H, U, B), true);
 
-  Variable alphas, summaries;
-  std::tie(alphas, summaries) = attention(encodedy, encodedx, Variable{});
-  ASSERT_EQ(alphas.dims(), af::dim4(U, T, B));
-  ASSERT_EQ(summaries.dims(), af::dim4(H, U, B));
+  std::vector<int> padRaw = {T / 2, T};
+  Variable pad = Variable(af::array(af::dim4(1, B), padRaw.data()), false);
 
-  auto alphasum = sum(alphas.array(), 1);
-  auto ones = af::constant(1.0, alphasum.dims(), alphasum.type());
-  ASSERT_TRUE(allClose(alphasum, ones, 1e-5));
+  std::vector<Variable> padV = {Variable(), pad};
+  for (auto currentPad : padV) {
+    Variable alphas, summaries;
+    std::tie(alphas, summaries) = attention.forward(
+        encodedy, encodedx, Variable{}, Variable{}, currentPad);
+    ASSERT_EQ(alphas.dims(), af::dim4(U, T, B));
+    ASSERT_EQ(summaries.dims(), af::dim4(H, U, B));
+    if (!currentPad.isempty()) {
+      ASSERT_TRUE(
+          af::count<int>(
+              alphas.array()(af::span, af::seq(T - T / 2, T - 1), 0) == 0) ==
+          T / 2 * U);
+    }
+    auto alphasum = sum(alphas.array(), 1);
+    auto ones = af::constant(1.0, alphasum.dims(), alphasum.type());
+    ASSERT_TRUE(allClose(alphasum, ones, 1e-5));
 
-  Variable window_mask = Variable(af::constant(1.0, U, T, B), false);
-  auto alphas1 = std::get<0>(
-      attention.forward(encodedy, encodedx, Variable{}, window_mask));
-  ASSERT_TRUE(allClose(alphas, alphas1, 1e-6));
+    Variable windowMask = Variable(af::constant(0.0, U, T, B), false);
+    auto alphas1 = std::get<0>(attention.forward(
+        encodedy, encodedx, Variable{}, windowMask, currentPad));
+    ASSERT_TRUE(allClose(alphas, alphas1, 1e-6));
+  }
 }
 
 TEST(AttentionTest, SimpleLocationAttention) {
   int H = 8, K = 5;
-  sequential_test(std::make_shared<SimpleLocationAttention>(K), H);
+  sequentialTest(std::make_shared<SimpleLocationAttention>(K), H);
+  sequentialTestWithPad(std::make_shared<SimpleLocationAttention>(K), H);
 }
 
 TEST(AttentionTest, LocationAttention) {
   int H = 8, K = 5;
-  sequential_test(std::make_shared<LocationAttention>(H, K), H);
+  sequentialTest(std::make_shared<LocationAttention>(H, K), H);
+  sequentialTestWithPad(std::make_shared<LocationAttention>(H, K), H);
 }
 
 TEST(AttentionTest, NeuralLocationAttention) {
   int H = 8, A = 8, C = 5, K = 3;
-  sequential_test(std::make_shared<NeuralLocationAttention>(H, A, C, K), H);
+  sequentialTest(std::make_shared<NeuralLocationAttention>(H, A, C, K), H);
+  sequentialTestWithPad(
+      std::make_shared<NeuralLocationAttention>(H, A, C, K), H);
 }
 
 TEST(AttentionTest, MultiHeadContentAttention) {
   int H = 512, B = 2, T = 10, U = 5, NH = 8;
 
-  for (bool keyValue : {true, false}) {
-    for (bool splitInput : {true, false}) {
-      MultiHeadContentAttention attention(H, NH, keyValue, splitInput);
+  std::vector<int> padRaw = {T / 2, T};
+  Variable pad = Variable(af::array(af::dim4(1, B), padRaw.data()), false);
 
-      auto Hencode = keyValue ? H * 2 : H;
-      Variable encodedx(af::randn(Hencode, T, B), true);
-      Variable encodedy(af::randn(H, U, B), true);
+  std::vector<Variable> padV = {Variable(), pad};
+  for (auto currentPad : padV) {
+    for (bool keyValue : {true, false}) {
+      for (bool splitInput : {true, false}) {
+        MultiHeadContentAttention attention(H, NH, keyValue, splitInput);
 
-      Variable alphas, summaries;
-      std::tie(alphas, summaries) = attention(encodedy, encodedx, Variable{});
-      ASSERT_EQ(alphas.dims(), af::dim4(U * NH, T, B));
-      ASSERT_EQ(summaries.dims(), af::dim4(H, U, B));
+        auto hEncode = keyValue ? H * 2 : H;
+        Variable encodedx(af::randn(hEncode, T, B), true);
+        Variable encodedy(af::randn(H, U, B), true);
 
-      auto alphasum = sum(alphas.array(), 1);
-      auto ones = af::constant(1.0, alphasum.dims(), alphasum.type());
-      ASSERT_TRUE(allClose(alphasum, ones, 1e-5));
+        Variable alphas, summaries;
+        std::tie(alphas, summaries) = attention.forward(
+            encodedy, encodedx, Variable{}, Variable{}, currentPad);
+        ASSERT_EQ(alphas.dims(), af::dim4(U * NH, T, B));
+        ASSERT_EQ(summaries.dims(), af::dim4(H, U, B));
+        if (!currentPad.isempty()) {
+          ASSERT_TRUE(
+              af::count<int>(
+                  alphas.array()(af::span, af::seq(T - T / 2, T - 1), 0) ==
+                  0) == T / 2 * U * NH);
+        }
+
+        auto alphasum = sum(alphas.array(), 1);
+        auto ones = af::constant(1.0, alphasum.dims(), alphasum.type());
+        ASSERT_TRUE(allClose(alphasum, ones, 1e-5));
+      }
     }
   }
+}
+
+TEST(AttentionTest, JacobianMaskAttention) {
+  // CxTxB
+  auto in = Variable(af::randu(10, 9, 5, af::dtype::f32), true);
+  std::vector<int> inpSzRaw = {1, 2, 4, 8, 16};
+  af::array inpSz = af::array(af::dim4(1, inpSzRaw.size()), inpSzRaw.data());
+  auto func_in = [&](Variable& input) {
+    return fl::app::asr::maskAttention(input, fl::Variable(inpSz, false));
+  };
+  ASSERT_TRUE(jacobianTestImpl(func_in, in, 2e-4));
 }
 
 int main(int argc, char** argv) {

--- a/flashlight/app/asr/tools/VoiceActivityDetection-CTC.cpp
+++ b/flashlight/app/asr/tools/VoiceActivityDetection-CTC.cpp
@@ -36,6 +36,7 @@
 #include "flashlight/app/asr/common/Defines.h"
 #include "flashlight/app/asr/criterion/criterion.h"
 #include "flashlight/app/asr/data/FeatureTransforms.h"
+#include "flashlight/app/asr/data/Utils.h"
 #include "flashlight/app/asr/decoder/TranscriptionUtils.h"
 #include "flashlight/app/asr/runtime/runtime.h"
 #include "flashlight/ext/common/SequentialBuilder.h"
@@ -163,18 +164,9 @@ int main(int argc, char** argv) {
   featParams.useEnergy = false;
   featParams.usePower = false;
   featParams.zeroMeanFrame = false;
-  int numFeatures = FLAGS_channels;
-  FeatureType featType = FeatureType::NONE;
-  if (FLAGS_pow) {
-    featType = FeatureType::POW_SPECTRUM;
-    numFeatures = featParams.powSpecFeatSz();
-  } else if (FLAGS_mfsc) {
-    featType = FeatureType::MFSC;
-    numFeatures = featParams.mfscFeatSz();
-  } else if (FLAGS_mfcc) {
-    featType = FeatureType::MFCC;
-    numFeatures = featParams.mfccFeatSz();
-  }
+  FeatureType featType =
+      getFeaturesType(FLAGS_features_type, FLAGS_channels, featParams).second;
+
   TargetGenerationConfig targetGenConfig(
       FLAGS_wordseparator,
       FLAGS_sampletarget,

--- a/flashlight/app/asr/tools/alignment/Align.cpp
+++ b/flashlight/app/asr/tools/alignment/Align.cpp
@@ -11,6 +11,7 @@
 #include "flashlight/app/asr/common/Defines.h"
 #include "flashlight/app/asr/criterion/criterion.h"
 #include "flashlight/app/asr/data/FeatureTransforms.h"
+#include "flashlight/app/asr/data/Utils.h"
 #include "flashlight/app/asr/runtime/runtime.h"
 #include "flashlight/app/asr/tools/alignment/Utils.h"
 #include "flashlight/ext/common/SequentialBuilder.h"
@@ -141,18 +142,9 @@ int main(int argc, char** argv) {
   featParams.useEnergy = false;
   featParams.usePower = false;
   featParams.zeroMeanFrame = false;
-  int numFeatures = FLAGS_channels;
-  FeatureType featType = FeatureType::NONE;
-  if (FLAGS_pow) {
-    featType = FeatureType::POW_SPECTRUM;
-    numFeatures = featParams.powSpecFeatSz();
-  } else if (FLAGS_mfsc) {
-    featType = FeatureType::MFSC;
-    numFeatures = featParams.mfscFeatSz();
-  } else if (FLAGS_mfcc) {
-    featType = FeatureType::MFCC;
-    numFeatures = featParams.mfccFeatSz();
-  }
+  FeatureType featType =
+      getFeaturesType(FLAGS_features_type, FLAGS_channels, featParams).second;
+
   TargetGenerationConfig targetGenConfig(
       FLAGS_wordseparator,
       FLAGS_sampletarget,

--- a/flashlight/app/asr/tutorial/FinetuneCTC.cpp
+++ b/flashlight/app/asr/tutorial/FinetuneCTC.cpp
@@ -21,6 +21,7 @@
 #include "flashlight/app/asr/common/Defines.h"
 #include "flashlight/app/asr/criterion/criterion.h"
 #include "flashlight/app/asr/data/FeatureTransforms.h"
+#include "flashlight/app/asr/data/Utils.h"
 #include "flashlight/app/asr/decoder/TranscriptionUtils.h"
 #include "flashlight/app/asr/runtime/runtime.h"
 #include "flashlight/ext/common/DistributedUtils.h"
@@ -177,18 +178,11 @@ int main(int argc, char** argv) {
   featParams.useEnergy = false;
   featParams.usePower = false;
   featParams.zeroMeanFrame = false;
-  int numFeatures = FLAGS_channels;
-  FeatureType featType = FeatureType::NONE;
-  if (FLAGS_pow) {
-    featType = FeatureType::POW_SPECTRUM;
-    numFeatures = featParams.powSpecFeatSz();
-  } else if (FLAGS_mfsc) {
-    featType = FeatureType::MFSC;
-    numFeatures = featParams.mfscFeatSz();
-  } else if (FLAGS_mfcc) {
-    featType = FeatureType::MFCC;
-    numFeatures = featParams.mfccFeatSz();
-  }
+  auto featureRes =
+      getFeaturesType(FLAGS_features_type, FLAGS_channels, featParams);
+  int numFeatures = featureRes.first;
+  FeatureType featType = featureRes.second;
+
   TargetGenerationConfig targetGenConfig(
       FLAGS_wordseparator,
       FLAGS_sampletarget,

--- a/flashlight/app/asr/tutorial/InferenceCTC.cpp
+++ b/flashlight/app/asr/tutorial/InferenceCTC.cpp
@@ -16,6 +16,7 @@
 #include "flashlight/app/asr/common/Defines.h"
 #include "flashlight/app/asr/data/FeatureTransforms.h"
 #include "flashlight/app/asr/data/Sound.h"
+#include "flashlight/app/asr/data/Utils.h"
 #include "flashlight/app/asr/decoder/DecodeUtils.h"
 #include "flashlight/app/asr/decoder/Defines.h"
 #include "flashlight/app/asr/decoder/TranscriptionUtils.h"
@@ -208,13 +209,23 @@ int main(int argc, char** argv) {
   featParams.useEnergy = false;
   featParams.usePower = false;
   featParams.zeroMeanFrame = false;
-  fl::app::asr::FeatureType featType = fl::app::asr::FeatureType::NONE;
-  if (networkFlags["pow"] == "true") {
-    featType = fl::app::asr::FeatureType::POW_SPECTRUM;
-  } else if (networkFlags["mfsc"] == "true") {
-    featType = fl::app::asr::FeatureType::MFSC;
-  } else if (networkFlags["mfcc"] == "true") {
-    featType = fl::app::asr::FeatureType::MFCC;
+  fl::app::asr::FeatureType featType;
+  if (networkFlags.find("features_type") != networkFlags.end()) {
+    featType = fl::app::asr::getFeaturesType(
+                   networkFlags["features_type"], 1, featParams)
+                   .second;
+  } else {
+    // old models
+    if (networkFlags["pow"] == "true") {
+      featType = fl::app::asr::FeatureType::POW_SPECTRUM;
+    } else if (networkFlags["mfsc"] == "true") {
+      featType = fl::app::asr::FeatureType::MFSC;
+    } else if (networkFlags["mfcc"] == "true") {
+      featType = fl::app::asr::FeatureType::MFCC;
+    } else {
+      // raw wave
+      featType = fl::app::asr::FeatureType::NONE;
+    }
   }
   auto inputTransform = fl::app::asr::inputFeatures(
       featParams,


### PR DESCRIPTION
Summary:
Support padding mask for encoder output = decoder input for the attention in encoder-decoder part.
- add extra argument for attention forward, which specifies not padded sizes of encoder output
- if mask is provided set -inf for log attention weights on these position, so after softmax there will be zero at padded positions. Thus decoder will never attend to the padded part of the encoder output
- Assume that extra attention weights provided in forward now in log scale to avoid extra log(exp) computations in the pre-training window. (Pre-training window will be fixed in the next diff to return log scaled attention)
- For now this fix doesn't change s2s models criteria, use the old behaviour for now.

Differential Revision: D25415790

