### PR TITLE
CPU backend revamp, fixes, and test coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,12 +215,17 @@ if (FL_BUILD_CORE)
   target_link_libraries(flashlight PUBLIC ArrayFire::${FL_AF_BACKEND})
 
   # ------------------------ flashlight Core ------------------------
-
   set(FL_CORE_DIR "${FL_ROOT_DIR}/fl")
   include(${FL_CORE_DIR}/CMakeLists.txt)
   set(INSTALLABLE_TARGETS ${INSTALLABLE_TARGETS} flashlight)
   # flashlight core components keep their relative paths with respect to project
   setup_install_headers(${FL_CORE_DIR} ${FL_INSTALL_INC_DIR_HEADER_LOC})
+  target_compile_definitions(flashlight
+    PUBLIC
+    FL_BACKEND_CPU=$<BOOL:${FL_USE_CPU}>
+    FL_BACKEND_CUDA=$<BOOL:${FL_USE_CUDA}>
+    FL_BACKEND_OPENCL=$<BOOL:${FL_USE_OPENCL}>
+    )
 
   # ------------------------ Extensions ------------------------
   set(FL_EXT_DIR "${FL_ROOT_DIR}/ext")

--- a/cmake/FindGloo.cmake
+++ b/cmake/FindGloo.cmake
@@ -6,13 +6,15 @@
 find_path(Gloo_INCLUDE_DIR
   NAMES gloo/common/common.h
   DOC "The directory where Gloo includes reside"
-  PATHS GLOO_ROOT
+  PATHS GLOO_ROOT ENV{GLOO_ROOT}
+  PATH_SUFFIXES include
   )
 
 find_library(Gloo_NATIVE_LIBRARY
   NAMES gloo
   DOC "The Gloo library (without CUDA)"
-  PATHS GLOO_ROOT
+  PATHS GLOO_ROOT ENV{GLOO_ROOT}
+  PATH_SUFFIXES lib
   )
 
 find_library(Gloo_CUDA_LIBRARY

--- a/flashlight/app/asr/test/criterion/CriterionTest.cpp
+++ b/flashlight/app/asr/test/criterion/CriterionTest.cpp
@@ -65,6 +65,13 @@ void jacobian_test(
 } // namespace
 
 TEST(CriterionTest, CTCEmptyTarget) {
+  // Subtle - related to memory manager initialization. Will be fixed in a
+  // future version of ArrayFire after which time this can be removed. The test
+  // passes/works properly in isolation.
+  if (FL_BACKEND_CPU) {
+    GTEST_SKIP() << "Skipping test for CPU backend";
+  }
+
   // Non-empty input, Empty target, batchsize > 0
   auto input = Variable(af::array(3, 2, 5), true);
   auto target = Variable(af::array(0, 5), false);

--- a/flashlight/ext/test/common/SequentialBuilderTest.cpp
+++ b/flashlight/ext/test/common/SequentialBuilderTest.cpp
@@ -22,6 +22,9 @@ std::string archDir = "";
 } // namespace
 
 TEST(SequentialBuilderTest, SeqModule) {
+  if (FL_BACKEND_CPU) {
+    GTEST_SKIP() << "Bidirectional RNN not supported";
+  }
   const std::string archfile = pathsConcat(archDir, "arch.txt");
   int nchannel = 4;
   int nclass = 40;
@@ -43,6 +46,9 @@ TEST(SequentialBuilderTest, SeqModule) {
 }
 
 TEST(SequentialBuilderTest, Serialization) {
+  if (FL_BACKEND_CPU) {
+    GTEST_SKIP() << "Bidirectional RNN not supported";
+  }
   char* user = getenv("USER");
   std::string userstr = "unknown";
   if (user != nullptr) {

--- a/flashlight/fl/autograd/Functions.h
+++ b/flashlight/fl/autograd/Functions.h
@@ -802,7 +802,11 @@ Variable gatedlinearunit(const Variable& input, const int dim);
  * \f]
  * where \f$h_t\f$, \f$c_t\f$ are the hidden/cell state at time \f$t\f$,
  * \f$x_t\f$ is the input at time \f$t\f$
-
+ *
+ * \note{cuDNN and oneDNN RNN weights are incompatible since the structure of
+ * the computation is different for each. There is no mapping between weights
+ * from each of those backends.}
+ *
  * @param input Variable of input with shape [input size, batch size, sequence
  * length]
  * @param hiddenState Variable of hidden state with shape [hidden size, batch

--- a/flashlight/fl/autograd/backend/cpu/DnnlUtils.h
+++ b/flashlight/fl/autograd/backend/cpu/DnnlUtils.h
@@ -83,6 +83,8 @@ dnnl::memory dnnlAlignOrdering(
  * For each primitive, passes the corresponding arguments map for that index to
  * the execution stream. The number of primitives and the number of arguments
  * must be equal, else throws.
+ *
+ * Blocks calling thread until the enqueued work has been completed.
  */
 void executeNetwork(
     std::vector<dnnl::primitive>& net,

--- a/flashlight/fl/autograd/backend/cpu/RNN.cpp
+++ b/flashlight/fl/autograd/backend/cpu/RNN.cpp
@@ -6,26 +6,582 @@
  */
 
 #include <stdexcept>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+#include <dnnl.hpp>
 
 #include "flashlight/fl/autograd/Functions.h"
 #include "flashlight/fl/autograd/Variable.h"
+#include "flashlight/fl/autograd/backend/cpu/DnnlUtils.h"
+#include "flashlight/fl/common/DevicePtr.h"
 
 namespace fl {
+namespace {
 
-// TODO, implement RNN, also check to ensure there will appropriate checks to
-// guard the use of half precision in case CPU implementation doesn't support
-// it.
+struct ParsedWeightsAndBias {
+  // First layer - will be empty if inSize == hiddenSize
+  af::array weightsInput1L;
+  af::array weightsHidden1L;
+  af::array bias1L;
+  // All other layers
+  af::array weightsInput;
+  af::array weightsHidden;
+  af::array bias;
+};
+
+// Each gate's weights have dimensions d1 x d2
+af::array reorderLbrGruWeights(int d1, int d2, const af::array weights) {
+  // LBR GRU requires switch the given the r, u, o gate order from cuDNN to u,
+  // r, o as required by oneDNN (this from empirical verification)
+  int weightsSize = d1 * d2;
+  auto weightsFlat = af::flat(weights);
+  return af::join(
+      0,
+      weightsFlat(af::seq(weightsSize, 2 * weightsSize - 1)),
+      weightsFlat(af::seq(weightsSize)),
+      weightsFlat(af::seq(2 * weightsSize, af::end)));
+}
+
+/**
+ * Converts flat cuDNN weights into the corresponding oneDNN DNNL RNN weights.
+ */
+ParsedWeightsAndBias parseWeights(
+    const af::array& weights,
+    RnnMode mode,
+    int numLayers,
+    int directionMult,
+    int inSize,
+    int numGates,
+    int hiddenSize) {
+  ParsedWeightsAndBias out;
+
+  // Per-layer sizes for weightsInput and weightsHidden.
+  // If inSize == hiddenSize, then weightsInputSize == weightsHiddenSize for all
+  // layers, else all but the first layer
+  size_t weightsInputSize1L = directionMult * inSize * numGates * hiddenSize;
+  size_t weightsHiddenSize = directionMult * hiddenSize * numGates * hiddenSize;
+  size_t weightsInputSize = weightsHiddenSize;
+  int lbrGruBias = mode == RnnMode::GRU ? 1 : 0;
+  size_t biasSize =
+      numLayers * directionMult * (numGates + lbrGruBias) * hiddenSize;
+
+  bool firstLayerDifferent = inSize != hiddenSize;
+  // Adjusted if skipping first layer parsing
+  int numWeightsLayers = firstLayerDifferent ? numLayers - 1 : numLayers;
+  int weightsOffset =
+      firstLayerDifferent ? weightsInputSize1L + weightsHiddenSize : 0;
+  // If skipping the first layer, parse then skip over the first layer
+  // weights and parse the remaining layers. Parsing all bias layers is still
+  // fine since biases for each layer have the same size
+  if (firstLayerDifferent) {
+    out.weightsInput1L = weights(af::seq(weightsInputSize1L));
+    out.weightsHidden1L = weights(af::seq(
+        weightsInputSize1L, weightsInputSize1L + weightsHiddenSize - 1));
+
+    if (mode == RnnMode::GRU) {
+      out.weightsInput1L =
+          reorderLbrGruWeights(inSize, hiddenSize, out.weightsInput1L);
+      out.weightsHidden1L =
+          reorderLbrGruWeights(hiddenSize, hiddenSize, out.weightsHidden1L);
+    }
+  }
+
+  auto weightsFlat = af::flat(weights).as(weights.type());
+  // cuDNN RNN weights, for each layer, are arranged with a chunk of
+  // input-hidden weights for each layer followed by a chunk of hidden-hidden
+  // weights for each layer:
+  // {[layers x [hiddenSize, inputSize]], [layers x  [hiddenSize, hiddenSize]]}
+  // Rearrange this to what oneDNN expects (or will reorder if not optimal),
+  // which is numLayers chunks of two chunks containing input-hidden and
+  // hidden-hidden:
+  // {[layers x [[hiddenSize x inSize], [hiddenSize x hiddenSize]]]}
+  // Note that the loop is over the total number of layers in case we're doing a
+  // single-layer operation where input size and hidden size are different but
+  // we'll call another primitive with the output of that first layer as the
+  // input to the next layers
+  auto weightsInput = af::array(0, weights.type());
+  auto weightsHidden = af::array(0, weights.type());
+  af::array weightsFlatOffset = weightsFlat(af::seq(weightsOffset, af::end));
+  // Specifically ignore the first layer's weights, so inSize == hiddenSize
+  for (size_t i = 0; i < numWeightsLayers; ++i) {
+    // number of input/hidden weights
+    // TODO: Will change for bidirectional
+    int chunkSize = hiddenSize * hiddenSize * numGates;
+    // weights per layer
+    int layerChunkSize = chunkSize + chunkSize;
+
+    // Grab input-hidden weights and chunk them together
+    auto inputWeightsChunk = weightsFlatOffset(
+        af::seq(layerChunkSize * i, layerChunkSize * i + chunkSize - 1));
+    // Grab hidden-hidden weights and chunk them together
+    auto inputHiddenChunk = weightsFlatOffset(af::seq(
+        layerChunkSize * i + chunkSize,
+        layerChunkSize * i + chunkSize + chunkSize - 1));
+
+    if (mode == RnnMode::GRU) {
+      inputWeightsChunk =
+          reorderLbrGruWeights(hiddenSize, hiddenSize, inputWeightsChunk);
+      inputHiddenChunk =
+          reorderLbrGruWeights(hiddenSize, hiddenSize, inputHiddenChunk);
+    }
+    weightsInput = af::join(2, weightsInput, inputWeightsChunk);
+    weightsHidden = af::join(2, weightsHidden, inputHiddenChunk);
+  }
+  out.weightsInput = weightsInput;
+  out.weightsHidden = weightsHidden;
+
+  // Reduce the weights to form biases. cuDNN uses two separate bias terms:
+  // https://docs.nvidia.com/deeplearning/cudnn/api/index.html#cudnnRNNMode_t -
+  // oneDNN expects only one bias term. Sum together the coefficients for both
+  // bias terms to get a single bias term for oneDNN. The gradients for each
+  // term can be computed as one since the gradients with respect to the bias
+  // subarrays will simply be half of the computed gradient with oneDNN
+  af::array bias(0, weights.type());
+  size_t biasStartOffset = numLayers * weightsHiddenSize +
+      (numLayers - 1) * weightsInputSize + weightsInputSize1L;
+  // In vanilla RNN modes, the biases can be simply added:
+  // two biases for each bias in fl cuDNN with CUDNN_RNN_DOUBLE_BIAS (default)
+  int numBiases = 2;
+  // First, grab a subarray which contains only both bias terms; then add them
+  af::array biasFlat = weightsFlat(af::seq(biasStartOffset, af::end));
+  // Layout is:
+  // {numLayers x [numBiases x [bias shape]]}
+  for (size_t i = 0; i < numLayers; ++i) {
+    if (mode == RnnMode::GRU) {
+      int lbrGruChunkSize = hiddenSize * 6;
+      // In the case of the LBR GRU, there's an extra bias term which shouldn't
+      // be combined with the first two pairs of biases. Six chunks total.
+      // cuDNN --> oneDNN transformation for ordering:
+      // r1, u1, o, r2, u2, u' --> u1 + u2, r1 + r2, o, u'
+      int base = i * lbrGruChunkSize;
+      // The sum of the following tensors yields the correct bias
+      // u1, r1, o, u'
+      auto biases1 = af::join(
+          0,
+          // u1 -- [1, 2]
+          biasFlat(af::seq(base + hiddenSize * 1, base + hiddenSize * 2 - 1)),
+          // r1 -- [0, 1]
+          biasFlat(af::seq(base + hiddenSize * 0, base + hiddenSize * 1 - 1)),
+          // o -- [2, 3]
+          biasFlat(af::seq(base + hiddenSize * 2, base + hiddenSize * 3 - 1)),
+          // 'u -- [5, 6]
+          biasFlat(af::seq(base + hiddenSize * 5, base + hiddenSize * 6 - 1)));
+      // u2, r2, 0, 0
+      auto biases2 = af::join(
+          0,
+          // u2 -- [4, 5]
+          biasFlat(af::seq(base + hiddenSize * 4, base + hiddenSize * 5 - 1)),
+          // r2 -- [3, 4]
+          biasFlat(af::seq(base + hiddenSize * 3, base + hiddenSize * 4 - 1)),
+          // zeroes to add to o and u'
+          af::constant(0.0, hiddenSize * 2, biasFlat.type()));
+      auto layerBiasCombined = biases1 + biases2;
+      bias = af::join(0, bias, layerBiasCombined);
+    } else {
+      // The number of bias terms in the tensor per-layer
+      int layerStride = biasSize / numLayers * numBiases;
+      auto biases1 = biasFlat(af::seq(
+          layerStride * i, layerStride * i + layerStride / numBiases - 1));
+      auto biases2 = biasFlat(af::seq(
+          layerStride * i + layerStride / numBiases,
+          layerStride * (i + 1) - 1));
+      auto layerBiasCombined = biases1 + biases2;
+      bias = af::join(0, bias, layerBiasCombined);
+    }
+  }
+
+  if (firstLayerDifferent) {
+    out.bias1L = bias(af::seq(biasSize / numLayers));
+    if (numLayers > 1) {
+      // bias for the second --> last layer
+      bias = bias(af::seq(biasSize / numLayers, af::end));
+    }
+  }
+  out.bias = bias;
+
+  // Case for a single layer of different in/hidden size
+  if (firstLayerDifferent && numLayers == 1) {
+    out.weightsInput = out.weightsInput1L;
+    out.weightsHidden = out.weightsHidden1L;
+    out.bias = out.bias1L;
+  }
+
+  return out;
+}
+
+struct RnnResult {
+  dnnl::memory workspace;
+  af::array y; // output
+  af::array hy; // hidden output
+  af::array cy; // cell output
+};
+
+/*
+ * Does forward for a single dnnl RNN primitive
+ */
+RnnResult rnnImpl(
+    const af::array& input,
+    const af::array& hiddenState,
+    const af::array& cellState,
+    const af::array& weightsInput,
+    const af::array& weightsHidden,
+    const af::array& bias,
+    int hiddenSize,
+    int numLayers,
+    RnnMode mode,
+    dnnl::algorithm activation,
+    int numGates,
+    dnnl::rnn_direction direction,
+    int directionMult,
+    dnnl::prop_kind kind,
+    float dropout) {
+  RnnResult result;
+  auto dnnlEngine = detail::DnnlEngine::getInstance().getEngine();
+
+  // Dimensions
+  int inSize = input.dims(0);
+  int batchSize = input.dims(1);
+  int seqLength = input.dims(2);
+  dnnl::memory::dims inputDims = {seqLength, batchSize, inSize};
+  dnnl::memory::dims outputDims = {
+      seqLength, batchSize, hiddenSize * directionMult};
+  auto dType = detail::dnnlMapToType(input.type());
+  int totalLayers = numLayers * directionMult;
+  int outSize = hiddenSize * directionMult;
+  dnnl::memory::dims hDims = {totalLayers, 1, batchSize, hiddenSize};
+  dnnl::memory::dims cDims = {totalLayers, 1, batchSize, hiddenSize};
+  int extraBias = mode == RnnMode::GRU ? 1 : 0; // for LBR GRU
+  dnnl::memory::dims biasDims = {
+      numLayers, directionMult, numGates + extraBias, hiddenSize};
+  // ldigo
+  dnnl::memory::dims weightsInputDims = {
+      numLayers, directionMult, inSize, numGates, hiddenSize};
+  dnnl::memory::dims weightsHiddenDims = {
+      numLayers, directionMult, hiddenSize, numGates, hiddenSize};
+
+  // Out tensors: output (y), hidden state output (hy), cell state output (cy)
+  auto y = af::array(outSize, batchSize, seqLength, input.type());
+  auto hy = af::array(hiddenSize, batchSize, totalLayers, input.type());
+  af::array cy;
+  if (mode == RnnMode::LSTM) {
+    cy = af::array(hy.dims(), input.type());
+  }
+
+  // Memory for forward
+  // input
+  DevicePtr inputPtr(input);
+  auto inputMemDesc =
+      dnnl::memory::desc(inputDims, dType, dnnl::memory::format_tag::tnc);
+  auto inputMemInit = dnnl::memory(inputMemDesc, dnnlEngine, inputPtr.get());
+  // output
+  DevicePtr outputPtr(y);
+  auto outputMemDesc =
+      dnnl::memory::desc(outputDims, dType, dnnl::memory::format_tag::tnc);
+  auto outputMemInit = dnnl::memory(outputMemDesc, dnnlEngine, outputPtr.get());
+  // input hidden state
+  DevicePtr hiddenInPtr(hiddenState);
+  dnnl::memory::desc hiddenInMemDesc;
+  dnnl::memory hiddenInMemInit;
+  if (!hiddenState.isempty()) {
+    hiddenInMemDesc =
+        dnnl::memory::desc(hDims, dType, dnnl::memory::format_tag::ldnc);
+    hiddenInMemInit =
+        dnnl::memory(hiddenInMemDesc, dnnlEngine, hiddenInPtr.get());
+  } else {
+    hiddenInMemDesc = dnnl::memory::desc();
+    hiddenInMemInit = dnnl::memory();
+  }
+  // output hidden state
+  DevicePtr hiddenOutPtr(hy);
+  auto hiddenOutMemDesc =
+      dnnl::memory::desc(hDims, dType, dnnl::memory::format_tag::ldnc);
+  auto hiddenOutMemInit =
+      dnnl::memory(hiddenOutMemDesc, dnnlEngine, hiddenOutPtr.get());
+
+  DevicePtr weightsInputPtr(weightsInput);
+  // TODO(jacobkahn): don't force a format tag - use any and do a reorder based
+  // on the format of the primitive - what it says - like you're supposed to
+  auto weightsInputMemDesc = dnnl::memory::desc(
+      weightsInputDims, dType, dnnl::memory::format_tag::ldigo);
+  auto weightsInputMemInit = dnnl::memory(weightsInputMemDesc, dnnlEngine);
+  // Primitive for reordering input weights: ldgoi --> ldigo
+  auto weightsInputMemRawDesc = dnnl::memory::desc(
+      weightsInputDims, dType, dnnl::memory::format_tag::ldgoi);
+  auto weightsInputMemRawInit =
+      dnnl::memory(weightsInputMemRawDesc, dnnlEngine, weightsInputPtr.get());
+
+  DevicePtr weightsHiddenPtr(weightsHidden);
+  auto weightsHiddenMemDesc = dnnl::memory::desc(
+      weightsHiddenDims, dType, dnnl::memory::format_tag::ldigo);
+  auto weightsHiddenMemInit = dnnl::memory(weightsHiddenMemDesc, dnnlEngine);
+  // Primitive for reordering iter/hidden weights: ldgoi --> ldigo
+  auto weightsHiddenMemRawDesc = dnnl::memory::desc(
+      weightsHiddenDims, dType, dnnl::memory::format_tag::ldgoi);
+  auto weightsHiddenMemRawInit =
+      dnnl::memory(weightsHiddenMemRawDesc, dnnlEngine, weightsHiddenPtr.get());
+
+  DevicePtr biasPtr(bias);
+  auto biasMemDesc =
+      dnnl::memory::desc(biasDims, dType, dnnl::memory::format_tag::ldgo);
+  auto biasMemInit = dnnl::memory(biasMemDesc, dnnlEngine, biasPtr.get());
+
+  // Add arguments
+  std::unordered_map<int, dnnl::memory> rnnFwdArgs = {
+      {DNNL_ARG_SRC_LAYER, inputMemInit},
+      {DNNL_ARG_SRC_ITER, hiddenInMemInit},
+      {DNNL_ARG_WEIGHTS_LAYER, weightsInputMemInit},
+      {DNNL_ARG_WEIGHTS_ITER, weightsHiddenMemInit},
+      {DNNL_ARG_BIAS, biasMemInit},
+      {DNNL_ARG_DST_LAYER, outputMemInit},
+      {DNNL_ARG_DST_ITER, hiddenOutMemInit}};
+
+  // Workspace memory, if needed
+  dnnl::memory workspace;
+  std::vector<dnnl::primitive> network;
+  std::vector<std::unordered_map<int, dnnl::memory>> fwdArgs;
+
+  // reorder input weights
+  network.push_back(dnnl::reorder(weightsInputMemRawInit, weightsInputMemInit));
+  fwdArgs.push_back({{DNNL_ARG_FROM, weightsInputMemRawInit},
+                     {DNNL_ARG_TO, weightsInputMemInit}});
+  // reorder iter weights
+  network.push_back(
+      dnnl::reorder(weightsHiddenMemRawInit, weightsHiddenMemInit));
+  fwdArgs.push_back({{DNNL_ARG_FROM, weightsHiddenMemRawInit},
+                     {DNNL_ARG_TO, weightsHiddenMemInit}});
+
+  // Initialize descriptors
+  if (mode == RnnMode::RELU || mode == RnnMode::TANH) {
+    auto vanilla = dnnl::vanilla_rnn_forward::desc(
+        kind,
+        activation,
+        direction,
+        inputMemDesc,
+        hiddenInMemDesc,
+        weightsInputMemDesc, // weights "layer"
+        weightsHiddenMemDesc, // weights "iter"
+        biasMemDesc,
+        outputMemDesc,
+        hiddenOutMemDesc);
+    auto vanillaPd =
+        dnnl::vanilla_rnn_forward::primitive_desc(vanilla, dnnlEngine);
+    network.push_back(dnnl::vanilla_rnn_forward(vanillaPd));
+    workspace = dnnl::memory(vanillaPd.workspace_desc(), dnnlEngine);
+
+  } else if (mode == RnnMode::LSTM) {
+    // LSTM-only
+    // input cell state
+    // TODO(jacobkahn): function that takes the array and
+    // returns the desciptor and memory -- takes an argument for
+    // which determines whether or not it's ok to return empty
+    // descriptors if the array is empty
+    DevicePtr cellInPtr(cellState);
+    dnnl::memory::desc cellInMemDesc;
+    dnnl::memory cellInMemInit;
+    if (!cellState.isempty()) {
+      cellInMemDesc =
+          dnnl::memory::desc({cDims}, dType, dnnl::memory::format_tag::ldnc);
+      cellInMemInit = dnnl::memory(cellInMemDesc, dnnlEngine, cellInPtr.get());
+    } else {
+      cellInMemDesc = dnnl::memory::desc();
+      cellInMemInit = dnnl::memory();
+    }
+
+    // output cell state
+    DevicePtr cellOutPtr(cy);
+    auto cellOutMemDesc =
+        dnnl::memory::desc({cDims}, dType, dnnl::memory::format_tag::ldnc);
+    auto cellOutMemInit =
+        dnnl::memory(cellOutMemDesc, dnnlEngine, cellOutPtr.get());
+
+    auto lstm = dnnl::lstm_forward::desc(
+        kind,
+        direction,
+        inputMemDesc,
+        hiddenInMemDesc,
+        cellInMemDesc,
+        weightsInputMemDesc, // weights "layer"
+        weightsHiddenMemDesc, // weights "iter"
+        biasMemDesc,
+        outputMemDesc,
+        hiddenOutMemDesc,
+        cellOutMemDesc);
+    auto lstmPd = dnnl::lstm_forward::primitive_desc(lstm, dnnlEngine);
+    network.push_back(dnnl::lstm_forward(lstmPd));
+    workspace = dnnl::memory(lstmPd.workspace_desc(), dnnlEngine);
+    rnnFwdArgs.insert({DNNL_ARG_SRC_ITER_C, cellInMemInit});
+    rnnFwdArgs.insert({DNNL_ARG_DST_ITER_C, cellOutMemInit});
+
+  } else if (mode == RnnMode::GRU) {
+    // Use a linear-before-reset GRU so we can have parity with cuDNN
+    auto gru = dnnl::lbr_gru_forward::desc(
+        kind,
+        direction,
+        inputMemDesc,
+        hiddenInMemDesc,
+        weightsInputMemDesc,
+        weightsHiddenMemDesc,
+        biasMemDesc,
+        outputMemDesc,
+        hiddenOutMemDesc);
+    auto gruPd = dnnl::lbr_gru_forward::primitive_desc(gru, dnnlEngine);
+    network.push_back(dnnl::lbr_gru_forward(gruPd));
+    workspace = dnnl::memory(gruPd.workspace_desc(), dnnlEngine);
+  }
+  rnnFwdArgs.insert({DNNL_ARG_WORKSPACE, workspace});
+  fwdArgs.push_back(rnnFwdArgs);
+
+  detail::executeNetwork(network, fwdArgs);
+
+  result.y = y;
+  result.hy = hy;
+  result.cy = cy;
+  result.workspace = workspace;
+  return result;
+}
+
+} // namespace
+
 std::tuple<Variable, Variable, Variable> rnn(
-    const Variable& /* input */,
-    const Variable& /* hidden_state */,
-    const Variable& /* cell_state */,
-    const Variable& /* weights */,
-    int /* hidden_size */,
-    int /* num_layers */,
-    RnnMode /* mode */,
-    bool /* bidirectional */,
-    float /* dropout */) {
-  throw std::runtime_error("rnn not yet implemented on CPU");
+    const Variable& inputV,
+    const Variable& hiddenStateV,
+    const Variable& cellStateV,
+    const Variable& weightsV,
+    int hiddenSize,
+    int numLayers,
+    RnnMode mode,
+    bool bidirectional,
+    float dropout) {
+  if (dropout > 0.0) {
+    throw std::invalid_argument("dnnl rnn: dropout > 0.0 unsupported");
+  }
+  if (bidirectional) {
+    throw std::invalid_argument("dnnl rnn: bidirectional not yet supported");
+  }
+
+  // Constants
+  auto direction = bidirectional
+      ? dnnl::rnn_direction::bidirectional_concat
+      : dnnl::rnn_direction::unidirectional_left2right;
+  int directionMult = bidirectional ? 2 : 1;
+  auto kind = (inputV.isCalcGrad() || weightsV.isCalcGrad())
+      ? dnnl::prop_kind::forward_training
+      : dnnl::prop_kind::forward_inference;
+  int numGates = 1;
+  auto activation = dnnl::algorithm::undef;
+  switch (mode) {
+    case RnnMode::LSTM:
+      numGates = 4;
+      break;
+    case RnnMode::GRU:
+      numGates = 3;
+      break;
+    case RnnMode::RELU:
+      activation = dnnl::algorithm::eltwise_relu;
+      break;
+    case RnnMode::TANH:
+      activation = dnnl::algorithm::eltwise_tanh;
+    default:
+      break;
+  }
+
+  auto& input = inputV.array();
+  auto& hiddenState = hiddenStateV.array();
+  auto& cellState = cellStateV.array();
+  auto& weights = weightsV.array();
+  int inSize = input.dims(0);
+
+  // In flashlight, all RNN weights are stored as one contiguous tensor, so we
+  // have to parse out the input weights, input biases, hidden weights, and
+  // hidden biases from one tensor. Order doesn't matter since the arrangement
+  // is a black box
+  auto parsedWeights = parseWeights(
+      weights, mode, numLayers, directionMult, inSize, numGates, hiddenSize);
+
+  RnnResult result;
+  // The oneDNN RNN primitive has an API limitation where input size and
+  // hidden size can only differ if the primitive has exactly one layer.
+  // Therefore, for computations for more than one layer, first do the
+  // operation for one layer, which gives an output vector of size [hidden
+  // size, batch size, sequence length * number of directions], then use
+  // that output as the input for layers [2, L]. Since the input size dim 0
+  // is now the hidden size, the primitive can fuse computation for
+  // arbitrarily-many layers.
+  if (inputV.dims(0) == hiddenSize || numLayers == 1) {
+    // Input and hidden size are the same, or we only have one layer, which
+    // means we can call the impl as is and parse weights "normally"
+    result = rnnImpl(
+        input,
+        hiddenState,
+        cellState,
+        parsedWeights.weightsInput,
+        parsedWeights.weightsHidden,
+        parsedWeights.bias,
+        hiddenSize,
+        numLayers,
+        mode,
+        activation,
+        numGates,
+        direction,
+        directionMult,
+        kind,
+        dropout);
+  } else {
+    // We require more than one layer with different input and hidden states -
+    // see the above.
+    // Seek to the first layer's hidden/cell state, weights, and bias
+    RnnResult resultL1 = rnnImpl(
+        input,
+        hiddenState(af::span, af::span, 0),
+        cellState(af::span, af::span, 0),
+        parsedWeights.weightsInput1L,
+        parsedWeights.weightsHidden1L,
+        parsedWeights.bias1L,
+        hiddenSize,
+        1,
+        mode,
+        activation,
+        numGates,
+        direction,
+        directionMult,
+        kind,
+        dropout);
+
+    /* Layers [2..N] */
+    // Seek  past the first layer's hidden/cell state, weights, and bias
+    RnnResult resultL2N = rnnImpl(
+        resultL1.y, // fixme
+        hiddenState(af::span, af::span, af::seq(1, af::end)),
+        cellState(af::span, af::span, af::seq(1, af::end)),
+        parsedWeights.weightsInput,
+        parsedWeights.weightsHidden,
+        parsedWeights.bias,
+        hiddenSize,
+        numLayers - 1, // layers [2..N]
+        mode,
+        activation,
+        numGates,
+        direction,
+        directionMult,
+        kind,
+        dropout);
+
+    result.y = resultL2N.y;
+    result.hy = af::join(2, resultL1.hy, resultL2N.hy);
+    result.cy = af::join(2, resultL1.cy, resultL2N.cy);
+  }
+
+  auto gradFuncUnsupported = [](std::vector<Variable>&, const Variable&) {
+    throw std::runtime_error(
+        "dnnl rnn: Gradient computation not yet supported");
+  };
+
+  return std::make_tuple(
+      Variable(result.y, {}, gradFuncUnsupported),
+      Variable(result.hy, {}, gradFuncUnsupported),
+      Variable(result.cy, {}, gradFuncUnsupported));
 }
 
 } // namespace fl

--- a/flashlight/fl/autograd/backend/cpu/RNN.cpp
+++ b/flashlight/fl/autograd/backend/cpu/RNN.cpp
@@ -248,10 +248,12 @@ RnnResult rnnImpl(
   dnnl::memory::dims outputDims = {
       seqLength, batchSize, hiddenSize * directionMult};
   auto dType = detail::dnnlMapToType(input.type());
-  int totalLayers = numLayers * directionMult;
-  int outSize = hiddenSize * directionMult;
-  dnnl::memory::dims hDims = {totalLayers, 1, batchSize, hiddenSize};
-  dnnl::memory::dims cDims = {totalLayers, 1, batchSize, hiddenSize};
+  int totalLayers = numLayers;
+  int outSize = hiddenSize;
+  dnnl::memory::dims hDims = {
+      totalLayers, directionMult, batchSize, hiddenSize};
+  dnnl::memory::dims cDims = {
+      totalLayers, directionMult, batchSize, hiddenSize};
   int extraBias = mode == RnnMode::GRU ? 1 : 0; // for LBR GRU
   dnnl::memory::dims biasDims = {
       numLayers, directionMult, numGates + extraBias, hiddenSize};

--- a/flashlight/fl/common/Utils.cpp
+++ b/flashlight/fl/common/Utils.cpp
@@ -18,6 +18,12 @@
 
 namespace fl {
 
+bool f16Supported() {
+  return af::isHalfAvailable(af::getDevice()) &&
+      // f16 isn't [yet] supported with the CPU backend per onednn limitations
+      !FL_BACKEND_CPU;
+}
+
 bool allClose(
     const af::array& a,
     const af::array& b,

--- a/flashlight/fl/common/Utils.h
+++ b/flashlight/fl/common/Utils.h
@@ -32,6 +32,12 @@
 namespace fl {
 
 /**
+ * @return if fp16 operations are supported with the current flashlight
+ * configuration.
+ */
+bool f16Supported();
+
+/**
  * Returns true if two arrays are of same type and are element-wise equal within
  * a given tolerance limit.
  *

--- a/flashlight/fl/distributed/CMakeLists.txt
+++ b/flashlight/fl/distributed/CMakeLists.txt
@@ -22,7 +22,7 @@ endif()
 # Gloo
 find_package(Gloo QUIET)
 if (Gloo_FOUND)
-  message(STATUS "Gloo found")
+  message(STATUS "Gloo found (include: ${Gloo_INCLUDE_DIR} lib: ${Gloo_LIBRARY})")
   setup_install_find_module(${CMAKE_MODULE_PATH}/FindGloo.cmake)
 else()
   message(STATUS "Gloo not found")

--- a/flashlight/fl/distributed/backend/cpu/DistributedBackend.cpp
+++ b/flashlight/fl/distributed/backend/cpu/DistributedBackend.cpp
@@ -143,13 +143,20 @@ void allReduceMultiple(
     std::vector<af::array*> arrs,
     bool async /* = false */,
     bool contiguous /* = false */) {
-  throw std::runtime_error(
-      "allReduceMultiple not yet supported for Gloo backend");
+  if (contiguous) {
+    throw std::runtime_error(
+        "contiguous allReduceMultiple is not yet supported for Gloo backend");
+  }
+
+  for (auto& arr : arrs) {
+    allReduce(*arr, async);
+  }
 }
 
 void syncDistributed() {
-  throw std::runtime_error(
-      "Asynchronous allReduce not yet supported for Gloo backend");
+  // NOOP since async distributed operations aren't yet supported with the Gloo
+  // backend
+  return;
 }
 
 int getWorldRank() {

--- a/flashlight/fl/distributed/backend/cuda/DistributedBackend.cpp
+++ b/flashlight/fl/distributed/backend/cuda/DistributedBackend.cpp
@@ -133,7 +133,7 @@ void allReduceMultiple(
     // Use nccl groups to do everything in a single kernel launch
     NCCLCHECK(ncclGroupStart());
     for (auto& arr : arrs) {
-      allReduce(*arr);
+      allReduce(*arr, async);
     }
     NCCLCHECK(ncclGroupEnd());
     return;

--- a/flashlight/fl/test/autograd/AutogradTest.cpp
+++ b/flashlight/fl/test/autograd/AutogradTest.cpp
@@ -244,7 +244,7 @@ TEST(AutogradTest, MultiplyAdd) {
 }
 
 TEST(AutogradTest, AutogradOperatorTypeCompatibility) {
-  if (!af::isHalfAvailable(af::getDevice())) {
+  if (!fl::f16Supported()) {
     GTEST_SKIP() << "Half-precision not supported on this device";
   }
 
@@ -311,7 +311,7 @@ TEST(AutogradTest, AutogradOperatorTypeCompatibility) {
 }
 
 TEST(AutogradTest, CastingAs) {
-  if (!af::isHalfAvailable(af::getDevice())) {
+  if (!fl::f16Supported()) {
     GTEST_SKIP() << "Half-precision not supported on this device";
   }
 
@@ -335,7 +335,7 @@ TEST(AutogradTest, CastingAs) {
 }
 
 TEST(AutogradTest, CastingAsInPlace) {
-  if (!af::isHalfAvailable(af::getDevice())) {
+  if (!fl::f16Supported()) {
     GTEST_SKIP() << "Half-precision not supported on this device";
   }
 
@@ -360,7 +360,7 @@ TEST(AutogradTest, CastingAsInPlace) {
 }
 
 TEST(AutogradTest, CastingAsDifferentGradTypes) {
-  if (!af::isHalfAvailable(af::getDevice())) {
+  if (!fl::f16Supported()) {
     GTEST_SKIP() << "Half-precision not supported on this device";
   }
 
@@ -371,7 +371,7 @@ TEST(AutogradTest, CastingAsDifferentGradTypes) {
 }
 
 TEST(AutogradTest, CastingAsGrad) {
-  if (!af::isHalfAvailable(af::getDevice())) {
+  if (!fl::f16Supported()) {
     GTEST_SKIP() << "Half-precision not supported on this device";
   }
 
@@ -564,7 +564,7 @@ TEST(AutogradTest, TileAs) {
 }
 
 TEST_F(AutogradTestF16, TileAsF16) {
-  if (!af::isHalfAvailable(af::getDevice())) {
+  if (!fl::f16Supported()) {
     GTEST_SKIP() << "Half-precision not supported on this device";
   }
 
@@ -811,7 +811,7 @@ TEST(AutogradTest, Convolve) {
 }
 
 TEST_F(AutogradTestF16, ConvolveF16) {
-  if (!af::isHalfAvailable(af::getDevice())) {
+  if (!fl::f16Supported()) {
     GTEST_SKIP() << "Half-precision not supported on this device";
   }
 
@@ -963,7 +963,7 @@ TEST(AutogradTest, Pooling) {
 }
 
 TEST_F(AutogradTestF16, PoolingF16) {
-  if (!af::isHalfAvailable(af::getDevice())) {
+  if (!fl::f16Supported()) {
     GTEST_SKIP() << "Half-precision not supported on this device";
   }
 
@@ -981,7 +981,7 @@ TEST(AutogradTest, Softmax) {
 }
 
 TEST_F(AutogradTestF16, SoftmaxF16) {
-  if (!af::isHalfAvailable(af::getDevice())) {
+  if (!fl::f16Supported()) {
     GTEST_SKIP() << "Half-precision not supported on this device";
   }
 
@@ -999,7 +999,7 @@ TEST(AutogradTest, LogSoftmax) {
 }
 
 TEST_F(AutogradTestF16, LogSoftmaxF16) {
-  if (!af::isHalfAvailable(af::getDevice())) {
+  if (!fl::f16Supported()) {
     GTEST_SKIP() << "Half-precision not supported on this device";
   }
 
@@ -1081,7 +1081,7 @@ TEST(AutogradTest, Linear) {
 }
 
 TEST_F(AutogradTestF16, LinearF16) {
-  if (!af::isHalfAvailable(af::getDevice())) {
+  if (!fl::f16Supported()) {
     GTEST_SKIP() << "Half-precision not supported on this device";
   }
 
@@ -1316,11 +1316,15 @@ void testRnnImpl(RnnMode mode, af::dtype precision = af::dtype::f64) {
 }
 
 TEST(AutogradTest, Rnn) {
+  if (FL_BACKEND_CPU) {
+    GTEST_SKIP() << "RNN gradient computation not yet supported on CPU";
+  }
+
   testRnnImpl(RnnMode::TANH);
 }
 
 TEST_F(AutogradTestF16, RnnF16) {
-  if (!af::isHalfAvailable(af::getDevice())) {
+  if (!fl::f16Supported()) {
     GTEST_SKIP() << "Half-precision not supported on this device";
   }
 
@@ -1328,10 +1332,14 @@ TEST_F(AutogradTestF16, RnnF16) {
 }
 
 TEST(AutogradTest, Lstm) {
+  if (FL_BACKEND_CPU) {
+    GTEST_SKIP() << "RNN LSTM graident computation not yet supported on CPU";
+  }
+
   testRnnImpl(RnnMode::LSTM);
 }
 TEST_F(AutogradTestF16, LstmF16) {
-  if (!af::isHalfAvailable(af::getDevice())) {
+  if (!fl::f16Supported()) {
     GTEST_SKIP() << "Half-precision not supported on this device";
   }
 
@@ -1339,11 +1347,14 @@ TEST_F(AutogradTestF16, LstmF16) {
 }
 
 TEST(AutogradTest, Gru) {
+  if (FL_BACKEND_CPU) {
+    GTEST_SKIP() << "RNN GRU graident computation not yet supported on CPU";
+  }
   testRnnImpl(RnnMode::GRU);
 }
 
 TEST_F(AutogradTestF16, GruF16) {
-  if (!af::isHalfAvailable(af::getDevice())) {
+  if (!fl::f16Supported()) {
     GTEST_SKIP() << "Half-precision not supported on this device";
   }
 
@@ -1358,7 +1369,7 @@ TEST(AutogradTest, Embedding) {
   ASSERT_TRUE(jacobianTestImpl(func_embed, weights, 1E-5));
 }
 
-TEST(AutogradTest, BatchnormEvalModeOutputSingleAxis) {
+TEST(AutogradTest, BatchNormEvalModeOutputSingleAxis) {
   int feat_dims = 3;
   std::vector<int> featAxes = {2};
   // input order: HWCN, following the docs
@@ -1415,7 +1426,7 @@ TEST(AutogradTest, BatchnormEvalModeOutputSingleAxis) {
   }
 }
 
-TEST(AutogradTest, BatchnormEvalModeOutputMultipleAxis) {
+TEST(AutogradTest, BatchNormEvalModeOutputMultipleAxis) {
   // input order: HWCN, following the docs
   std::vector<int> featAxes = {0, 1, 2};
   auto input = Variable(af::randu(13, 13, 4, 16), false);
@@ -1478,7 +1489,7 @@ TEST(AutogradTest, BatchnormEvalModeOutputMultipleAxis) {
   }
 }
 
-TEST(AutogradTest, BatchnormTrainModeOutputSingleAxis) {
+TEST(AutogradTest, BatchNormTrainModeOutputSingleAxis) {
   int numFeat = 3;
   std::vector<int> featAxes = {2};
   double epsilon = 1E-5;
@@ -1511,7 +1522,7 @@ TEST(AutogradTest, BatchnormTrainModeOutputSingleAxis) {
   ASSERT_TRUE(allClose(out.array(), expectedOut.array(), 1e-5));
 }
 
-TEST(AutogradTest, BatchnormTrainModeOutputMultipleAxis) {
+TEST(AutogradTest, BatchNormTrainModeOutputMultipleAxis) {
   std::vector<int> featAxes = {0, 1, 2};
   auto input = Variable(af::randu(13, 13, 4, 8), true);
 
@@ -1548,7 +1559,7 @@ TEST(AutogradTest, BatchnormTrainModeOutputMultipleAxis) {
   }
 }
 
-TEST(AutogradTest, BatchnormJacobian) {
+TEST(AutogradTest, BatchNormJacobian) {
   // Jacobian Test with  train_mode = true;
 
   int numFeat = 3;
@@ -1558,10 +1569,6 @@ TEST(AutogradTest, BatchnormJacobian) {
   auto runningVar = Variable(af::randu(numFeat, af::dtype::f32), false);
   auto weight = Variable(af::randu(numFeat, af::dtype::f32), true);
   auto bias = Variable(af::randu(numFeat, af::dtype::f32), true);
-
-  // Observation:
-  // When testing on CPU/DNNL backend, precision 1E-2 is a good choice.
-  // Higher precision may lead to testing failure on some elements.
 
   auto func_bn_in = [&](Variable& in) {
     return (batchnorm(
@@ -1582,8 +1589,8 @@ TEST(AutogradTest, BatchnormJacobian) {
   ASSERT_TRUE(jacobianTestImpl(func_bn_bs, bias, 1e-2, 1e-4));
 }
 
-TEST_F(AutogradTestF16, BatchnormJacobianF16) {
-  if (!af::isHalfAvailable(af::getDevice())) {
+TEST_F(AutogradTestF16, BatchNormJacobianF16) {
+  if (!fl::f16Supported()) {
     GTEST_SKIP() << "Half-precision not supported on this device";
   }
 
@@ -1618,7 +1625,7 @@ TEST_F(AutogradTestF16, BatchnormJacobianF16) {
   ASSERT_TRUE(jacobianTestImpl(func_bn_bs, bias, 5e-2, 1e-1));
 }
 
-TEST(AutogradTest, BatchnormJacobianMultipleAxes) {
+TEST(AutogradTest, BatchNormJacobianMultipleAxes) {
   // Jacobian Test with  train_mode = true;
   std::vector<int> featAxes = {0, 1, 2};
   auto input = Variable(af::randu(8, 8, 3, 16, af::dtype::f32), true);
@@ -1630,10 +1637,6 @@ TEST(AutogradTest, BatchnormJacobianMultipleAxes) {
   auto runningVar = Variable(af::randu(nfeatures, af::dtype::f32), false);
   auto weight = Variable(af::randu(nfeatures, af::dtype::f32), true);
   auto bias = Variable(af::randu(nfeatures, af::dtype::f32), true);
-
-  // Observation:
-  // When testing on CPU/DNNL backend, precision 1E-2 is a good choice.
-  // Higher precision may lead to testing failure on some elements.
 
   auto func_bn_in = [&](Variable& in) {
     return (batchnorm(
@@ -1654,8 +1657,8 @@ TEST(AutogradTest, BatchnormJacobianMultipleAxes) {
   ASSERT_TRUE(jacobianTestImpl(func_bn_bs, bias, 1e-2, 1e-3));
 }
 
-TEST_F(AutogradTestF16, BatchnormJacobianMultipleAxesF16) {
-  if (!af::isHalfAvailable(af::getDevice())) {
+TEST_F(AutogradTestF16, BatchNormJacobianMultipleAxesF16) {
+  if (!fl::f16Supported()) {
     GTEST_SKIP() << "Half-precision not supported on this device";
   }
 
@@ -1714,7 +1717,7 @@ TEST(AutogradTest, LayerNormJacobian) {
 }
 
 TEST_F(AutogradTestF16, LayerNormJacobianF16) {
-  if (!af::isHalfAvailable(af::getDevice())) {
+  if (!fl::f16Supported()) {
     GTEST_SKIP() << "Half-precision not supported on this device";
   }
 

--- a/flashlight/fl/test/contrib/modules/ContribModuleTest.cpp
+++ b/flashlight/fl/test/contrib/modules/ContribModuleTest.cpp
@@ -16,7 +16,7 @@ using namespace fl;
 
 namespace {
 
-class ModuleTestF16 : public ::testing::Test {
+class ContribModuleTestF16 : public ::testing::Test {
  protected:
   void SetUp() override {
     // Ensures all operations will be in f16
@@ -30,9 +30,9 @@ class ModuleTestF16 : public ::testing::Test {
 
 } // namespace
 
-TEST(ModuleTest, ResidualFwd) {
+TEST(ContribModuleTest, ResidualFwd) {
   auto conv = Conv2D(30, 50, 9, 7, 2, 3, 3, 2);
-  auto bn = BatchNorm(2, 50);
+  auto bn = BatchNorm(2, 50, 0.0);
   auto relu = ReLU();
 
   int batchsize = 10;
@@ -65,7 +65,7 @@ TEST(ModuleTest, ResidualFwd) {
   ASSERT_TRUE(allClose(output2, output2True));
 }
 
-TEST(ModuleTest, ResidualFwdWithProjection) {
+TEST(ContribModuleTest, ResidualFwdWithProjection) {
   const float proj1FwdScale = 0.24;
   const float proj2FwdScale = 0.5;
   const float linFwdScale = 0.3;
@@ -107,7 +107,7 @@ TEST(ModuleTest, ResidualFwdWithProjection) {
   ASSERT_TRUE(allClose(outputRes, outputTrue));
 }
 
-TEST(ModuleTest, AsymmetricConv1DFwd) {
+TEST(ContribModuleTest, AsymmetricConv1DFwd) {
   int batchsize = 10;
   int timesteps = 120;
   int c = 32;
@@ -130,7 +130,7 @@ TEST(ModuleTest, AsymmetricConv1DFwd) {
   ASSERT_FALSE(allClose(output, outputFuture));
 }
 
-TEST(ModuleTest, TransformerPadMaskFwd) {
+TEST(ContribModuleTest, TransformerPadMaskFwd) {
   int timesteps = 10;
   int c = 4;
   int nheads = 2;
@@ -157,8 +157,7 @@ TEST(ModuleTest, TransformerPadMaskFwd) {
                   Variable(padMask.rows(0, timesteps / 2 - 1).col(0), false)})
           .front();
   auto output2 = tr.forward({input2, Variable(padMask.col(1), false)}).front();
-  ASSERT_TRUE(
-      allClose(output.array()(af::span, af::span, 1), output2.array()));
+  ASSERT_TRUE(allClose(output.array()(af::span, af::span, 1), output2.array()));
   ASSERT_TRUE(
       allClose(outputNoPad.array()(af::span, af::span, 1), output2.array()));
   ASSERT_TRUE(allClose(
@@ -168,8 +167,8 @@ TEST(ModuleTest, TransformerPadMaskFwd) {
       output1.array()));
 }
 
-TEST_F(ModuleTestF16, TransformerPadMaskFwd16) {
-  if (!af::isHalfAvailable(af::getDevice())) {
+TEST_F(ContribModuleTestF16, TransformerPadMaskFwd16) {
+  if (!fl::f16Supported()) {
     GTEST_SKIP() << "Half-precision not supported on this device";
   }
   int timesteps = 10;
@@ -204,8 +203,7 @@ TEST_F(ModuleTestF16, TransformerPadMaskFwd16) {
                   Variable(padMask.rows(0, timesteps / 2 - 1).col(0), false)})
           .front();
   auto output2 = tr.forward({input2, Variable(padMask.col(1), false)}).front();
-  ASSERT_TRUE(
-      allClose(output.array()(af::span, af::span, 1), output2.array()));
+  ASSERT_TRUE(allClose(output.array()(af::span, af::span, 1), output2.array()));
   ASSERT_TRUE(
       allClose(outputNoPad.array()(af::span, af::span, 1), output2.array()));
   ASSERT_TRUE(allClose(
@@ -215,7 +213,7 @@ TEST_F(ModuleTestF16, TransformerPadMaskFwd16) {
       output1.array()));
 }
 
-TEST(ModuleTest, TransformerFwd) {
+TEST(ContribModuleTest, TransformerFwd) {
   int batchsize = 10;
   int timesteps = 120;
   int c = 32;
@@ -233,8 +231,8 @@ TEST(ModuleTest, TransformerFwd) {
   ASSERT_EQ(output[0].dims(2), batchsize);
 }
 
-TEST_F(ModuleTestF16, TransformerFwdF16) {
-  if (!af::isHalfAvailable(af::getDevice())) {
+TEST_F(ContribModuleTestF16, TransformerFwdF16) {
+  if (!fl::f16Supported()) {
     GTEST_SKIP() << "Half-precision not supported on this device";
   }
 
@@ -261,7 +259,7 @@ TEST_F(ModuleTestF16, TransformerFwdF16) {
   ASSERT_EQ(output[0].dims(2), batchsize);
 }
 
-TEST(ModuleTest, ConformerFwd) {
+TEST(ContribModuleTest, ConformerFwd) {
   int batchsize = 10;
   int timesteps = 120;
   int c = 32;
@@ -277,8 +275,8 @@ TEST(ModuleTest, ConformerFwd) {
   ASSERT_EQ(output[0].dims(2), batchsize);
 }
 
-TEST_F(ModuleTestF16, ConformerFwdF16) {
-  if (!af::isHalfAvailable(af::getDevice())) {
+TEST_F(ContribModuleTestF16, ConformerFwdF16) {
+  if (!fl::f16Supported()) {
     GTEST_SKIP() << "Half-precision not supported on this device";
   }
 
@@ -303,7 +301,7 @@ TEST_F(ModuleTestF16, ConformerFwdF16) {
   ASSERT_EQ(output[0].dims(2), batchsize);
 }
 
-TEST(ModuleTest, PositionEmbeddingFwd) {
+TEST(ContribModuleTest, PositionEmbeddingFwd) {
   int batchsize = 10;
   int timesteps = 120;
   int csz = 256;
@@ -320,8 +318,8 @@ TEST(ModuleTest, PositionEmbeddingFwd) {
   ASSERT_FALSE(allClose(output[0], input));
 }
 
-TEST_F(ModuleTestF16, PositionEmbeddingFwdF16) {
-  if (!af::isHalfAvailable(af::getDevice())) {
+TEST_F(ContribModuleTestF16, PositionEmbeddingFwdF16) {
+  if (!fl::f16Supported()) {
     GTEST_SKIP() << "Half-precision not supported on this device";
   }
 
@@ -342,7 +340,7 @@ TEST_F(ModuleTestF16, PositionEmbeddingFwdF16) {
   ASSERT_FALSE(allClose(output[0], input));
 }
 
-TEST(ModuleTest, SinusoidalPositionEmbeddingFwd) {
+TEST(ContribModuleTest, SinusoidalPositionEmbeddingFwd) {
   int batchsize = 10;
   int timesteps = 120;
   int csz = 256;
@@ -359,8 +357,8 @@ TEST(ModuleTest, SinusoidalPositionEmbeddingFwd) {
   ASSERT_TRUE((af::min(output[0].array())).scalar<float>() >= -2);
 }
 
-TEST_F(ModuleTestF16, SinusoidalPositionEmbeddingFwdF16) {
-  if (!af::isHalfAvailable(af::getDevice())) {
+TEST_F(ContribModuleTestF16, SinusoidalPositionEmbeddingFwdF16) {
+  if (!fl::f16Supported()) {
     GTEST_SKIP() << "Half-precision not supported on this device";
   }
 
@@ -383,7 +381,7 @@ TEST_F(ModuleTestF16, SinusoidalPositionEmbeddingFwdF16) {
   ASSERT_TRUE((af::min(outfp16)).scalar<float>() >= -2);
 }
 
-TEST(ModuleTest, AdaptiveEmbedding) {
+TEST(ContribModuleTest, AdaptiveEmbedding) {
   std::vector<int> values = {1, 4, 6, 2, 12, 7, 4, 21, 22, 18, 3, 23};
   int T = 6, B = 2, dim = 128;
   auto input = Variable(af::array(af::dim4(T, B), values.data()), false);
@@ -396,7 +394,7 @@ TEST(ModuleTest, AdaptiveEmbedding) {
   ASSERT_EQ(output.dims(2), B);
 }
 
-TEST(ModuleTest, TDSFwd) {
+TEST(ContribModuleTest, TDSFwd) {
   int batchsize = 10;
   int timesteps = 120;
   int w = 4;
@@ -412,7 +410,7 @@ TEST(ModuleTest, TDSFwd) {
   ASSERT_EQ(output.dims(2), c);
 }
 
-TEST(ModuleTest, StreamingTDSFwd) {
+TEST(ContribModuleTest, StreamingTDSFwd) {
   int batchsize = 10;
   int timesteps = 120;
   int w = 4;
@@ -432,7 +430,7 @@ TEST(ModuleTest, StreamingTDSFwd) {
   ASSERT_EQ(output.dims(2), c);
 }
 
-TEST(ModuleTest, SpecAugmentFwd) {
+TEST(ContribModuleTest, SpecAugmentFwd) {
   SpecAugment specAug(0, 27, 2, 100, 0.2, 2);
   int T = 512, F = 80;
   auto input = Variable(af::randu(T, F), false);
@@ -470,17 +468,19 @@ TEST(ModuleTest, SpecAugmentFwd) {
   ASSERT_GT(fZeros, 0);
 }
 
-TEST(ModuleTest, RawWavSpecAugmentFwd) {
+TEST(ContribModuleTest, RawWavSpecAugmentFwd) {
   // no time, only freq masking
   for (int nmask = 1; nmask < 3; nmask++) {
-    RawWavSpecAugment specAug(0, 1, nmask, 0, 0, 0, 1, 2000, 6000, 16000, 20000);
+    RawWavSpecAugment specAug(
+        0, 1, nmask, 0, 0, 0, 1, 2000, 6000, 16000, 20000);
     specAug.train();
 
     int T = 300, C = 3, B = 4;
     auto time = 2 * M_PI * af::iota(af::dim4(T)) / 16000;
-    auto finalWav =
-      af::sin(time * 500) + af::sin(time * 1000) + af::sin(time * 7000) + af::sin(time * 7500);
-    auto inputWav = finalWav + af::sin(time * 3000) + af::sin(time * 4000) + af::sin(time * 5000);
+    auto finalWav = af::sin(time * 500) + af::sin(time * 1000) +
+        af::sin(time * 7000) + af::sin(time * 7500);
+    auto inputWav = finalWav + af::sin(time * 3000) + af::sin(time * 4000) +
+        af::sin(time * 5000);
     inputWav = af::tile(inputWav, 1, C, B);
     finalWav = af::tile(finalWav, 1, C, B);
 
@@ -488,9 +488,10 @@ TEST(ModuleTest, RawWavSpecAugmentFwd) {
     // compare middle of filtered wave to avoid edge artifacts comparison
     int halfKernelWidth = 63;
     ASSERT_TRUE(fl::allClose(
-      fl::Variable(finalWav.rows(halfKernelWidth, T - halfKernelWidth - 1), false),
-      filteredWav.rows(halfKernelWidth, T - halfKernelWidth - 1),
-      1e-3));
+        fl::Variable(
+            finalWav.rows(halfKernelWidth, T - halfKernelWidth - 1), false),
+        filteredWav.rows(halfKernelWidth, T - halfKernelWidth - 1),
+        1e-3));
   }
 }
 

--- a/flashlight/fl/test/distributed/AllReduceTest.cpp
+++ b/flashlight/fl/test/distributed/AllReduceTest.cpp
@@ -63,10 +63,12 @@ TEST(Distributed, AllReduceAsync) {
 
   auto rank = getWorldRank();
   auto size = getWorldSize();
+  // not supported for the CPU backend
+  bool async = true && !FL_BACKEND_CPU;
 
   Variable var(af::constant(rank, 10), false);
 
-  allReduce(var, 2.0, /*async=*/true);
+  allReduce(var, 2.0, async);
   syncDistributed();
 
   float expected_val = size * (size - 1.0);
@@ -80,6 +82,9 @@ TEST(Distributed, AllReduceSetAsync) {
 
   auto rank = getWorldRank();
   auto size = getWorldSize();
+  // not supported for the CPU backend
+  bool async = true && !FL_BACKEND_CPU;
+  bool contiguous = true && !FL_BACKEND_CPU;
 
   size_t vSize = (1 << 20);
   std::vector<Variable> vars;
@@ -87,7 +92,7 @@ TEST(Distributed, AllReduceSetAsync) {
     vars.push_back(Variable(af::constant(rank + 1, vSize), false));
   }
 
-  allReduceMultiple(vars, 2.0, /*async=*/true, /*contiguous=*/true);
+  allReduceMultiple(vars, 2.0, async, contiguous);
   syncDistributed();
 
   float expected_val = size * (size + 1.0);
@@ -148,8 +153,8 @@ TEST(Distributed, CoalescingReducer) {
 
   auto s = std::make_shared<fl::CoalescingReducer>(
       /* scale = */ 1.0 / size,
-      /*async=*/true,
-      /*contiguous=*/true);
+      /*async=*/true && !FL_BACKEND_CPU,
+      /*contiguous=*/true && !FL_BACKEND_CPU);
 
   size_t vSize = (1 << 20);
   std::vector<Variable> vars;

--- a/flashlight/fl/test/memory/CachingMemoryManagerTest.cpp
+++ b/flashlight/fl/test/memory/CachingMemoryManagerTest.cpp
@@ -54,6 +54,12 @@ TEST_F(CachingMemoryManagerTest, BasicOps) {
 
 TEST_F(CachingMemoryManagerTest, DevicePtr) {
   // This test checks whether device pointer API works for the arrays
+  // The CPU backend in AF allocates a buffer for empty arrays - see
+  // https://github.com/arrayfire/arrayfire/issues/3058. When this is fixed,
+  // this can be relaxed.
+  if (FL_BACKEND_CPU) {
+    GTEST_SKIP() << "ArrayFire CPU backend allocates buffers for empty arrays";
+  }
 
   // Empty array
   auto arr1 = af::array(0, 0, 0, 0, af::dtype::f32);

--- a/flashlight/fl/test/memory/MemoryFrameworkTest.cpp
+++ b/flashlight/fl/test/memory/MemoryFrameworkTest.cpp
@@ -269,6 +269,13 @@ class MockTestMemoryManager : public TestMemoryManager {
  *   memory manager
  */
 TEST(MemoryFramework, AdapterInstallerDeviceInterfaceTest) {
+  // The CPU backend in AF allocates a buffer for empty arrays - see
+  // https://github.com/arrayfire/arrayfire/issues/3058. When this is fixed,
+  // this can be relaxed/this test will pass
+  if (FL_BACKEND_CPU) {
+    GTEST_SKIP() << "ArrayFire CPU backend allocates buffers for empty arrays";
+  }
+
   std::stringstream logStream;
   std::stringstream mockLogStream;
   {

--- a/flashlight/fl/test/nn/ModuleTest.cpp
+++ b/flashlight/fl/test/nn/ModuleTest.cpp
@@ -95,7 +95,7 @@ TEST(ModuleTest, LinearFwd) {
 }
 
 TEST_F(ModuleTestF16, LinearFwdF16) {
-  if (!af::isHalfAvailable(af::getDevice())) {
+  if (!fl::f16Supported()) {
     GTEST_SKIP() << "Half-precision not supported on this device";
   }
 
@@ -182,7 +182,7 @@ TEST(ModuleTest, GLUFwd) {
 }
 
 TEST_F(ModuleTestF16, GLUFwdF16) {
-  if (!af::isHalfAvailable(af::getDevice())) {
+  if (!fl::f16Supported()) {
     GTEST_SKIP() << "Half-precision not supported on this device";
   }
 
@@ -248,7 +248,7 @@ TEST(ModuleTest, LogSoftmaxFwd) {
 }
 
 TEST_F(ModuleTestF16, LogSoftmaxFwdF16) {
-  if (!af::isHalfAvailable(af::getDevice())) {
+  if (!fl::f16Supported()) {
     GTEST_SKIP() << "Half-precision not supported on this device";
   }
 
@@ -301,7 +301,7 @@ TEST(ModuleTest, ConvolutionFwd) {
 }
 
 TEST_F(ModuleTestF16, ConvolutionFwdF16) {
-  if (!af::isHalfAvailable(af::getDevice())) {
+  if (!fl::f16Supported()) {
     GTEST_SKIP() << "Half-precision not supported on this device";
   }
 
@@ -360,7 +360,7 @@ TEST(ModuleTest, PoolingFwd) {
 }
 
 TEST_F(ModuleTestF16, PoolingFwdF16) {
-  if (!af::isHalfAvailable(af::getDevice())) {
+  if (!fl::f16Supported()) {
     GTEST_SKIP() << "Half-precision not supported on this device";
   }
 
@@ -499,7 +499,7 @@ TEST(ModuleTest, GRUFwd) {
 }
 
 TEST_F(ModuleTestF16, RNNFwdF16) {
-  if (!af::isHalfAvailable(af::getDevice())) {
+  if (!fl::f16Supported()) {
     GTEST_SKIP() << "Half-precision not supported on this device";
   }
 
@@ -573,7 +573,7 @@ TEST(ModuleTest, DropoutFwd) {
 }
 
 TEST_F(ModuleTestF16, DropoutFwdF16) {
-  if (!af::isHalfAvailable(af::getDevice())) {
+  if (!fl::f16Supported()) {
     GTEST_SKIP() << "Half-precision not supported on this device";
   }
 
@@ -655,7 +655,7 @@ TEST(ModuleTest, LayerNormFwd) {
 }
 
 TEST_F(ModuleTestF16, LayerNormFwdF16) {
-  if (!af::isHalfAvailable(af::getDevice())) {
+  if (!fl::f16Supported()) {
     GTEST_SKIP() << "Half-precision not supported on this device";
   }
 
@@ -715,7 +715,7 @@ TEST(ModuleTest, TransformFwd) {
 }
 
 TEST(ModuleTest, PrecisionCastFwd) {
-  if (!af::isHalfAvailable(af::getDevice())) {
+  if (!fl::f16Supported()) {
     GTEST_SKIP() << "Half precision not available on this device";
   }
 

--- a/flashlight/fl/test/nn/NNSerializationTest.cpp
+++ b/flashlight/fl/test/nn/NNSerializationTest.cpp
@@ -149,7 +149,7 @@ TEST(NNSerializationTest, BaseModule) {
 }
 
 TEST(NNSerializationTest, PrecisionCast) {
-  if (!af::isHalfAvailable(af::getDevice())) {
+  if (!fl::f16Supported()) {
     GTEST_SKIP() << "Half precision not available on this device";
   }
 

--- a/flashlight/fl/test/optim/OptimTest.cpp
+++ b/flashlight/fl/test/optim/OptimTest.cpp
@@ -35,7 +35,7 @@ TEST(OptimTest, GradNorm) {
 }
 
 TEST(OptimTest, GradNormF16) {
-  if (!af::isHalfAvailable(af::getDevice())) {
+  if (!fl::f16Supported()) {
     GTEST_SKIP() << "Half-precision not supported on this device";
   }
 


### PR DESCRIPTION
Summary:
Fix a host of issues and get the CPU backend to 100% test passage so we can use it confidently for inference/fine-tuning things. Will reenable CPU tests in CI in a future diff.

Fix a bad bug with BatchNorm -- correctness tests with full precision now pass. Conformer and transformer modules produce results with perfect parity with the CUDA backend and cuDNN. Fixes https://github.com/facebookresearch/flashlight/issues/271.

Also fix a race with oneDNN operators and the AF CPU computation stream. Since there isn't a CPU computation stream, calling `af::sync()` before enqueueing oneDNN operations is required, as is waiting on oneDNN operations to complete before resuming operations on the AF stream.

Other changes:
- Add `fl::fp16Supported()` to wrap AF and fl backend macros. Added to CPU tests (no CPU support for fp16 with oneDNN - oneDNN does support AMD GPU half-precision training, though)
- Add preprocessor definitions to determine
- Better Gloo finding
- Skip tests that are "unsupported" - SequentialBuilder (no bidirectional RNN), CTCEmptyTarget (related to memory management), autograd tests related to RNNs (not adding those unless we need them), memory management tests (AF allocates empty buffers for empty arrays, will be fixed in a future AF release)
- Rename ContribModuleTest ModuleTests to be ContribModuleTest consistenly

Differential Revision: D25602777

