### PR TITLE
Remove runtime test discovery, other fixes

### DIFF
--- a/cmake/TestUtils.cmake
+++ b/cmake/TestUtils.cmake
@@ -13,8 +13,6 @@ if (NOT GTEST_FOUND)
   endif()
 else()
   message(STATUS "gtest found: (include: ${GTEST_INCLUDE_DIRS}, lib: ${GTEST_BOTH_LIBRARIES}")
-  # Try again with a config to make sure there isn't some broken module in the way
-  find_package(GTest CONFIG 1.10.0)
   if (TARGET GTest::GTest)
     # We found the differently-named CMake targets from FindGTest
     if (NOT TARGET GTest::Main)
@@ -61,9 +59,13 @@ function(build_test)
     PUBLIC
     ${build_test_PREPROC}
     )
-  if (build_test_NO_DISCOVERY)
-    add_test(${target} ${target})
-  else()
-    gtest_discover_tests(${target})
-  endif()
+  # TODO(jacobkahn): investigate and bring back either gtest_discover_tests
+  # or gtest_add_tests once I can figure out what's wrong with the invocation
+  # failing to find dynamically-linked or runtime deps
+  # if (build_test_NO_DISCOVERY)
+  #   add_test(${target} ${target})
+  # else()
+  #   gtest_add_tests(${target})
+  # endif()
+  add_test(${target} ${target})
 endfunction(build_test)

--- a/flashlight/app/lm/CMakeLists.txt
+++ b/flashlight/app/lm/CMakeLists.txt
@@ -41,7 +41,7 @@ target_include_directories(
   flashlight-app-lm
   PUBLIC
   ${GLOG_INCLUDE_DIRS}
-  ${gflags_LIBRARIES}
+  ${gflags_INCLUDE_DIRS}
   )
 # ------------------------ Components ------------------------
 

--- a/flashlight/fl/autograd/CMakeLists.txt
+++ b/flashlight/fl/autograd/CMakeLists.txt
@@ -37,14 +37,8 @@ if (FL_USE_CPU)
 
   target_link_libraries(
     flashlight
-    PUBLIC
-    ${DNNL_LIBRARIES} # also contains MKL or mklml libraries
-    )
-
-  target_include_directories(
-    flashlight
-    PUBLIC
-    ${DNNL_INCLUDE_DIR} # includes MKL headers if found
+    PRIVATE
+    DNNL::dnnl
     )
 endif ()
 


### PR DESCRIPTION
Summary:
`gtest_discover_tests` actually invokes the test binaries to find tests, but it sometimes fails to find things as it should along `LD_LIBRARY_PATH`s, and is quite flakey. Switch to `gtest_add_tests`, which does almost the same thing but statically. We shouldn't be using test fixtures or parameterizations [yet] that are so complicated that the result is any different from discovery.

Also fix some straggler issues that weirdly were never changedin D25409790 (https://github.com/facebookresearch/flashlight/commit/15d4ba0bd0c55271723bc4c344b012d68a57768b).

Reviewed By: tlikhomanenko

Differential Revision: D25507227

