### PR TITLE
improve python binding/ready for pypi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,12 +224,15 @@ commands:
       - run:
           name: "Install Flashlight library Python bindings"
           command: |
-            pip install packaging
+            pip3 install packaging nose
             cd bindings/python
             export USE_MKL=<< parameters.use_mkl >>
             export USE_CUDA=<< parameters.use_cuda >>
             export USE_KENLM=<< parameters.use_kenlm >>
-            python setup.py install
+            python3 setup.py install
+            # MKL doesn't work in current docker with CUDA
+            export LD_PRELOAD=/opt/intel/mkl/lib/intel64/libmkl_def.so:/opt/intel/mkl/lib/intel64/libmkl_avx2.so:/opt/intel/mkl/lib/intel64/libmkl_core.so:/opt/intel/mkl/lib/intel64/libmkl_intel_lp64.so:/opt/intel/mkl/lib/intel64/libmkl_intel_thread.so:/opt/intel/lib/intel64_lin/libiomp5.so
+            cd .. && python3 -m nose python/tests -vds
 
 ############################ Jobs ############################
 jobs:

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -10,10 +10,19 @@ set_target_properties(
   TRUE
   )
 
-function (add_pybind11_extension ext_name file_name)
+function (add_pybind11_extension ext_name)
+  string(REPLACE "_" ";" modlist ${ext_name})
+  list(GET modlist -1 modname)
+  list(REMOVE_AT modlist -1)
+  if(modlist)
+    string(REPLACE ";" "/" relpath "${modlist}")
+  else()
+    set(relpath "")
+  endif()
+
   pybind11_add_module(
     ${ext_name}
-    ${CMAKE_CURRENT_LIST_DIR}/${file_name}.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/${relpath}/_${modname}.cpp
     )
 
   target_link_libraries(
@@ -23,9 +32,12 @@ function (add_pybind11_extension ext_name file_name)
     )
 
   add_dependencies(${ext_name} pybind11)
+  set_target_properties(${ext_name} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${relpath})
+  set_target_properties(${ext_name} PROPERTIES OUTPUT_NAME ${ext_name})
+
 endfunction ()
 
-add_pybind11_extension(_lib_audio_feature flashlight/lib/audio/_feature)
-add_pybind11_extension(_lib_sequence_criterion flashlight/lib/sequence/_criterion)
-add_pybind11_extension(_lib_text_decoder flashlight/lib/text/_decoder)
-add_pybind11_extension(_lib_text_dictionary flashlight/lib/text/_dictionary)
+add_pybind11_extension(flashlight_lib_audio_feature)
+add_pybind11_extension(flashlight_lib_sequence_criterion)
+add_pybind11_extension(flashlight_lib_text_decoder)
+add_pybind11_extension(flashlight_lib_text_dictionary)

--- a/bindings/python/MANIFEST.in
+++ b/bindings/python/MANIFEST.in
@@ -1,0 +1,3 @@
+include ../../CMakeLists.txt ../../cmake/* CMakeLists.txt
+recursive-include ../../flashlight/lib *.h *.cpp CMakeLists.txt
+recursive-include flashlight *.cpp

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -49,13 +49,22 @@ The following dependencies **are not required** to build python bindings:
 
 ### Build Instructions
 
-Once the dependencies are satisfied, simply run from wav2letter root:
+Once the dependencies are satisfied, use:
 ```
 cd bindings/python
-pip install -e .
+python3 setup.py install
 ```
 
-Note that if you encounter errors, you'll probably have to ``rm -rf build`` before retrying the install.
+with `pip` either install from `pypi` (coming soon)
+```
+pip3 install pyflashlight
+```
+or locally in editable mode (wihout `-e` it will not work as we need to build some libs outside the python binding folder)
+```
+pip3 install -e .
+```
+
+Note that if you encounter errors, you'll probably have to ``rm -rf build dist`` before retrying the install.
 
 ### Advanced Options
 The following environment variables can be used to control various options:
@@ -68,15 +77,15 @@ The following environment variables can be used to control various options:
 ### Build inside docker container
 - For CUDA backend inside docker container run commands
 ```
-    pip install torch==1.2.0 packaging==19.1
-    cd /root/flashlight/bindings/python && pip install -e .
+    pip3 install torch==1.2.0 packaging==19.1
+    cd /root/flashlight/bindings/python && python3 setup.py install
 ```
 
 - For CPU backend inside docker container run commands
 ```
-    pip install torch==1.2.0 packaging==19.1
+    pip3 install torch==1.2.0 packaging==19.1
     export USE_CUDA=0 && \
-    cd /root/flashlight/bindings/python && pip install -e .
+    cd /root/flashlight/bindings/python && python3 setup.py install
 ```
 
 ## Python API
@@ -329,17 +338,20 @@ After flashlight python package is installed, please, have a look at the example
 
 - ASG criterion
 ```bash
+    cd [flashlight]
     # with cpu backend
-    python example/criterion_example.py --cpu
+    python3 bindings/python/example/criterion_example.py --cpu
     # with gpu backend
-    python example/criterion_example.py
+    python3 bindings/python/example/criterion_example.py
 ```
 
 - lexicon beam-search decoder with KenLM word-level language model
 ```bash
-    python example/decoder_example.py ../../flashlight/app/asr/test/decoder/data
+    cd [flashlight]
+    python3 bindings/python/example/decoder_example.py flashlight/app/asr/test/decoder/data
 ```
 - audio featurization
 ```bash
-    python example/feature_example.py ../../flashlight/lib/test/audio/feature/data
+    cd [flashlight]
+    python3 bindings/python/example/feature_example.py flashlight/lib/test/audio/feature/data
 ```

--- a/bindings/python/flashlight/lib/audio/_feature.cpp
+++ b/bindings/python/flashlight/lib/audio/_feature.cpp
@@ -39,7 +39,7 @@ using PreEmphasis = fl::lib::audio::PreEmphasis;
 using TriFilterbank = fl::lib::audio::TriFilterbank;
 using Windowing = fl::lib::audio::Windowing;
 
-PYBIND11_MODULE(_lib_audio_feature, m) {
+PYBIND11_MODULE(flashlight_lib_audio_feature, m) {
   py::enum_<WindowType>(m, "WindowType")
       .value("HAMMING", WindowType::HAMMING)
       .value("HANNING", WindowType::HANNING);

--- a/bindings/python/flashlight/lib/audio/feature.py
+++ b/bindings/python/flashlight/lib/audio/feature.py
@@ -6,7 +6,7 @@ This source code is licensed under the BSD-style license found in the
 LICENSE file in the root directory of this source tree.
 """
 
-from flashlight._lib_audio_feature import (
+from .flashlight_lib_audio_feature import (
     Ceplifter,
     Dct,
     Derivatives,

--- a/bindings/python/flashlight/lib/sequence/_criterion.cpp
+++ b/bindings/python/flashlight/lib/sequence/_criterion.cpp
@@ -274,7 +274,7 @@ static void CudaViterbi_compute(
 
 #endif // FL_LIBRARIES_USE_CUDA
 
-PYBIND11_MODULE(_lib_sequence_criterion, m) {
+PYBIND11_MODULE(flashlight_lib_sequence_criterion, m) {
   py::enum_<CriterionScaleMode>(m, "CriterionScaleMode")
       .value("NONE", CriterionScaleMode::NONE)
       .value("INPUT_SZ", CriterionScaleMode::INPUT_SZ)

--- a/bindings/python/flashlight/lib/sequence/criterion.py
+++ b/bindings/python/flashlight/lib/sequence/criterion.py
@@ -6,7 +6,7 @@ This source code is licensed under the BSD-style license found in the
 LICENSE file in the root directory of this source tree.
 """
 
-from flashlight._lib_sequence_criterion import (
+from .flashlight_lib_sequence_criterion import (
     CpuForceAlignmentCriterion,
     CpuFullConnectionCriterion,
     CpuViterbiPath,

--- a/bindings/python/flashlight/lib/sequence/criterion_torch.py
+++ b/bindings/python/flashlight/lib/sequence/criterion_torch.py
@@ -9,7 +9,7 @@ LICENSE file in the root directory of this source tree.
 import struct
 import sys
 
-import flashlight._lib_sequence_criterion as _C
+import flashlight.lib.sequence.flashlight_lib_sequence_criterion as _C
 import torch
 import torch.nn as nn
 

--- a/bindings/python/flashlight/lib/text/_decoder.cpp
+++ b/bindings/python/flashlight/lib/text/_decoder.cpp
@@ -130,7 +130,7 @@ std::vector<DecodeResult> LexiconFreeDecoder_decode(
 
 } // namespace
 
-PYBIND11_MODULE(_lib_text_decoder, m) {
+PYBIND11_MODULE(flashlight_lib_text_decoder, m) {
   py::enum_<SmearingMode>(m, "SmearingMode")
       .value("NONE", SmearingMode::NONE)
       .value("MAX", SmearingMode::MAX)

--- a/bindings/python/flashlight/lib/text/_dictionary.cpp
+++ b/bindings/python/flashlight/lib/text/_dictionary.cpp
@@ -30,7 +30,7 @@ void Dictionary_addEntry_1(Dictionary& dict, const std::string& entry) {
 
 } // namespace
 
-PYBIND11_MODULE(_lib_text_dictionary, m) {
+PYBIND11_MODULE(flashlight_lib_text_dictionary, m) {
   py::class_<Dictionary>(m, "Dictionary")
       .def(py::init<>())
       .def(py::init<const std::string&>(), "filename"_a)

--- a/bindings/python/flashlight/lib/text/decoder.py
+++ b/bindings/python/flashlight/lib/text/decoder.py
@@ -6,7 +6,7 @@ This source code is licensed under the BSD-style license found in the
 LICENSE file in the root directory of this source tree.
 """
 
-from flashlight._lib_text_decoder import (
+from .flashlight_lib_text_decoder import (
     LM,
     CriterionType,
     DecodeResult,

--- a/bindings/python/flashlight/lib/text/dictionary.py
+++ b/bindings/python/flashlight/lib/text/dictionary.py
@@ -6,7 +6,7 @@ This source code is licensed under the BSD-style license found in the
 LICENSE file in the root directory of this source tree.
 """
 
-from flashlight._lib_text_dictionary import (
+from .flashlight_lib_text_dictionary import (
     Dictionary,
     create_word_dict,
     load_words,

--- a/bindings/python/tests/test_import.py
+++ b/bindings/python/tests/test_import.py
@@ -1,0 +1,23 @@
+"""
+Copyright (c) Facebook, Inc. and its affiliates.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
+import os
+
+
+def test_import_lib_audio():
+    from flashlight.lib.audio import feature as fl_feat
+
+
+def test_import_lib_sequence():
+    from flashlight.lib.sequence import criterion as fl_crit
+
+
+def test_import_lib_text():
+    from flashlight.lib.text import dictionary as fl_dict
+
+    if os.getenv("USE_KENLM", "").upper() not in ["OFF", "0", "NO", "FALSE", "N"]:
+        from flashlight.lib.text import decoder as fl_decoder

--- a/bindings/python/tests/test_lib_audio.py
+++ b/bindings/python/tests/test_lib_audio.py
@@ -1,0 +1,64 @@
+"""
+Copyright (c) Facebook, Inc. and its affiliates.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
+import itertools
+from pathlib import Path
+
+
+def load_data(filename):
+    with open(filename) as f:
+        return [
+            float(x) for x in itertools.chain.from_iterable(line.split() for line in f)
+        ]
+
+
+def test_mfcc():
+    from flashlight.lib.audio import feature as fl_feat
+
+    data_path = (
+        Path(__file__)
+        .absolute()
+        .parent.joinpath("../../../flashlight/lib/test/audio/feature/data")
+    )
+
+    wavinput = load_data(data_path.joinpath("sa1.dat"))
+    # golden features to compare
+    htkfeatures = load_data(data_path.joinpath("sa1-mfcc.htk"))
+
+    assert len(wavinput) > 0
+    assert len(htkfeatures) > 0
+
+    params = fl_feat.FeatureParams()
+    # define parameters of the featurization
+    params.sampling_freq = 16000
+    params.low_freq_filterbank = 0
+    params.high_freq_filterbank = 8000
+    params.num_filterbank_chans = 20
+    params.num_cepstral_coeffs = 13
+    params.use_energy = False
+    params.zero_mean_frame = False
+    params.use_power = False
+
+    # apply MFCC featurization
+    mfcc = fl_feat.Mfcc(params)
+    features = mfcc.apply(wavinput)
+
+    # check that obtained features are the same as golden one
+    assert len(features) == len(htkfeatures)
+    assert len(features) % 39 == 0
+    numframes = len(features) // 39
+    featurescopy = features.copy()
+    for f in range(numframes):
+        for i in range(1, 39):
+            features[f * 39 + i - 1] = features[f * 39 + i]
+        features[f * 39 + 12] = featurescopy[f * 39 + 0]
+        features[f * 39 + 25] = featurescopy[f * 39 + 13]
+        features[f * 39 + 38] = featurescopy[f * 39 + 26]
+    differences = [abs(x[0] - x[1]) for x in zip(features, htkfeatures)]
+
+    assert max(differences) < 0.4
+    assert sum(differences) / len(differences) < 0.03


### PR DESCRIPTION
Summary:
Improve python binding:
- support now `python setup.py install` along with `pip install -e .` (`pip install .` will not work as it copies to tmp folder all files where setup.py lives so we don't have access to full fl CMakeLists.txt, this is known problem of pip since 2014)
- improve naming and placing .so files, not in `flashlight/` but in the following structure
```
root@60913a11742b:~/fl/bindings/python# tree -L 4 /usr/local/lib/python3.8/dist-packages/flashlight-0.0.1-py3.8-linux-x86_64.egg/
/usr/local/lib/python3.8/dist-packages/flashlight-0.0.1-py3.8-linux-x86_64.egg/
|-- flashlight
|   |-- __init__.py
|   |-- __pycache__
|   |   |-- __init__.cpython-38.pyc
|   |-- lib
|       |-- audio
|       |   |-- __init__.py
|       |   |-- __pycache__
|       |   |-- _feature.cpython-38-x86_64-linux-gnu.so
|       |   |-- feature.py
|       |-- sequence
|       |   |-- __pycache__
|       |   |-- _criterion.cpython-38-x86_64-linux-gnu.so
|       |   |-- criterion.py
|       |   |-- criterion_torch.py
|       |-- text
|           |-- __pycache__
|           |-- _decoder.cpython-38-x86_64-linux-gnu.so
|           |-- _dictionary.cpython-38-x86_64-linux-gnu.so
|           |-- decoder.py
|           |-- dictionary.py
`-- libfl-libraries.so
```
- add running example in CI to make sure `python setup.py install` worked correctly

Differential Revision: D25844193

