### PR TITLE
replace tempnam() with fl::lib::getTmpPath() in AdditiveNoiseTest

### DIFF
--- a/flashlight/app/asr/test/augmentation/AdditiveNoiseTest.cpp
+++ b/flashlight/app/asr/test/augmentation/AdditiveNoiseTest.cpp
@@ -17,6 +17,7 @@ using ::fl::app::asr::saveSound;
 using ::fl::lib::dirCreateRecursive;
 using ::fl::lib::pathsConcat;
 using ::testing::Pointwise;
+using ::fl::lib::getTmpPath;
 
 const size_t sampleRate = 16000;
 
@@ -36,7 +37,7 @@ MATCHER_P(FloatNearPointwise, tol, "Out of range") {
  * considering the SNR value.
  */
 TEST(AdditiveNoise, Snr) {
-  const std::string tmpDir = std::tmpnam(nullptr);
+  const std::string tmpDir = getTmpPath("AdditiveNoise");
   dirCreateRecursive(tmpDir);
   const std::string listFilePath = pathsConcat(tmpDir, "noise.lst");
   const std::string noiseFilePath = pathsConcat(tmpDir, "noise.flac");


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.** Changes *must* be discussed.

**Original Issue**: [corresponding issue on Github]

*Note:* You can add `closes #[issue number]` to automatically close the issue that this PR resolves when it is merged.

### Summary
[Explain the details for this change and the problem that the pull request solves]

### Test Plan (required)
[steps by which you tested that your fix resolves the issue. These might include specific commands and configurations]
