### PR TITLE
Remove KenLM transitive header inclusion

### DIFF
--- a/cmake/flashlightConfig.cmake.in
+++ b/cmake/flashlightConfig.cmake.in
@@ -24,6 +24,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 include(CMakeFindDependencyMacro)
 # Lib dependencies
 find_dependency(OpenMP)
+find_dependency(kenlm)
 find_dependency(Threads)
 find_dependency(FFTW3)
 # Core dependencies

--- a/flashlight/lib/text/decoder/lm/CMakeLists.txt
+++ b/flashlight/lib/text/decoder/lm/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(
 
 if (FL_LIBRARIES_USE_KENLM)
   find_package(kenlm REQUIRED)
+  setup_install_find_module(${CMAKE_MODULE_PATH}/Findkenlm.cmake)
 
   # Required for KenLM to read ARPA files in compressed format
   find_package(LibLZMA)

--- a/flashlight/lib/text/decoder/lm/KenLM.cpp
+++ b/flashlight/lib/text/decoder/lm/KenLM.cpp
@@ -15,6 +15,8 @@ namespace fl {
 namespace lib {
 namespace text {
 
+KenLMState::KenLMState() : ken_(std::make_unique<lm::ngram::State>()) {}
+
 KenLM::KenLM(const std::string& path, const Dictionary& usrTknDict) {
   // Load LM
   model_.reset(lm::ngram::LoadVirtual(path.c_str()));

--- a/flashlight/lib/text/decoder/lm/KenLM.h
+++ b/flashlight/lib/text/decoder/lm/KenLM.h
@@ -7,10 +7,25 @@
 
 #pragma once
 
+#include <memory>
+
 #include "flashlight/lib/text/decoder/lm/LM.h"
 #include "flashlight/lib/text/dictionary/Dictionary.h"
 
-#include <kenlm/lm/model.hh>
+// Forward declarations to avoid including KenLM headers
+namespace lm {
+namespace base {
+
+struct Vocabulary;
+struct Model;
+
+} // namespace base
+namespace ngram {
+
+struct State;
+
+} // namespace ngram
+} // namespace lm
 
 namespace fl {
 namespace lib {
@@ -21,11 +36,11 @@ namespace text {
  * indicies and compare functions
  * https://github.com/kpu/kenlm/blob/master/lm/state.hh.
  */
-
 struct KenLMState : LMState {
-  lm::ngram::State ken_;
+  KenLMState();
+  std::unique_ptr<lm::ngram::State> ken_;
   lm::ngram::State* ken() {
-    return &ken_;
+    return ken_.get();
   }
 };
 


### PR DESCRIPTION
Summary:
Including KenLM headers in our headers without forward declarations meant that KenLM headers had to be on the include path of flashlight headers which is... terrible, especially since the way KenLM headers are structured is so nonstandard.

Remove these and forward declare everything so we don't need those to be available when people include flashlight headers. cc chaitan3

Reviewed By: tlikhomanenko

Differential Revision: D25601177

