### PR TITLE
Add FL_BUILD_APPS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ option(FL_BUILD_RECIPES "Build recipes" ON)
 option(FL_BUILD_STANDALONE "Build standalone installation" ON)
 option(FL_BUILD_LIBRARIES "Build flashlight libraries" ON)
 cmake_dependent_option(FL_BUILD_CORE "Build flashlight core" ON "FL_BUILD_LIBRARIES" OFF)
+cmake_dependent_option(FL_BUILD_APPS "Build flashlight apps" ON "FL_BUILD_CORE" OFF)
 
 # Flashlight backend
 set(FL_BACKEND "CUDA" CACHE STRING "Backend with which to build flashlight")
@@ -236,8 +237,10 @@ if (FL_BUILD_CORE)
 endif() # if FL_BUILD_CORE
 
 # --------------------------- Apps ---------------------------
-set(FL_APPS_DIR "${FL_ROOT_DIR}/app")
-include(${FL_APPS_DIR}/CMakeLists.txt)
+if (FL_BUILD_APPS)
+  set(FL_APPS_DIR "${FL_ROOT_DIR}/app")
+  include(${FL_APPS_DIR}/CMakeLists.txt)
+endif()
 
 # --------------------------- Cleanup ---------------------------
 setup_install_targets(INSTALL_TARGETS ${INSTALLABLE_TARGETS})

--- a/flashlight/app/CMakeLists.txt
+++ b/flashlight/app/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.10)
 
-cmake_dependent_option(FL_BUILD_APP_ASR "Build asr task for flashlight" ON "FL_BUILD_CORE;FL_BUILD_CONTRIB" OFF)
-cmake_dependent_option(FL_BUILD_APP_IMGCLASS "Build image classification app" ON "FL_BUILD_CORE;FL_BUILD_CONTRIB" OFF)
-cmake_dependent_option(FL_BUILD_APP_LM "Build lm task for flashlight" ON "FL_BUILD_CORE;FL_BUILD_CONTRIB" OFF)
+cmake_dependent_option(FL_BUILD_APP_ASR "Build asr task for flashlight" ON "FL_BUILD_CORE;FL_BUILD_CONTRIB;FL_BUILD_APPS" OFF)
+cmake_dependent_option(FL_BUILD_APP_IMGCLASS "Build image classification app" ON "FL_BUILD_CORE;FL_BUILD_CONTRIB;FL_BUILD_APPS" OFF)
+cmake_dependent_option(FL_BUILD_APP_LM "Build lm task for flashlight" ON "FL_BUILD_CORE;FL_BUILD_CONTRIB;FL_BUILD_APPS" OFF)
 
 if (FL_BUILD_APP_ASR)
   message(STATUS "Building flashlight ASR app")
@@ -17,8 +17,7 @@ endif ()
 
 if (FL_BUILD_APP_IMGCLASS)
   if (NOT FL_BUILD_DISTRIBUTED)
-    message(FATAL_ERROR
-    "FL_BUILD_DISTRIBUTED must be enabled for image classification")
+    message(FATAL_ERROR "FL_BUILD_DISTRIBUTED must be enabled for image classification")
   endif()
   set(FL_APP_IMGCLASS_ROOT_DIR ${FL_APPS_DIR}/imgclass)
   include(${FL_APP_IMGCLASS_ROOT_DIR}/CMakeLists.txt)

--- a/flashlight/fl/CMakeLists.txt
+++ b/flashlight/fl/CMakeLists.txt
@@ -5,7 +5,9 @@ set(FL_CORE_COMPONENT_SRC_DIR "${CMAKE_CURRENT_LIST_DIR}") # module root
 
 # ----------------------------- Configuration -----------------------------
 # Distributed Training Backend
-set(FL_BUILD_DISTRIBUTED ON CACHE BOOL "Whether to build and link the distributed backend with flashlight")
+cmake_dependent_option(FL_BUILD_DISTRIBUTED
+  "Build and link a distributed backend with flashlight" ON
+  "FL_BUILD_CORE" OFF)
 # If building with CUDA, use NCCL to on; if using CPU or OpenCL, use GLOO
 set(USE_NCCL FALSE)
 set(USE_GLOO FALSE)


### PR DESCRIPTION
Summary:
Add a toggle to switch off building all apps - it's annoying to add `-DFL_BUILD_APP_ASR=OFF -DFL_BUILD_APP_LM=OFF -DFL_BUILD_APP_IMGCLASS=OFF` when the user only wants to build the core. `FL_BUILD_APPS=OFF` accomplishes this

cc vineelpratap

Differential Revision: D25710012

