### PR TITLE
Add hint to find NCCL_LIBRARIES for AWS AMI

### DIFF
--- a/cmake/FindNCCL.cmake
+++ b/cmake/FindNCCL.cmake
@@ -39,6 +39,7 @@ find_library(NCCL_LIBRARIES
   ${NCCL_ROOT_DIR}/lib
   ${NCCL_ROOT_DIR}/lib/x86_64-linux-gnu
   ${NCCL_ROOT_DIR}/lib64
+  ${CUDA_TOOLKIT_ROOT_DIR}/lib
   ${CUDA_TOOLKIT_ROOT_DIR}/lib64)
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
**Original Issue**: https://github.com/facebookresearch/flashlight/issues/403

### Summary
Build from source should work out of the box with the standard deep learning AMIs on AWS.
This PR ads a new hint in the makefile of NCCL to support new deep learning AMIs. 

### Test Plan
described in https://github.com/facebookresearch/flashlight/issues/403

closes #403 

