### PR TITLE
Link Opus encoding and auto get/build/install libsndfile if not found

### DIFF
--- a/cmake/BuildSndFile.cmake
+++ b/cmake/BuildSndFile.cmake
@@ -1,0 +1,58 @@
+cmake_minimum_required(VERSION 3.10.0)
+
+include(ExternalProject)
+
+set(SndFile_URL https://github.com/libsndfile/libsndfile.git)
+set(SndFile_BUILD ${CMAKE_CURRENT_BINARY_DIR}/sndfile/)
+set(SndFile_TEMP_INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern/sndfile)
+set(SndFile_TAG v1.0.30) # release v1.0.30
+
+if (NOT TARGET SndFile)
+  # Download SndFile
+  ExternalProject_Add(
+    SndFile
+    PREFIX sndfile
+    GIT_REPOSITORY ${SndFile_URL}
+    GIT_TAG ${SndFile_TAG}
+    BUILD_IN_SOURCE 1
+    BUILD_COMMAND ${CMAKE_COMMAND} --build .
+    CMAKE_CACHE_ARGS
+      -DBUILD_SHARED_LIBS:BOOL=${BUILD_SHARED_LIBS}
+      -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+      -DCMAKE_INSTALL_PREFIX:PATH=${SndFile_TEMP_INSTALL_DIR}
+      -DBUILD_TESTING:BOOL=OFF
+      -DBUILD_PROGRAMS:BOOL=OFF
+      -DBUILD_EXAMPLES:BOOL=OFF
+      -DBUILD_REGTEST:BOOL=OFF
+  )
+endif ()
+
+# Install the install executed at build time
+install(DIRECTORY ${SndFile_TEMP_INSTALL_DIR}/include DESTINATION ${CMAKE_INSTALL_PREFIX})
+install(DIRECTORY ${SndFile_TEMP_INSTALL_DIR}/lib DESTINATION ${CMAKE_INSTALL_PREFIX})
+install(DIRECTORY ${SndFile_TEMP_INSTALL_DIR}/share DESTINATION ${CMAKE_INSTALL_PREFIX})
+
+ExternalProject_Get_Property(SndFile source_dir)
+set(SndFile_SOURCE_DIR ${source_dir})
+
+ExternalProject_Get_Property(SndFile binary_dir)
+set(SndFile_BINARY_DIR ${binary_dir})
+
+if (BUILD_SHARED_LIBS)
+  set(LIB_TYPE SHARED)
+else()
+  set(LIB_TYPE STATIC)
+endif()
+
+# Library and include dirs
+set(SndFile_LIBRARIES "${SndFile_TEMP_INSTALL_DIR}/lib/${CMAKE_${LIB_TYPE}_LIBRARY_PREFIX}sndfile${CMAKE_${LIB_TYPE}_LIBRARY_SUFFIX}")
+set(SndFile_INCLUDE_DIRS "${SndFile_TEMP_INSTALL_DIR}/include")
+# Make dirs so this can be used as an interface include directory
+file(MAKE_DIRECTORY ${SndFile_TEMP_INSTALL_DIR})
+file(MAKE_DIRECTORY ${SndFile_INCLUDE_DIRS})
+
+add_library(SndFile::sndfile ${LIB_TYPE} IMPORTED)
+set_target_properties(SndFile::sndfile PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${SndFile_INCLUDE_DIRS}
+  IMPORTED_LOCATION ${SndFile_LIBRARIES}
+  )

--- a/cmake/FindOpus.cmake
+++ b/cmake/FindOpus.cmake
@@ -1,0 +1,65 @@
+# - Find opus
+# Find the native opus includes and libraries
+#
+#  OPUS_INCLUDE_DIRS - where to find opus.h, etc.
+#  OPUS_LIBRARIES    - List of libraries when using opus.
+#  OPUS_FOUND        - True if opus found.
+
+find_package(Opus CONFIG QUIET)
+
+if (NOT TARGET Opus::opus)
+  if (OPUS_INCLUDE_DIR)
+    # Already in cache, be silent
+    set(OPUS_FIND_QUIETLY TRUE)
+  endif()
+
+  find_package(PkgConfig QUIET)
+  pkg_check_modules(PC_OPUS QUIET opus)
+
+  set(OPUS_VERSION ${PC_OPUS_VERSION})
+
+  find_path(OPUS_INCLUDE_DIR opus/opus.h
+    HINTS
+      ${PC_OPUS_INCLUDEDIR}
+      ${PC_OPUS_INCLUDE_DIRS}
+      ${OPUS_ROOT}
+    )
+  # MSVC built opus may be named opus_static.
+  # The provided project files name the library with the lib prefix.
+  find_library(OPUS_LIBRARY
+    NAMES
+      opus
+      opus_static
+      libopus
+      libopus_static
+    HINTS
+      ${PC_OPUS_LIBDIR}
+      ${PC_OPUS_LIBRARY_DIRS}
+      ${OPUS_ROOT}
+    )
+  # Handle the QUIETLY and REQUIRED arguments and set OPUS_FOUND
+  # to TRUE if all listed variables are TRUE.
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(Opus
+    REQUIRED_VARS
+      OPUS_LIBRARY
+      OPUS_INCLUDE_DIR
+    VERSION_VAR
+      OPUS_VERSION
+      )
+
+  if (OPUS_FOUND)
+    set(OPUS_LIBRARIES "${OPUS_LIBRARY}")
+    set(OPUS_INCLUDE_DIRS "${OPUS_INCLUDE_DIR}")
+
+    if(NOT TARGET Opus::opus)
+      add_library(Opus::opus UNKNOWN IMPORTED)
+      set_target_properties(Opus::opus PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${OPUS_INCLUDE_DIRS}"
+        IMPORTED_LOCATION "${OPUS_LIBRARIES}"
+        )
+    endif()
+  endif()
+
+  mark_as_advanced(OPUS_INCLUDE_DIR OPUS_LIBRARY)
+endif()

--- a/cmake/FindSndFile.cmake
+++ b/cmake/FindSndFile.cmake
@@ -14,11 +14,6 @@
 #  SndFile_LIBRARIES - Link these to use libsndfile
 #
 
-# We require sndfile having been built with external libs.
-find_package(Ogg REQUIRED)
-find_package(Vorbis REQUIRED)
-find_package(FLAC REQUIRED)
-
 find_package(SndFile CONFIG)
 
 if (TARGET SndFile::sndfile AND NOT SndFile_WITH_EXTERNAL_LIBS)
@@ -59,21 +54,12 @@ if (NOT TARGET SndFile::sndfile)
   include(FindPackageHandleStandardArgs)
   find_package_handle_standard_args(SndFile DEFAULT_MSG SndFile_INCLUDE_DIRS SndFile_LIBRARIES)
 
-  add_library(SndFile::sndfile UNKNOWN IMPORTED)
-  set_target_properties(SndFile::sndfile PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${SndFile_INCLUDE_DIRS}"
-    IMPORTED_LOCATION "${SndFile_LIBRARIES}"
-    )
-  set_property(
-    TARGET SndFile::sndfile
-    PROPERTY INTERFACE_LINK_LIBRARIES
-    Vorbis::vorbis
-    Vorbis::vorbisenc
-    Ogg::ogg
-    FLAC::FLAC
-    )
-
   if (SndFile_FOUND)
+    add_library(SndFile::sndfile UNKNOWN IMPORTED)
+    set_target_properties(SndFile::sndfile PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${SndFile_INCLUDE_DIRS}"
+      IMPORTED_LOCATION "${SndFile_LIBRARIES}"
+      )
     message(STATUS "Found libsndfile: (lib: ${SndFile_LIBRARIES} include: ${SndFile_INCLUDE_DIRS}")
   else()
     message(STATUS "libsndfile not found.")

--- a/flashlight/app/asr/data/CMakeLists.txt
+++ b/flashlight/app/asr/data/CMakeLists.txt
@@ -1,16 +1,31 @@
 cmake_minimum_required(VERSION 3.10)
 
 # ----------------------------- Dependencies -----------------------------
-find_package(SndFile REQUIRED)
+# SndFile must be built with encoder libs
+find_package(Ogg REQUIRED)
+find_package(Vorbis REQUIRED)
+find_package(Opus REQUIRED)
+find_package(FLAC REQUIRED)
+
+find_package(SndFile)
 if (TARGET SndFile::sndfile)
   message(STATUS "libsndfile found.")
+else ()
+  if (FL_BUILD_STANDALONE)
+    message(STATUS "libsndfile not found - will download and build from source.")
+    include(${CMAKE_MODULE_PATH}/BuildSndFile.cmake)
+    add_dependencies(flashlight-app-asr SndFile) # ExternalProject target
+  else()
+    message(FATAL_ERROR "Required dependency libsndfile not found")
+  endif()
+endif ()
+if (FL_BUILD_STANDALONE)
   setup_install_find_module(${CMAKE_MODULE_PATH}/FindSndFile.cmake)
   setup_install_find_module(${CMAKE_MODULE_PATH}/FindOgg.cmake)
   setup_install_find_module(${CMAKE_MODULE_PATH}/FindVorbis.cmake)
+  setup_install_find_module(${CMAKE_MODULE_PATH}/FindOpus.cmake)
   setup_install_find_module(${CMAKE_MODULE_PATH}/FindFLAC.cmake)
-else ()
-  message(FATAL_ERROR "Required dependency libsndfile not found.")
-endif ()
+endif()
 
 # ----------------------------- Lib -----------------------------
 target_sources(
@@ -26,4 +41,9 @@ target_link_libraries(
   flashlight-app-asr
   PRIVATE
   SndFile::sndfile
+  Vorbis::vorbis
+  Vorbis::vorbisenc
+  FLAC::FLAC
+  Opus::opus
+  Ogg::ogg
   )


### PR DESCRIPTION
Summary:
Title

Add Opus encoding lib to libsndfile so it can be used (in libsndfile >= 1.0.29)

Differential Revision: D25707841

