### PR TITLE
disable caching memory manager for CPU

### DIFF
--- a/flashlight/fl/common/Init.cpp
+++ b/flashlight/fl/common/Init.cpp
@@ -26,7 +26,9 @@ std::once_flag flInitFlag;
 void init() {
   std::call_once(flInitFlag, []() {
     af_init();
-    MemoryManagerInstaller::installDefaultMemoryManager();
+    if (!FL_BACKEND_CPU) {
+      MemoryManagerInstaller::installDefaultMemoryManager();
+    }
   });
 }
 


### PR DESCRIPTION
Summary: Cashing memory manager is not required on CPU. It also seems that having it installed on CPU backend exposes subtle AF race condition.

Differential Revision: D25850090

