### PR TITLE
Remove setter for CachingMemoryManagemenr statics

### DIFF
--- a/flashlight/app/asr/Decode.cpp
+++ b/flashlight/app/asr/Decode.cpp
@@ -51,6 +51,7 @@ using fl::lib::text::SmearingMode;
 using namespace fl::app::asr;
 
 int main(int argc, char** argv) {
+  fl::init();
   google::InitGoogleLogging(argv[0]);
   google::InstallFailureSignalHandler();
   std::string exec(argv[0]);
@@ -421,8 +422,9 @@ int main(int argc, char** argv) {
         fl::Variable rawEmission;
         if (usePlugin) {
           rawEmission = localNetwork
-                            ->forward({fl::input(sample[kInputIdx]),
-                                       fl::noGrad(sample[kDurationIdx])})
+                            ->forward(
+                                {fl::input(sample[kInputIdx]),
+                                 fl::noGrad(sample[kDurationIdx])})
                             .front();
         } else {
           rawEmission = fl::ext::forwardSequentialModuleWithPadMask(

--- a/flashlight/app/asr/Test.cpp
+++ b/flashlight/app/asr/Test.cpp
@@ -39,6 +39,7 @@ using fl::lib::pathsConcat;
 using namespace fl::app::asr;
 
 int main(int argc, char** argv) {
+  fl::init();
   google::InitGoogleLogging(argv[0]);
   google::InstallFailureSignalHandler();
   std::string exec(argv[0]);
@@ -137,8 +138,8 @@ int main(int argc, char** argv) {
     LOG(INFO) << "Number of words: " << wordDict.indexSize();
   }
 
-  fl::lib::text::DictionaryMap dicts = {{kTargetIdx, tokenDict},
-                                        {kWordIdx, wordDict}};
+  fl::lib::text::DictionaryMap dicts = {
+      {kTargetIdx, tokenDict}, {kWordIdx, wordDict}};
 
   /* ===================== Create Dataset ===================== */
   fl::lib::audio::FeatureParams featParams(
@@ -290,8 +291,9 @@ int main(int argc, char** argv) {
       fl::Variable rawEmission;
       if (usePlugin) {
         rawEmission = localNetwork
-                          ->forward({fl::input(sample[kInputIdx]),
-                                     fl::noGrad(sample[kDurationIdx])})
+                          ->forward(
+                              {fl::input(sample[kInputIdx]),
+                               fl::noGrad(sample[kDurationIdx])})
                           .front();
       } else {
         rawEmission = fl::ext::forwardSequentialModuleWithPadMask(

--- a/flashlight/app/asr/Train.cpp
+++ b/flashlight/app/asr/Train.cpp
@@ -93,6 +93,7 @@ DEFINE_int64(
 } // namespace
 
 int main(int argc, char** argv) {
+  fl::init();
   google::InitGoogleLogging(argv[0]);
   google::InstallFailureSignalHandler();
   std::string exec(argv[0]);
@@ -418,11 +419,12 @@ int main(int argc, char** argv) {
           usePlugin,
           tokenDict,
           wordDict,
-          DecodeMasterTrainOptions{.repLabel = int32_t(FLAGS_replabel),
-                                   .wordSepIsPartOfToken = FLAGS_usewordpiece,
-                                   .surround = FLAGS_surround,
-                                   .wordSep = FLAGS_wordseparator,
-                                   .targetPadIdx = targetpadVal});
+          DecodeMasterTrainOptions{
+              .repLabel = int32_t(FLAGS_replabel),
+              .wordSepIsPartOfToken = FLAGS_usewordpiece,
+              .surround = FLAGS_surround,
+              .wordSep = FLAGS_wordseparator,
+              .targetPadIdx = targetpadVal});
     } else {
       throw std::runtime_error(
           "Other decoders are not supported yet during training");
@@ -789,8 +791,9 @@ int main(int argc, char** argv) {
       fl::Variable output;
       if (usePlugin) {
         output = ntwrk
-                     ->forward({fl::input(batch[kInputIdx]),
-                                fl::noGrad(batch[kDurationIdx])})
+                     ->forward(
+                         {fl::input(batch[kInputIdx]),
+                          fl::noGrad(batch[kDurationIdx])})
                      .front();
       } else {
         output = fl::ext::forwardSequentialModuleWithPadMask(

--- a/flashlight/app/asr/test/augmentation/AdditiveNoiseTest.cpp
+++ b/flashlight/app/asr/test/augmentation/AdditiveNoiseTest.cpp
@@ -11,14 +11,15 @@
 #include "flashlight/app/asr/augmentation/AdditiveNoise.h"
 #include "flashlight/app/asr/augmentation/SoundEffectUtil.h"
 #include "flashlight/app/asr/data/Sound.h"
+#include "flashlight/fl/common/Init.h"
 #include "flashlight/lib/common/System.h"
 
 using namespace ::fl::app::asr::sfx;
 using ::fl::app::asr::saveSound;
 using ::fl::lib::dirCreateRecursive;
+using ::fl::lib::getTmpPath;
 using ::fl::lib::pathsConcat;
 using ::testing::Pointwise;
-using ::fl::lib::getTmpPath;
 
 const size_t sampleRate = 16000;
 
@@ -64,7 +65,7 @@ TEST(AdditiveNoise, Snr) {
     listFile << noiseFilePath;
   }
 
-  float threshold = 0.02 ; // allow 2% difference from expected value
+  float threshold = 0.02; // allow 2% difference from expected value
 
   for (float snr = 1; snr < 30; ++snr) {
     AdditiveNoise::Config conf;
@@ -82,15 +83,20 @@ TEST(AdditiveNoise, Snr) {
 
     std::vector<float> extractNoise(augmented.size());
     for (int i = 0; i < extractNoise.size(); ++i) {
-      extractNoise[i] = (augmented[i] - signal[i]) ;
+      extractNoise[i] = (augmented[i] - signal[i]);
     }
 
-    ASSERT_LE(signalToNoiseRatio(signal, extractNoise), (conf.maxSnr_ * (1 + threshold)));
-    ASSERT_GE(signalToNoiseRatio(signal, extractNoise), (conf.minSnr_ * (1 - threshold)));
+    ASSERT_LE(
+        signalToNoiseRatio(signal, extractNoise),
+        (conf.maxSnr_ * (1 + threshold)));
+    ASSERT_GE(
+        signalToNoiseRatio(signal, extractNoise),
+        (conf.minSnr_ * (1 - threshold)));
   }
 }
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
   return RUN_ALL_TESTS();
 }

--- a/flashlight/app/asr/test/augmentation/GaussianNoiseTest.cpp
+++ b/flashlight/app/asr/test/augmentation/GaussianNoiseTest.cpp
@@ -10,34 +10,36 @@
 
 #include "flashlight/app/asr/augmentation/GaussianNoise.h"
 #include "flashlight/app/asr/augmentation/SoundEffectUtil.h"
+#include "flashlight/fl/common/Init.h"
 
 using namespace ::fl::app::asr::sfx;
 
 const int numSamples = 10000;
 
 TEST(GaussianNoise, SnrCheck) {
-    RandomNumberGenerator rng(0);
-    std::vector<float> signal(numSamples);
-    for (auto& i : signal) {
-        i = rng.random() ;
-    }
+  RandomNumberGenerator rng(0);
+  std::vector<float> signal(numSamples);
+  for (auto& i : signal) {
+    i = rng.random();
+  }
 
-    GaussianNoise::Config cfg;
-    cfg.minSnr_ = 9;
-    cfg.maxSnr_ = 11;
-    GaussianNoise sfx(cfg);
-    auto originalSignal = signal;
-    sfx.apply(signal);
-    ASSERT_EQ(signal.size(), originalSignal.size());
-    std::vector<float> noise(signal.size());
-    for (int i = 0 ;i < noise.size(); ++i) {
-      noise[i] = signal[i] - originalSignal[i];
-    }
-    ASSERT_LE(signalToNoiseRatio(originalSignal, noise), cfg.maxSnr_);
-    ASSERT_GE(signalToNoiseRatio(originalSignal, noise), cfg.minSnr_);
+  GaussianNoise::Config cfg;
+  cfg.minSnr_ = 9;
+  cfg.maxSnr_ = 11;
+  GaussianNoise sfx(cfg);
+  auto originalSignal = signal;
+  sfx.apply(signal);
+  ASSERT_EQ(signal.size(), originalSignal.size());
+  std::vector<float> noise(signal.size());
+  for (int i = 0; i < noise.size(); ++i) {
+    noise[i] = signal[i] - originalSignal[i];
+  }
+  ASSERT_LE(signalToNoiseRatio(originalSignal, noise), cfg.maxSnr_);
+  ASSERT_GE(signalToNoiseRatio(originalSignal, noise), cfg.minSnr_);
 }
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
   return RUN_ALL_TESTS();
 }

--- a/flashlight/app/asr/test/augmentation/ReverberationTest.cpp
+++ b/flashlight/app/asr/test/augmentation/ReverberationTest.cpp
@@ -9,6 +9,7 @@
 #include <gtest/gtest.h>
 
 #include "flashlight/app/asr/augmentation/Reverberation.h"
+#include "flashlight/fl/common/Init.h"
 
 using namespace ::fl::app::asr::sfx;
 using testing::Pointwise;
@@ -131,5 +132,6 @@ TEST(ReverbEcho, SinWaveReverb) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
   return RUN_ALL_TESTS();
 }

--- a/flashlight/app/asr/test/augmentation/SoundEffectConfigTest.cpp
+++ b/flashlight/app/asr/test/augmentation/SoundEffectConfigTest.cpp
@@ -10,6 +10,7 @@
 
 #include "flashlight/app/asr/augmentation/SoundEffect.h"
 #include "flashlight/app/asr/augmentation/SoundEffectConfig.h"
+#include "flashlight/fl/common/Init.h"
 #include "flashlight/lib/common/System.h"
 
 using namespace ::fl::app::asr::sfx;
@@ -72,5 +73,6 @@ TEST(SoundEffectConfigFile, ReadWriteJson) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
   return RUN_ALL_TESTS();
 }

--- a/flashlight/app/asr/test/augmentation/SoundEffectTest.cpp
+++ b/flashlight/app/asr/test/augmentation/SoundEffectTest.cpp
@@ -9,6 +9,7 @@
 #include <gtest/gtest.h>
 
 #include "flashlight/app/asr/augmentation/SoundEffect.h"
+#include "flashlight/fl/common/Init.h"
 
 using namespace ::fl::app::asr::sfx;
 using ::testing::AllOf;
@@ -161,5 +162,6 @@ TEST(SoundEffect, SfxChain) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
   return RUN_ALL_TESTS();
 }

--- a/flashlight/app/asr/test/criterion/BenchmarkASG.cpp
+++ b/flashlight/app/asr/test/criterion/BenchmarkASG.cpp
@@ -20,6 +20,8 @@ using namespace fl::app::asr;
 
 int main() {
   af::setDevice(1);
+  fl::init();
+
   int N = 30, T = 487, L = 34, B = 20;
 
   auto asg = AutoSegmentationCriterion(N);

--- a/flashlight/app/asr/test/criterion/BenchmarkCTC.cpp
+++ b/flashlight/app/asr/test/criterion/BenchmarkCTC.cpp
@@ -21,6 +21,8 @@ using namespace fl::app::asr;
 int main() {
   af::info();
   af::setDevice(1);
+  fl::init();
+
   auto ctc = ConnectionistTemporalClassificationCriterion();
 
   int N = 30, T = 487, L = 34, B = 10;

--- a/flashlight/app/asr/test/criterion/BenchmarkSeq2Seq.cpp
+++ b/flashlight/app/asr/test/criterion/BenchmarkSeq2Seq.cpp
@@ -79,6 +79,8 @@ void timeForwardBackward() {
 
 int main() {
   af::info();
+  fl::init();
+
   timeForwardBackward();
   timeBeamSearch();
   return 0;

--- a/flashlight/app/asr/test/criterion/CompareASG.cpp
+++ b/flashlight/app/asr/test/criterion/CompareASG.cpp
@@ -95,6 +95,7 @@ void printDiscrepancies(
 } // namespace
 
 int main(int argc, char** argv) {
+  fl::init();
   if (argc < 2) {
     usage(argv[0]);
   }

--- a/flashlight/app/asr/test/criterion/CriterionTest.cpp
+++ b/flashlight/app/asr/test/criterion/CriterionTest.cpp
@@ -11,7 +11,7 @@
 #include <array>
 
 #include "flashlight/app/asr/criterion/criterion.h"
-
+#include "flashlight/fl/common/Init.h"
 #include "flashlight/lib/common/System.h"
 
 using namespace fl;
@@ -900,5 +900,6 @@ TEST(CriterionTest, AsgSerialization) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
   return RUN_ALL_TESTS();
 }

--- a/flashlight/app/asr/test/criterion/Seq2SeqTest.cpp
+++ b/flashlight/app/asr/test/criterion/Seq2SeqTest.cpp
@@ -325,38 +325,39 @@ TEST(Seq2SeqTest, BatchedDecoderStep) {
   std::vector<std::shared_ptr<AttentionBase>> neuralContentAttentions(
       nAttnRound, std::make_shared<NeuralContentAttention>(H));
 
-  std::vector<Seq2SeqCriterion> criterions{Seq2SeqCriterion(
-                                               N,
-                                               H,
-                                               N - 1,
-                                               maxoutputlen,
-                                               contentAttentions,
-                                               nullptr,
-                                               false,
-                                               100,
-                                               0.0,
-                                               false,
-                                               kRandSampling,
-                                               1.0,
-                                               nRnnLayer,
-                                               nAttnRound,
-                                               0.0),
-                                           Seq2SeqCriterion(
-                                               N,
-                                               H,
-                                               N - 1,
-                                               maxoutputlen,
-                                               neuralContentAttentions,
-                                               nullptr,
-                                               false,
-                                               100,
-                                               0.0,
-                                               false,
-                                               kRandSampling,
-                                               1.0,
-                                               nRnnLayer,
-                                               nAttnRound,
-                                               0.0)};
+  std::vector<Seq2SeqCriterion> criterions{
+      Seq2SeqCriterion(
+          N,
+          H,
+          N - 1,
+          maxoutputlen,
+          contentAttentions,
+          nullptr,
+          false,
+          100,
+          0.0,
+          false,
+          kRandSampling,
+          1.0,
+          nRnnLayer,
+          nAttnRound,
+          0.0),
+      Seq2SeqCriterion(
+          N,
+          H,
+          N - 1,
+          maxoutputlen,
+          neuralContentAttentions,
+          nullptr,
+          false,
+          100,
+          0.0,
+          false,
+          kRandSampling,
+          1.0,
+          nRnnLayer,
+          nAttnRound,
+          0.0)};
 
   for (auto& seq2seq : criterions) {
     seq2seq.eval();
@@ -466,5 +467,6 @@ TEST(Seq2SeqTest, Seq2SeqSampling) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
   return RUN_ALL_TESTS();
 }

--- a/flashlight/app/asr/test/criterion/attention/AttentionTest.cpp
+++ b/flashlight/app/asr/test/criterion/attention/AttentionTest.cpp
@@ -110,5 +110,6 @@ TEST(AttentionTest, MultiHeadContentAttention) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
   return RUN_ALL_TESTS();
 }

--- a/flashlight/app/asr/test/criterion/attention/WindowTest.cpp
+++ b/flashlight/app/asr/test/criterion/attention/WindowTest.cpp
@@ -175,5 +175,6 @@ TEST(WindowTest, SoftPretrainWindow) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
   return RUN_ALL_TESTS();
 }

--- a/flashlight/app/asr/test/data/FeaturizationTest.cpp
+++ b/flashlight/app/asr/test/data/FeaturizationTest.cpp
@@ -15,7 +15,7 @@
 #include "flashlight/app/asr/data/ListFileDataset.h"
 #include "flashlight/app/asr/data/Utils.h"
 #include "flashlight/app/asr/decoder/TranscriptionUtils.h"
-
+#include "flashlight/fl/common/Init.h"
 #include "flashlight/lib/audio/feature/SpeechUtils.h"
 
 using namespace fl;
@@ -395,8 +395,8 @@ TEST(FeaturizationTest, targetFeaturizer) {
   auto tokenDict = getDict();
   tokenDict.addEntry(kEosToken);
   auto lexicon = getLexicon();
-  std::vector<std::vector<char>> targets = {{'a', 'b', 'c', 'c', 'c'},
-                                            {'b', 'c', 'd', 'd'}};
+  std::vector<std::vector<char>> targets = {
+      {'a', 'b', 'c', 'c', 'c'}, {'b', 'c', 'd', 'd'}};
 
   TargetGenerationConfig targetGenConfig(
       "",
@@ -452,5 +452,6 @@ TEST(FeaturizationTest, targetFeaturizer) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
   return RUN_ALL_TESTS();
 }

--- a/flashlight/app/asr/test/data/ListFileDatasetTest.cpp
+++ b/flashlight/app/asr/test/data/ListFileDatasetTest.cpp
@@ -13,7 +13,7 @@
 #include <gtest/gtest.h>
 
 #include "flashlight/app/asr/data/ListFileDataset.h"
-
+#include "flashlight/fl/common/Init.h"
 #include "flashlight/lib/common/String.h"
 #include "flashlight/lib/common/System.h"
 
@@ -64,6 +64,7 @@ TEST(ListFileDatasetTest, LoadData) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
 
 // Resolve directory for data
 #ifdef DATA_TEST_DATADIR

--- a/flashlight/app/asr/test/data/SoundTest.cpp
+++ b/flashlight/app/asr/test/data/SoundTest.cpp
@@ -12,6 +12,7 @@
 #include <sstream>
 
 #include "flashlight/app/asr/data/Sound.h"
+#include "flashlight/fl/common/Init.h"
 #include "flashlight/lib/common/System.h"
 
 using namespace fl::lib;
@@ -162,6 +163,7 @@ TEST(SoundTest, StreamReadWrite) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
 
 // Resolve directory for data
 #ifdef DATA_TEST_DATADIR

--- a/flashlight/app/asr/test/decoder/ConvLmModuleTest.cpp
+++ b/flashlight/app/asr/test/decoder/ConvLmModuleTest.cpp
@@ -116,6 +116,7 @@ TEST(ConvLmModuleTest, SerializationGCNN14BAdaptiveSoftmax) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
 
 // Resolve directory for arch
 #ifdef DECODER_TEST_DATADIR

--- a/flashlight/app/asr/test/decoder/DecoderTest.cpp
+++ b/flashlight/app/asr/test/decoder/DecoderTest.cpp
@@ -17,6 +17,7 @@
 #include "flashlight/app/asr/decoder/Defines.h"
 #include "flashlight/app/asr/decoder/TranscriptionUtils.h"
 #include "flashlight/app/asr/runtime/runtime.h"
+#include "flashlight/fl/common/Init.h"
 #include "flashlight/lib/common/System.h"
 #include "flashlight/lib/text/decoder/LexiconDecoder.h"
 #include "flashlight/lib/text/decoder/Trie.h"
@@ -191,6 +192,7 @@ TEST(DecoderTest, run) {
 }
 
 int main(int argc, char** argv) {
+  fl::init();
   google::InitGoogleLogging(argv[0]);
   google::InstallFailureSignalHandler();
   ::testing::InitGoogleTest(&argc, argv);

--- a/flashlight/app/asr/test/runtime/RuntimeTest.cpp
+++ b/flashlight/app/asr/test/runtime/RuntimeTest.cpp
@@ -12,11 +12,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "flashlight/fl/flashlight.h"
-
 #include "flashlight/app/asr/runtime/runtime.h"
 #include "flashlight/ext/common/Serializer.h"
-
+#include "flashlight/fl/flashlight.h"
 #include "flashlight/lib/common/System.h"
 
 using namespace fl::app::asr;
@@ -87,7 +85,8 @@ TEST(RuntimeTest, SpeechStatMeter) {
   std::array<int, 2> tgSizes1{6, 10};
   std::array<int, 4> inpSizes2{2, 4, 2, 8};
   std::array<int, 4> tgSizes2{3, 7, 2, 4};
-  meter.add(af::array(1, 2, inpSizes1.data()), af::array(1, 2, tgSizes1.data()));
+  meter.add(
+      af::array(1, 2, inpSizes1.data()), af::array(1, 2, tgSizes1.data()));
   af::array out;
   auto stats1 = meter.value();
   ASSERT_EQ(stats1[0], 9.0);
@@ -96,7 +95,8 @@ TEST(RuntimeTest, SpeechStatMeter) {
   ASSERT_EQ(stats1[3], 10.0);
   ASSERT_EQ(stats1[4], 2.0);
   ASSERT_EQ(stats1[5], 1);
-  meter.add(af::array(1, 4, inpSizes2.data()), af::array(1, 4, tgSizes2.data()));
+  meter.add(
+      af::array(1, 4, inpSizes2.data()), af::array(1, 4, tgSizes2.data()));
   auto stats2 = meter.value();
   ASSERT_EQ(stats2[0], 25.0);
   ASSERT_EQ(stats2[1], 32.0);
@@ -127,5 +127,6 @@ TEST(RuntimeTest, parseValidSets) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
   return RUN_ALL_TESTS();
 }

--- a/flashlight/app/asr/tools/VoiceActivityDetection-CTC.cpp
+++ b/flashlight/app/asr/tools/VoiceActivityDetection-CTC.cpp
@@ -77,6 +77,8 @@ int main(int argc, char** argv) {
     LOG(FATAL) << gflags::ProgramUsage();
   }
 
+  fl::init();
+
   /* ===================== Parse Options ===================== */
   LOG(INFO) << "Parsing command line flags";
   gflags::ParseCommandLineFlags(&argc, &argv, false);

--- a/flashlight/app/asr/tools/alignment/Align.cpp
+++ b/flashlight/app/asr/tools/alignment/Align.cpp
@@ -36,8 +36,9 @@ int main(int argc, char** argv) {
   if (argc <= 2) {
     LOG(FATAL) << gflags::ProgramUsage();
   }
-
   std::string alignFilePath = argv[1];
+
+  fl::init();
 
   /* ===================== Parse Options ===================== */
   LOG(INFO) << "Parsing command line flags";

--- a/flashlight/app/asr/tutorial/FinetuneCTC.cpp
+++ b/flashlight/app/asr/tutorial/FinetuneCTC.cpp
@@ -53,6 +53,8 @@ int main(int argc, char** argv) {
   }
   gflags::SetUsageMessage("Usage: \n " + exec + " [model] [flags]");
 
+  fl::init();
+
   /* ===================== Parse Options ===================== */
   int runIdx = 1; // current #runs in this path
   std::string reloadPath = argv[1]; // path to model to reload

--- a/flashlight/app/asr/tutorial/InferenceCTC.cpp
+++ b/flashlight/app/asr/tutorial/InferenceCTC.cpp
@@ -125,6 +125,8 @@ int main(int argc, char** argv) {
     argvs.emplace_back(argv[i]);
   }
 
+  fl::init();
+
   /* ===================== Parse Options ===================== */
   LOG(INFO) << "Parsing command line flags";
   gflags::ParseCommandLineFlags(&argc, &argv, false);

--- a/flashlight/app/imgclass/examples/ImageNetResnet34.cpp
+++ b/flashlight/app/imgclass/examples/ImageNetResnet34.cpp
@@ -88,6 +88,7 @@ std::tuple<double, double, double> evalLoop(
 };
 
 int main(int argc, char** argv) {
+  fl::init();
   google::InitGoogleLogging(argv[0]);
   google::InstallFailureSignalHandler();
   gflags::ParseCommandLineFlags(&argc, &argv, true);

--- a/flashlight/app/lm/BuildDictionary.cpp
+++ b/flashlight/app/lm/BuildDictionary.cpp
@@ -11,8 +11,8 @@
 
 #include "flashlight/app/lm/common/Defines.h"
 #include "flashlight/app/lm/common/Helpers.h"
+#include "flashlight/fl/common/Init.h"
 #include "flashlight/fl/common/Logging.h"
-
 #include "flashlight/lib/common/String.h"
 #include "flashlight/lib/common/System.h"
 #include "flashlight/lib/text/tokenizer/Tokenizer.h"
@@ -70,6 +70,7 @@ DEFINE_bool(
 } // namespace
 
 int main(int argc, char** argv) {
+  fl::init();
   std::string exec(argv[0]);
   gflags::SetUsageMessage(
       "Preparation of tokens dictionary from the text data. \n Usage: " + exec +

--- a/flashlight/app/lm/Train.cpp
+++ b/flashlight/app/lm/Train.cpp
@@ -12,8 +12,10 @@ using namespace fl::lib;
 using namespace fl::app::lm;
 
 int main(int argc, char** argv) {
+  fl::init();
   /* Parse or load persistent states */
   gflags::ParseCommandLineFlags(&argc, &argv, false);
+
   if (FLAGS_distributed_enable) {
     initDistributed(
         FLAGS_distributed_world_rank,

--- a/flashlight/app/lm/test/data/TextDatasetTest.cpp
+++ b/flashlight/app/lm/test/data/TextDatasetTest.cpp
@@ -10,12 +10,12 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "flashlight/app/lm/data/TextDataset.h"
+#include "flashlight/fl/common/Init.h"
 #include "flashlight/lib/text/dictionary/Defines.h"
 #include "flashlight/lib/text/dictionary/Dictionary.h"
 #include "flashlight/lib/text/tokenizer/PartialFileReader.h"
 #include "flashlight/lib/text/tokenizer/Tokenizer.h"
-
-#include "flashlight/app/lm/data/TextDataset.h"
 
 using fl::lib::pathsConcat;
 using namespace fl::lib;
@@ -134,6 +134,7 @@ TEST(TextDatasetTest, EosModeWithDynamicBatching) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
 
 #ifdef TEXTDATASET_TEST_DATADIR
   dataDir = TEXTDATASET_TEST_DATADIR;

--- a/flashlight/ext/test/common/SequentialBuilderTest.cpp
+++ b/flashlight/ext/test/common/SequentialBuilderTest.cpp
@@ -8,7 +8,7 @@
 #include <gtest/gtest.h>
 
 #include "flashlight/ext/common/SequentialBuilder.h"
-
+#include "flashlight/fl/common/Init.h"
 #include "flashlight/lib/common/System.h"
 
 using namespace fl;
@@ -76,6 +76,7 @@ TEST(SequentialBuilderTest, Serialization) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
 
 // Resolve directory for arch
 #ifdef ARCHDIR

--- a/flashlight/ext/test/plugin/ModulePluginTest.cpp
+++ b/flashlight/ext/test/plugin/ModulePluginTest.cpp
@@ -10,8 +10,8 @@
 #include <gtest/gtest.h>
 
 #include "flashlight/ext/plugin/ModulePlugin.h"
-#include "flashlight/fl/flashlight.h"
 #include "flashlight/fl/contrib/modules/modules.h"
+#include "flashlight/fl/flashlight.h"
 #include "flashlight/lib/common/System.h"
 
 using namespace fl;
@@ -47,6 +47,7 @@ TEST(ModulePluginTest, ModulePlugin) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
 
   // Resolve directory for arch
 #ifdef PLUGINDIR

--- a/flashlight/fl/common/CMakeLists.txt
+++ b/flashlight/fl/common/CMakeLists.txt
@@ -7,6 +7,7 @@ set(
   ${CMAKE_CURRENT_LIST_DIR}/DevicePtr.cpp
   ${CMAKE_CURRENT_LIST_DIR}/Defines.cpp
   ${CMAKE_CURRENT_LIST_DIR}/DynamicBenchmark.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/Init.cpp
   ${CMAKE_CURRENT_LIST_DIR}/Logging.cpp
   ${CMAKE_CURRENT_LIST_DIR}/Histogram.cpp
   ${CMAKE_CURRENT_LIST_DIR}/Plugin.cpp

--- a/flashlight/fl/common/Init.cpp
+++ b/flashlight/fl/common/Init.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <mutex>
+
+#include <af/device.h>
+
+#include "flashlight/fl/memory/MemoryManagerInstaller.h"
+
+namespace fl {
+namespace {
+std::once_flag flInitFlag;
+}
+
+/**
+ * Initialize Flashlight. Performs setup, including:
+ * - Ensures ArrayFire globals are initialized
+ * - Sets the default memory manager (CachingMemoryManager)
+ *
+ * Can only be called once per process. Subsequent calls will be noops.
+ */
+void init() {
+  std::call_once(flInitFlag, []() {
+    af_init();
+    MemoryManagerInstaller::installDefaultMemoryManager();
+  });
+}
+
+} // namespace fl

--- a/flashlight/fl/common/Init.h
+++ b/flashlight/fl/common/Init.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace fl {
+
+/**
+ * Initialize Flashlight.
+ */
+void init();
+
+} // namespace fl

--- a/flashlight/fl/common/common.h
+++ b/flashlight/fl/common/common.h
@@ -11,6 +11,7 @@
 #include "flashlight/fl/common/Defines.h"
 #include "flashlight/fl/common/DevicePtr.h"
 #include "flashlight/fl/common/DynamicBenchmark.h"
+#include "flashlight/fl/common/Init.h"
 #include "flashlight/fl/common/Serialization.h"
 #include "flashlight/fl/common/Types.h"
 #include "flashlight/fl/common/Utils.h"

--- a/flashlight/fl/examples/AdaptiveClassification.cpp
+++ b/flashlight/fl/examples/AdaptiveClassification.cpp
@@ -5,12 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include "flashlight/fl/common/Init.h"
 #include "flashlight/fl/nn/nn.h"
 #include "flashlight/fl/optim/optim.h"
 
 using namespace fl;
 
 int main(int /* unused */, const char** /* unused */) {
+  fl::init();
   int nsamples = 100;
   int categories = 3;
   int feature_dim = 10;

--- a/flashlight/fl/examples/Benchmark.cpp
+++ b/flashlight/fl/examples/Benchmark.cpp
@@ -8,6 +8,7 @@
 #include <iomanip>
 #include <iostream>
 
+#include "flashlight/fl/common/Init.h"
 #include "flashlight/fl/nn/nn.h"
 
 using namespace fl;
@@ -140,6 +141,7 @@ double layerNorm() {
 
 int main() {
   af::info();
+  fl::init();
   TIME(alexnet);
   TIME(embedding);
   TIME(linear);

--- a/flashlight/fl/examples/Classification.cpp
+++ b/flashlight/fl/examples/Classification.cpp
@@ -5,12 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include "flashlight/fl/common/Init.h"
 #include "flashlight/fl/nn/nn.h"
 #include "flashlight/fl/optim/optim.h"
 
 using namespace fl;
 
 int main(int /* unused */, const char** /* unused */) {
+  fl::init();
   int nsamples = 500;
   int categories = 3;
   int feature_dim = 10;

--- a/flashlight/fl/examples/DistributedTraining.cpp
+++ b/flashlight/fl/examples/DistributedTraining.cpp
@@ -12,8 +12,8 @@
 using namespace fl;
 
 int main() {
+  fl::init();
   af::info();
-
   fl::distributedInit(
       fl::DistributedInit::MPI,
       -1, // worldRank - unused. Automatically derived from `MPI_Comm_Rank`

--- a/flashlight/fl/examples/LinearRegression.cpp
+++ b/flashlight/fl/examples/LinearRegression.cpp
@@ -11,6 +11,7 @@
 
 int main() {
   af::info();
+  fl::init();
 
   // Create data
   const int nSamples = 10000;

--- a/flashlight/fl/examples/Mnist.cpp
+++ b/flashlight/fl/examples/Mnist.cpp
@@ -77,6 +77,7 @@ std::pair<array, array> load_dataset(
 } // namespace
 
 int main(int argc, char** argv) {
+  fl::init();
   if (argc != 2) {
     throw af::exception("You must pass a data directory.");
   }

--- a/flashlight/fl/examples/Perceptron.cpp
+++ b/flashlight/fl/examples/Perceptron.cpp
@@ -12,6 +12,7 @@
 using namespace fl;
 
 int main() {
+  fl::init();
   af::info();
 
   // Create dataset

--- a/flashlight/fl/examples/RnnClassification.cpp
+++ b/flashlight/fl/examples/RnnClassification.cpp
@@ -75,23 +75,24 @@ class ClassificationDataset : public Dataset {
 
   ClassificationDataset(const std::string datasetPath) {
     // As found in the dataset folder:
-    std::vector<std::string> lang = {"Arabic",
-                                     "Greek",
-                                     "Chinese",
-                                     "Czech",
-                                     "Dutch",
-                                     "Japanese",
-                                     "Korean",
-                                     "Russian",
-                                     "English",
-                                     "Scottish",
-                                     "Vietnamese",
-                                     "German",
-                                     "Spanish",
-                                     "French",
-                                     "Polish",
-                                     "Italian",
-                                     "Irish"};
+    std::vector<std::string> lang = {
+        "Arabic",
+        "Greek",
+        "Chinese",
+        "Czech",
+        "Dutch",
+        "Japanese",
+        "Korean",
+        "Russian",
+        "English",
+        "Scottish",
+        "Vietnamese",
+        "German",
+        "Spanish",
+        "French",
+        "Polish",
+        "Italian",
+        "Irish"};
     for (auto& l : lang)
       read(datasetPath, l);
     for (auto& it : Id2Label)
@@ -218,6 +219,7 @@ class RnnClassifier : public Container {
 };
 
 int main(int argc, char** argv) {
+  fl::init();
   std::cout << "RnnClassification (path to the data dir) (learning rate) (num "
                "epochs) (hiddensize)"
             << std::endl;

--- a/flashlight/fl/examples/RnnLm.cpp
+++ b/flashlight/fl/examples/RnnLm.cpp
@@ -129,9 +129,11 @@ class RnnLm : public Container {
 } // namespace
 
 int main(int argc, char** argv) {
+  fl::init();
   if (argc != 2) {
     throw af::exception("You must pass a data directory.");
   }
+
   std::string data_dir = argv[1];
 
   std::string train_dir = data_dir + "/ptb.train.txt";
@@ -269,6 +271,7 @@ LMDataset::LMDataset(
 std::vector<af::array> LMDataset::get(const int64_t idx) const {
   int start = idx * time_steps;
   int end = (idx + 1) * time_steps - 1;
-  return {data(af::span, af::seq(start, end)),
-          data(af::span, af::seq(start + 1, end + 1))};
+  return {
+      data(af::span, af::seq(start, end)),
+      data(af::span, af::seq(start + 1, end + 1))};
 }

--- a/flashlight/fl/examples/Xor.cpp
+++ b/flashlight/fl/examples/Xor.cpp
@@ -13,6 +13,7 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
+#include "flashlight/fl/common/Init.h"
 #include "flashlight/fl/nn/nn.h"
 #include "flashlight/fl/optim/optim.h"
 
@@ -28,6 +29,7 @@ int main(int argc, const char** argv) {
     std::cerr << "usage: " << argv[0] << " [--adam | --rmsprop]\n";
     return 1;
   }
+  fl::init();
 
   int optim_mode = 0;
   std::string optimizer_arg = std::string(argv[1]);

--- a/flashlight/fl/memory/MemoryManagerInstaller.cpp
+++ b/flashlight/fl/memory/MemoryManagerInstaller.cpp
@@ -23,12 +23,6 @@ std::shared_ptr<MemoryManagerInstaller>
 std::shared_ptr<MemoryManagerAdapter>
     MemoryManagerInstaller::currentlyInstalledMemoryManager_;
 
-namespace {
-
-bool init = MemoryManagerInstaller::installDefaultMemoryManager();
-
-} // namespace
-
 MemoryManagerAdapter* MemoryManagerInstaller::getImpl(
     af_memory_manager manager) {
   void* ptr;
@@ -227,7 +221,7 @@ MemoryManagerInstaller::currentlyInstalledMemoryManager() {
   return currentlyInstalledMemoryManager_.get();
 }
 
-bool MemoryManagerInstaller::installDefaultMemoryManager() {
+void MemoryManagerInstaller::installDefaultMemoryManager() {
   std::call_once(startupMemoryInitialize_, []() {
     auto deviceInterface = std::make_shared<MemoryManagerDeviceInterface>();
     auto adapter = std::make_shared<CachingMemoryManager>(
@@ -237,7 +231,6 @@ bool MemoryManagerInstaller::installDefaultMemoryManager() {
     MemoryManagerInstaller::startupMemoryManagerInstaller_
         ->setAsMemoryManager();
   });
-  return true;
 }
 
 void MemoryManagerInstaller::unsetMemoryManager() {

--- a/flashlight/fl/memory/MemoryManagerInstaller.h
+++ b/flashlight/fl/memory/MemoryManagerInstaller.h
@@ -89,7 +89,7 @@ class MemoryManagerInstaller {
    * @return a pointer to the `MemoryManagerInstaller` for the default memory
    * manager.
    */
-  static bool installDefaultMemoryManager();
+  static void installDefaultMemoryManager();
 
   /**
    * Unsets the currently-set custom ArrayFire memory manager. If no custom

--- a/flashlight/fl/test/autograd/AutogradTest.cpp
+++ b/flashlight/fl/test/autograd/AutogradTest.cpp
@@ -18,7 +18,9 @@
 #include <stdexcept>
 
 #include <gtest/gtest.h>
+
 #include "flashlight/fl/autograd/autograd.h"
+#include "flashlight/fl/common/Init.h"
 #include "flashlight/fl/common/common.h"
 
 using namespace fl;
@@ -1805,5 +1807,6 @@ TEST(AutogradTest, GetAdvancedIndexF16) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
   return RUN_ALL_TESTS();
 }

--- a/flashlight/fl/test/common/DevicePtrTest.cpp
+++ b/flashlight/fl/test/common/DevicePtrTest.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include "flashlight/fl/common/DevicePtr.h"
+#include "flashlight/fl/common/Init.h"
 
 using namespace fl;
 
@@ -60,5 +61,6 @@ TEST(DevicePtrTest, Move) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
   return RUN_ALL_TESTS();
 }

--- a/flashlight/fl/test/common/DynamicBenchmarkTest.cpp
+++ b/flashlight/fl/test/common/DynamicBenchmarkTest.cpp
@@ -13,6 +13,7 @@
 #include <gtest/gtest.h>
 
 #include "flashlight/fl/common/DynamicBenchmark.h"
+#include "flashlight/fl/common/Init.h"
 
 namespace {
 
@@ -142,4 +143,10 @@ TEST_F(DynamicBenchmark, DynamicBenchmarkMatmul) {
   auto ops = dynamicBench->getOptions<fl::DynamicBenchmarkOptions<int>>();
   ASSERT_TRUE(ops->timingsComplete());
   ASSERT_EQ(ops->currentOption(), 4);
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
+  return RUN_ALL_TESTS();
 }

--- a/flashlight/fl/test/common/HistogramTest.cpp
+++ b/flashlight/fl/test/common/HistogramTest.cpp
@@ -10,6 +10,7 @@
 #include <gtest/gtest.h>
 
 #include "flashlight/fl/common/Histogram.h"
+#include "flashlight/fl/common/Init.h"
 
 using namespace fl;
 
@@ -132,5 +133,6 @@ TEST(FixedBucketSizeHistogram, ExponentialDistribution) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
   return RUN_ALL_TESTS();
 }

--- a/flashlight/fl/test/common/LoggingTest.cpp
+++ b/flashlight/fl/test/common/LoggingTest.cpp
@@ -10,6 +10,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "flashlight/fl/common/Init.h"
 #include "flashlight/fl/common/Logging.h"
 
 using namespace fl;
@@ -137,5 +138,6 @@ TEST(LoggingDeathTest, FatalOnOff) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
   return RUN_ALL_TESTS();
 }

--- a/flashlight/fl/test/common/SerializationTest.cpp
+++ b/flashlight/fl/test/common/SerializationTest.cpp
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 
+#include "flashlight/fl/common/Init.h"
 #include "flashlight/fl/common/Serialization.h"
 
 // ========== utility functions ==========
@@ -240,5 +241,6 @@ TEST(SerializationTest, TemporaryRvalues) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
   return RUN_ALL_TESTS();
 }

--- a/flashlight/fl/test/contrib/modules/ContribModuleTest.cpp
+++ b/flashlight/fl/test/contrib/modules/ContribModuleTest.cpp
@@ -497,5 +497,6 @@ TEST(ContribModuleTest, RawWavSpecAugmentFwd) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
   return RUN_ALL_TESTS();
 }

--- a/flashlight/fl/test/contrib/modules/ContribSerializationTest.cpp
+++ b/flashlight/fl/test/contrib/modules/ContribSerializationTest.cpp
@@ -12,9 +12,9 @@
 #include <gtest/gtest.h>
 
 #include "flashlight/fl/autograd/autograd.h"
+#include "flashlight/fl/common/Init.h"
 #include "flashlight/fl/contrib/modules/modules.h"
 #include "flashlight/fl/nn/nn.h"
-
 #include "flashlight/lib/common/System.h"
 
 using namespace fl;
@@ -64,7 +64,7 @@ TEST(SerializationTest, Transformer) {
   int nheads = 4;
 
   auto model = std::make_shared<Transformer>(
-    c, c / nheads, c, nheads, timesteps, 0.2, 0.1, false, false);
+      c, c / nheads, c, nheads, timesteps, 0.2, 0.1, false, false);
   model->eval();
 
   const std::string path = fl::lib::getTmpPath("Transformer.mdl");
@@ -89,7 +89,7 @@ TEST(SerializationTest, ConformerSerialization) {
   int nheads = 4;
 
   auto model = std::make_shared<Conformer>(
-    c, c / nheads, c, nheads, timesteps, 33, 0.2, 0.1);
+      c, c / nheads, c, nheads, timesteps, 33, 0.2, 0.1);
   model->eval();
 
   const std::string path = fl::lib::getTmpPath("Conformer.mdl");
@@ -129,7 +129,8 @@ TEST(SerializationTest, PositionEmbedding) {
 TEST(SerializationTest, SinusoidalPositionEmbedding) {
   auto model = std::make_shared<SinusoidalPositionEmbedding>(128, 2.);
 
-  const std::string path = fl::lib::getTmpPath("SinusoidalPositionEmbedding.mdl");
+  const std::string path =
+      fl::lib::getTmpPath("SinusoidalPositionEmbedding.mdl");
   save(path, model);
 
   std::shared_ptr<SinusoidalPositionEmbedding> loaded;
@@ -163,7 +164,8 @@ TEST(SerializationTest, AdaptiveEmbedding) {
 }
 
 TEST(SerializationTest, RawWavSpecAugment) {
-  auto model = std::make_shared<RawWavSpecAugment>(0, 1, 1, 0, 0, 0, 1, 2000, 6000, 16000, 20000);
+  auto model = std::make_shared<RawWavSpecAugment>(
+      0, 1, 1, 0, 0, 0, 1, 2000, 6000, 16000, 20000);
   model->eval();
 
   const std::string path = fl::lib::getTmpPath("RawWavSpecAugment.mdl");
@@ -175,20 +177,23 @@ TEST(SerializationTest, RawWavSpecAugment) {
 
   int T = 300;
   auto time = 2 * M_PI * af::iota(af::dim4(T)) / 16000;
-  auto finalWav =
-    af::sin(time * 500) + af::sin(time * 1000) + af::sin(time * 7000) + af::sin(time * 7500);
-  auto inputWav = finalWav + af::sin(time * 3000) + af::sin(time * 4000) + af::sin(time * 5000);
+  auto finalWav = af::sin(time * 500) + af::sin(time * 1000) +
+      af::sin(time * 7000) + af::sin(time * 7500);
+  auto inputWav = finalWav + af::sin(time * 3000) + af::sin(time * 4000) +
+      af::sin(time * 5000);
 
   auto filteredWav = loaded->forward(fl::Variable(inputWav, false));
   // compare middle of filtered wave to avoid edge artifacts comparison
   int halfKernelWidth = 63;
   ASSERT_TRUE(fl::allClose(
-    fl::Variable(finalWav.rows(halfKernelWidth, T - halfKernelWidth - 1), false),
-    filteredWav.rows(halfKernelWidth, T - halfKernelWidth - 1),
-    1e-3));
+      fl::Variable(
+          finalWav.rows(halfKernelWidth, T - halfKernelWidth - 1), false),
+      filteredWav.rows(halfKernelWidth, T - halfKernelWidth - 1),
+      1e-3));
 }
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
   return RUN_ALL_TESTS();
 }

--- a/flashlight/fl/test/dataset/DatasetTest.cpp
+++ b/flashlight/fl/test/dataset/DatasetTest.cpp
@@ -11,8 +11,8 @@
 #include <arrayfire.h>
 #include <gtest/gtest.h>
 
+#include "flashlight/fl/common/Init.h"
 #include "flashlight/fl/dataset/datasets.h"
-
 #include "flashlight/lib/common/System.h"
 
 using namespace fl;
@@ -28,8 +28,8 @@ bool allClose(
 }
 
 TEST(DatasetTest, TensorDataset) {
-  std::vector<af::array> tensormap = {af::randu(100, 200, 300),
-                                      af::randu(150, 300)};
+  std::vector<af::array> tensormap = {
+      af::randu(100, 200, 300), af::randu(150, 300)};
   TensorDataset tensords(tensormap);
 
   // Check `size` method
@@ -280,7 +280,8 @@ TEST(DatasetTest, FileBlobDataset) {
   // multi-threaded read
   {
     std::vector<std::vector<af::array>> thdata(data.size());
-    auto blob = std::make_shared<FileBlobDataset>(fl::lib::getTmpPath("data.blob"));
+    auto blob =
+        std::make_shared<FileBlobDataset>(fl::lib::getTmpPath("data.blob"));
     std::vector<std::thread> workers;
     const int nworker = 4;
     int nperworker = data.size() / nworker;
@@ -318,8 +319,8 @@ TEST(DatasetTest, FileBlobDataset) {
       data[i].push_back(af::constant(i, 1, f32));
     }
     {
-      auto blob =
-          std::make_shared<FileBlobDataset>(fl::lib::getTmpPath("data.blob"), true, true);
+      auto blob = std::make_shared<FileBlobDataset>(
+          fl::lib::getTmpPath("data.blob"), true, true);
       std::vector<std::thread> workers;
       const int nworker = 10;
       int nperworker = data.size() / nworker;
@@ -338,7 +339,8 @@ TEST(DatasetTest, FileBlobDataset) {
       blob->writeIndex();
     }
     {
-      auto blob = std::make_shared<FileBlobDataset>(fl::lib::getTmpPath("data.blob"));
+      auto blob =
+          std::make_shared<FileBlobDataset>(fl::lib::getTmpPath("data.blob"));
       ASSERT_EQ(data.size(), blob->size());
       for (int64_t i = 0; i < data.size(); i++) {
         auto blobSample = blob->get(i);
@@ -574,5 +576,6 @@ TEST(DatasetTest, DISABLED_PrefetchDatasetPerformance) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
   return RUN_ALL_TESTS();
 }

--- a/flashlight/fl/test/dataset/DatasetUtilsTest.cpp
+++ b/flashlight/fl/test/dataset/DatasetUtilsTest.cpp
@@ -11,6 +11,7 @@
 #include <arrayfire.h>
 #include <gtest/gtest.h>
 
+#include "flashlight/fl/common/Init.h"
 #include "flashlight/fl/dataset/datasets.h"
 
 using namespace fl;
@@ -55,5 +56,6 @@ TEST(DatasetTest, DynamicRoundRobinPacker) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
   return RUN_ALL_TESTS();
 }

--- a/flashlight/fl/test/distributed/AllReduceBenchmark.cpp
+++ b/flashlight/fl/test/distributed/AllReduceBenchmark.cpp
@@ -10,11 +10,13 @@
 #include <string>
 #include <vector>
 
+#include "flashlight/fl/common/Init.h"
 #include "flashlight/fl/distributed/distributed.h"
 
 using namespace fl;
 
 int main() {
+  fl::init();
   distributedInit(
       DistributedInit::MPI,
       -1,

--- a/flashlight/fl/test/distributed/AllReduceTest.cpp
+++ b/flashlight/fl/test/distributed/AllReduceTest.cpp
@@ -13,10 +13,10 @@
 
 #include <gtest/gtest.h>
 
+#include "flashlight/fl/common/Init.h"
+#include "flashlight/fl/distributed/distributed.h"
 #include "flashlight/lib/common/String.h"
 #include "flashlight/lib/common/System.h"
-
-#include "flashlight/fl/distributed/distributed.h"
 
 using namespace fl;
 
@@ -179,6 +179,7 @@ TEST(Distributed, CoalescingReducer) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
 
   try {
     distributedInit(

--- a/flashlight/fl/test/memory/CachingMemoryManagerTest.cpp
+++ b/flashlight/fl/test/memory/CachingMemoryManagerTest.cpp
@@ -14,6 +14,7 @@
 #include <arrayfire.h>
 #include <gtest/gtest.h>
 
+#include "flashlight/fl/common/Init.h"
 #include "flashlight/fl/memory/memory.h"
 
 class CachingMemoryManagerTest : public ::testing::Test {
@@ -193,5 +194,6 @@ TEST_F(CachingMemoryManagerTest, RecLimit) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
   return RUN_ALL_TESTS();
 }

--- a/flashlight/fl/test/memory/MemoryFrameworkTest.cpp
+++ b/flashlight/fl/test/memory/MemoryFrameworkTest.cpp
@@ -16,6 +16,8 @@
 #include <arrayfire.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
+#include "flashlight/fl/common/Init.h"
 #include "flashlight/fl/memory/memory.h"
 
 using namespace fl;
@@ -398,18 +400,19 @@ TEST(MemoryFramework, AdapterInstallerDeviceInterfaceTest) {
   }
   // The custom memory is destroyed; check that the log stream, which is flushed
   // on destruction, contains the correct output
-  std::vector<std::string> expectedLinePrefixes = {"initialize",
-                                                   "nativeAlloc",
-                                                   "alloc",
-                                                   "nativeAlloc",
-                                                   "alloc",
-                                                   "unlock",
-                                                   "unlock",
-                                                   "signalMemoryCleanup",
-                                                   "nativeFree",
-                                                   "nativeFree",
-                                                   "shutdown",
-                                                   "shutdown"};
+  std::vector<std::string> expectedLinePrefixes = {
+      "initialize",
+      "nativeAlloc",
+      "alloc",
+      "nativeAlloc",
+      "alloc",
+      "unlock",
+      "unlock",
+      "signalMemoryCleanup",
+      "nativeFree",
+      "nativeFree",
+      "shutdown",
+      "shutdown"};
   size_t idx = 0;
   for (std::string line; std::getline(logStream, line);) {
     EXPECT_EQ(line.substr(0, line.find(" ")), expectedLinePrefixes[idx]);
@@ -427,5 +430,6 @@ TEST(MemoryFramework, AdapterInstallerDeviceInterfaceTest) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
   return RUN_ALL_TESTS();
 }

--- a/flashlight/fl/test/memory/MemoryInitTest.cpp
+++ b/flashlight/fl/test/memory/MemoryInitTest.cpp
@@ -12,6 +12,7 @@
 #include <arrayfire.h>
 #include <gtest/gtest.h>
 
+#include "flashlight/fl/common/Init.h"
 #include "flashlight/fl/memory/memory.h"
 
 using namespace fl;
@@ -26,5 +27,6 @@ TEST(MemoryInitTest, DefaultManagerInitializesCorrectType) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
   return RUN_ALL_TESTS();
 }

--- a/flashlight/fl/test/meter/MeterTest.cpp
+++ b/flashlight/fl/test/meter/MeterTest.cpp
@@ -9,6 +9,7 @@
 
 #include <gtest/gtest.h>
 
+#include "flashlight/fl/common/Init.h"
 #include "flashlight/fl/meter/meters.h"
 
 using namespace fl;
@@ -84,5 +85,6 @@ TEST(MeterTest, CountMeter) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
   return RUN_ALL_TESTS();
 }

--- a/flashlight/fl/test/nn/ModuleTest.cpp
+++ b/flashlight/fl/test/nn/ModuleTest.cpp
@@ -834,8 +834,9 @@ TEST(ModuleTest, AdaptiveSoftMaxLossIgnoreIndex) {
 
 TEST(ModuleTest, IdentityFwd) {
   auto module = Identity();
-  std::vector<Variable> in = {Variable(af::randu(af::dim4(1000, 1000)), true),
-                              Variable(af::randu(af::dim4(100, 100)), true)};
+  std::vector<Variable> in = {
+      Variable(af::randu(af::dim4(1000, 1000)), true),
+      Variable(af::randu(af::dim4(100, 100)), true)};
 
   // Train Mode
   module.train();
@@ -854,5 +855,6 @@ TEST(ModuleTest, IdentityFwd) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
   return RUN_ALL_TESTS();
 }

--- a/flashlight/fl/test/nn/NNSerializationTest.cpp
+++ b/flashlight/fl/test/nn/NNSerializationTest.cpp
@@ -15,8 +15,8 @@
 #include <gtest/gtest.h>
 
 #include "flashlight/fl/autograd/autograd.h"
+#include "flashlight/fl/common/Init.h"
 #include "flashlight/fl/nn/nn.h"
-
 #include "flashlight/lib/common/System.h"
 
 using namespace fl;
@@ -377,5 +377,6 @@ TEST(NNSerializationTest, ContainerWithParams) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
   return RUN_ALL_TESTS();
 }

--- a/flashlight/fl/test/nn/NNUtilsTest.cpp
+++ b/flashlight/fl/test/nn/NNUtilsTest.cpp
@@ -9,6 +9,7 @@
 #include <gtest/gtest.h>
 
 #include "flashlight/fl/autograd/autograd.h"
+#include "flashlight/fl/common/Init.h"
 #include "flashlight/fl/nn/nn.h"
 
 using namespace fl;
@@ -55,5 +56,6 @@ TEST(UtilsTest, Join) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
   return RUN_ALL_TESTS();
 }

--- a/flashlight/fl/test/optim/OptimBenchmark.cpp
+++ b/flashlight/fl/test/optim/OptimBenchmark.cpp
@@ -82,6 +82,7 @@ double nag() {
 
 int main() {
   af::info();
+  fl::init();
   TIME(sgd);
   TIME(nag);
   TIME(adam);

--- a/flashlight/fl/test/optim/OptimTest.cpp
+++ b/flashlight/fl/test/optim/OptimTest.cpp
@@ -9,7 +9,6 @@
 
 #include "flashlight/fl/common/common.h"
 #include "flashlight/fl/optim/optim.h"
-
 #include "flashlight/lib/common/System.h"
 
 using namespace fl;
@@ -117,5 +116,6 @@ TEST(SerializationTest, OptimizerSerialize) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  fl::init();
   return RUN_ALL_TESTS();
 }

--- a/flashlight/lib/test/common/ProducerConsumerQueueTest.cpp
+++ b/flashlight/lib/test/common/ProducerConsumerQueueTest.cpp
@@ -89,6 +89,5 @@ TEST(ProducerConsumerQueueTest, MultiThreads) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
-
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Summary:
Due to some CUDA 11 changes in how device context initialization occurs, `af::DeviceManager` initialization behaves differently so as to create a race with the global static initialization of the MemoryManagerInstaller setter.

Remove the global initialization to remove the race and initialize manually in binaries. We're no longer using the CachingMemoryManager in tests since setting everywhere is a nuisance. This might make the case better for `fl::initFlashlight()` down the road.

Reviewed By: tlikhomanenko

Differential Revision: D25805375

