### PR TITLE
Add Plugin Compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,22 @@ set(FL_INSTALL_CMAKE_DIR "${FL_INSTALL_ASSETS_BASE_DIR}/cmake" CACHE PATH "Insta
 set(FL_INSTALL_EXAMPLES_DIR "${FL_INSTALL_ASSETS_BASE_DIR}/examples" CACHE PATH "Install path for example files")
 set(FL_INSTALL_DOC_DIR "${FL_INSTALL_ASSETS_BASE_DIR}/doc" CACHE PATH "Install path for documentation")
 
+include(CheckCXXCompilerFlag)
+# All libraries should have their symbols exported so plugins can lazily
+# symbols from any of them
+check_cxx_compiler_flag("-rdynamic" COMPILER_SUPPORTS_RDYNAMIC)
+if(${COMPILER_SUPPORTS_RDYNAMIC})
+  message(STATUS "-rdynamic supported.")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -rdynamic")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -rdynamic")
+else()
+  message(WARNING
+    "This compiler doesn't support dynamic symbol exports. "
+    "Plugin functionality likely won't work.")
+endif()
+
+include(InternalUtils)
+
 # ----------------------------- Configuration -----------------------------
 
 option(FL_BUILD_TESTS "Build tests" ON)
@@ -51,8 +67,7 @@ else ()
   message(FATAL_ERROR "Invalid FLASHLIGHT backend specified")
 endif ()
 
-# Installation utilities
-include(InternalUtils)
+# List of installable targets
 set(INSTALLABLE_TARGETS "")
 
 set(FL_ROOT_DIR ${PROJECT_SOURCE_DIR}/flashlight)

--- a/flashlight/app/asr/Train.cpp
+++ b/flashlight/app/asr/Train.cpp
@@ -26,7 +26,7 @@
 #include "flashlight/app/asr/decoder/TranscriptionUtils.h"
 #include "flashlight/app/asr/runtime/runtime.h"
 #include "flashlight/ext/common/DistributedUtils.h"
-#include "flashlight/ext/common/ModulePlugin.h"
+#include "flashlight/ext/plugin/ModulePlugin.h"
 #include "flashlight/ext/common/SequentialBuilder.h"
 #include "flashlight/ext/common/Serializer.h"
 #include "flashlight/fl/contrib/contrib.h"

--- a/flashlight/app/asr/tutorial/FinetuneCTC.cpp
+++ b/flashlight/app/asr/tutorial/FinetuneCTC.cpp
@@ -24,7 +24,7 @@
 #include "flashlight/app/asr/decoder/TranscriptionUtils.h"
 #include "flashlight/app/asr/runtime/runtime.h"
 #include "flashlight/ext/common/DistributedUtils.h"
-#include "flashlight/ext/common/ModulePlugin.h"
+#include "flashlight/ext/plugin/ModulePlugin.h"
 #include "flashlight/ext/common/SequentialBuilder.h"
 #include "flashlight/ext/common/Serializer.h"
 #include "flashlight/fl/contrib/contrib.h"

--- a/flashlight/ext/CMakeLists.txt
+++ b/flashlight/ext/CMakeLists.txt
@@ -2,9 +2,9 @@ cmake_minimum_required(VERSION 3.10)
 
 # ------------------------- Components -------------------------
 
-# common
 include(${CMAKE_CURRENT_LIST_DIR}/common/CMakeLists.txt)
 include(${CMAKE_CURRENT_LIST_DIR}/image/CMakeLists.txt)
+include(${CMAKE_CURRENT_LIST_DIR}/plugin/CMakeLists.txt)
 
 # --------------------------- Tests ---------------------------
 

--- a/flashlight/ext/common/CMakeLists.txt
+++ b/flashlight/ext/common/CMakeLists.txt
@@ -5,5 +5,4 @@ target_sources(
   PRIVATE
   ${CMAKE_CURRENT_LIST_DIR}/SequentialBuilder.cpp
   ${CMAKE_CURRENT_LIST_DIR}/DistributedUtils.cpp
-  ${CMAKE_CURRENT_LIST_DIR}/ModulePlugin.cpp
   )

--- a/flashlight/ext/plugin/CMakeLists.txt
+++ b/flashlight/ext/plugin/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.10)
+
+target_sources(
+  flashlight
+  PRIVATE
+  ${CMAKE_CURRENT_LIST_DIR}/ModulePlugin.cpp
+  )
+
+# Plugin Compiler - only run if a plugin path is passed
+if (NOT ${FL_PLUGIN_MODULE_SRC_PATH} STREQUAL "")
+  include(${CMAKE_CURRENT_LIST_DIR}/plugincompiler/CMakeLists.txt)
+endif()

--- a/flashlight/ext/plugin/ModulePlugin.cpp
+++ b/flashlight/ext/plugin/ModulePlugin.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "flashlight/ext/common/ModulePlugin.h"
+#include "flashlight/ext/plugin/ModulePlugin.h"
 
 namespace fl {
 namespace ext {

--- a/flashlight/ext/plugin/ModulePlugin.h
+++ b/flashlight/ext/plugin/ModulePlugin.h
@@ -16,7 +16,7 @@ namespace ext {
 
 typedef Module* (*w2l_module_plugin_t)(int64_t nFeatures, int64_t nClasses);
 
-class ModulePlugin : public fl::Plugin {
+class ModulePlugin : public Plugin {
  public:
   explicit ModulePlugin(const std::string& name);
   std::shared_ptr<fl::Module> arch(int64_t nFeatures, int64_t nClasses);

--- a/flashlight/ext/plugin/plugincompiler/CMakeLists.txt
+++ b/flashlight/ext/plugin/plugincompiler/CMakeLists.txt
@@ -1,0 +1,43 @@
+cmake_minimum_required(VERSION 3.10)
+
+# Detect if we're doing an in-source or an out-of-source build
+set(FL_PLUGIN_LINK_TARGET)
+if (NOT TARGET flashlight)
+  find_package(flashlight CONFIG REQUIRED)
+  set(FL_PLUGIN_LINK_TARGET flashlight::flashlight)
+else()
+  set(FL_PLUGIN_LINK_TARGET flashlight)
+endif()
+
+function(compile_plugin)
+  set(options)
+  set(oneValueArgs SRC)
+  set(multiValueArgs)
+  cmake_parse_arguments(compile_plugin "${options}" "${oneValueArgs}"
+    "${multiValueArgs}" ${ARGN})
+
+  get_filename_component(src_name ${compile_plugin_SRC} NAME_WE)
+  set(target "${src_name}")
+  add_library(${target} MODULE ${compile_plugin_SRC})
+  target_include_directories(
+    ${target}
+    PUBLIC
+    "$<TARGET_PROPERTY:${FL_PLUGIN_LINK_TARGET},INTERFACE_INCLUDE_DIRECTORIES>"
+    )
+  set_target_properties(
+    ${target}
+    PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+    PREFIX ""
+    )
+  add_dependencies(${target} ${FL_PLUGIN_LINK_TARGET})
+endfunction()
+
+if (${FL_PLUGIN_MODULE_SRC_PATH} STREQUAL "")
+  message(FATAL_ERROR
+    "FL_PLUGIN_MODULE_SRC_PATH argument required. "
+    "Usage: cmake -D FL_PLUGIN_MODULE_SRC_PATH=[path] [...]")
+endif()
+
+message(STATUS "Building plugin with src ${FL_PLUGIN_MODULE_SRC_PATH}")
+compile_plugin(SRC ${FL_PLUGIN_MODULE_SRC_PATH})

--- a/flashlight/ext/plugin/plugincompiler/PluginModule.cpp
+++ b/flashlight/ext/plugin/plugincompiler/PluginModule.cpp
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <memory>
+
+#include "flashlight/fl/flashlight.h"
+
+/**
+ * This is a placeholder plugin module.
+ *
+ * Modifications SHOULD NOT be committed, but this file should be replaced with
+ * valid plugin code when doing internal compilation with buck. In external
+ * environments when building with CMake, this file is irrelevant as plugin
+ * source paths can be freely specified.
+ */
+extern "C" fl::Module* createModule(int64_t nFeature, int64_t nLabel) {
+  auto seq = std::make_unique<fl::Sequential>(); // placeholder
+  return seq.release();
+}

--- a/flashlight/ext/test/CMakeLists.txt
+++ b/flashlight/ext/test/CMakeLists.txt
@@ -12,7 +12,7 @@ if(FL_BUILD_CONTRIB)
 endif()
 
 add_library(test_module_plugin MODULE
-  ${DIR}/common/test_module_plugin.cpp)
+  ${DIR}/plugin/test_module_plugin.cpp)
 target_include_directories(test_module_plugin
   PUBLIC "$<TARGET_PROPERTY:flashlight,INTERFACE_INCLUDE_DIRECTORIES>")
 set_target_properties(test_module_plugin PROPERTIES
@@ -21,9 +21,8 @@ set_target_properties(test_module_plugin PROPERTIES
 add_dependencies(test_module_plugin flashlight)
 
 build_test(
-  SRC ${DIR}/common/ModulePluginTest.cpp
+  SRC ${DIR}/plugin/ModulePluginTest.cpp
   LIBS ${LIBS}
   PREPROC "PLUGINDIR=\"${CMAKE_CURRENT_BINARY_DIR}\""
   )
-target_link_libraries(ModulePluginTest PUBLIC "-Wl,--export-dynamic")
 add_dependencies(ModulePluginTest test_module_plugin)

--- a/flashlight/ext/test/plugin/ModulePluginTest.cpp
+++ b/flashlight/ext/test/plugin/ModulePluginTest.cpp
@@ -9,8 +9,9 @@
 #include <arrayfire.h>
 #include <gtest/gtest.h>
 
-#include "flashlight/ext/common/ModulePlugin.h"
+#include "flashlight/ext/plugin/ModulePlugin.h"
 #include "flashlight/fl/flashlight.h"
+#include "flashlight/fl/contrib/modules/modules.h"
 #include "flashlight/lib/common/System.h"
 
 using namespace fl;

--- a/flashlight/ext/test/plugin/test_module_plugin.cpp
+++ b/flashlight/ext/test/plugin/test_module_plugin.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "flashlight/fl/flashlight.h"
+#include "flashlight/fl/contrib/contrib.h"
 
 extern "C" fl::Module* createModule(int64_t nFeature, int64_t nLabel) {
   auto seq = new fl::Sequential();


### PR DESCRIPTION
Summary:
Adds plugin compiler, and standalone CMake list to compile flashlight module plugins.

The plugin compiler can be used in one of two ways:

### 1. With a flashlight build:

To compile a plugin when building flashlight from source, pass normal CMake options then include a plugin path. For example, if there's a plugin to be built at `/tmp/PluginTestModule.cpp`:
```
cmake .. -DFL_BACKEND=CUDA [...] -DFL_PLUGIN_MODULE_SRC_PATH=/tmp/PluginTestModule.cpp
cmake --build . --parallel 80
```
will build the plugin:
```
...
Scanning dependencies of target PluginTestModule
[ 99%] Building CXX object CMakeFiles/PluginTestModule.dir/tmp/PluginTestModule.cpp.o
[100%] Linking CXX shared library PluginTestModule.so
[100%] Built target PluginTestModule
```
and drop `PluginTestModule.so` in the build directory for use.

### 2. As a standalone build

Given an existing flashlight installation, one can build a plugin with the `plugincompiler/CMakeLists.txt` alone. For example:
```
cp -r flashlight/ext/plugin/plugincompiler /tmp # put the compiler somewhere else
cd /tmp/plugincompiler && mkdir build && cd build

cmake .. -DFL_PLUGIN_MODULE_SRC_PATH=/tmp/PluginTestModule.cpp
cmake --build . --parallel 80
```
gives
```
Scanning dependencies of target PluginTestModule
[ 50%] Building CXX object CMakeFiles/PluginTestModule.dir/tmp/PluginTestModule.cpp.o
[100%] Linking CXX shared library PluginTestModule.so
[100%] Built target PluginTestModule
```
and drops the plugin in the build directory as before.

### 3. In fbcode

Because Buck is rigid and constructs a static graph of dependencies, custom plugin paths can't be dynamically passed at compile time.

`flashlight/ext/plugin/plugincompiler/PluginModule.cpp` exists for this purpose. While it's irrelevant in a non-fbcode build with CMake, in fbcode, one has to change the file to compile a plugin of their choice, then run

> buck build mode/dev-nosan deeplearning/projects/flashlight/flashlight/ext/plugin/plugincompiler:fl_plugin_out

to compile the resulting `.so`. They can rename the file as they want and load the plugin in fb infra as expected.

It's unlikely there will be another way to do this in fbcode since Buck doesn't really support passing dynamic sources a build time.

Differential Revision: D25689706

