### PR TITLE
make one flag for audio feature types

### DIFF
--- a/flashlight/app/asr/Decode.cpp
+++ b/flashlight/app/asr/Decode.cpp
@@ -23,6 +23,7 @@
 #include "flashlight/app/asr/common/Flags.h"
 #include "flashlight/app/asr/criterion/criterion.h"
 #include "flashlight/app/asr/data/FeatureTransforms.h"
+#include "flashlight/app/asr/data/Utils.h"
 #include "flashlight/app/asr/decoder/ConvLmModule.h"
 #include "flashlight/app/asr/decoder/DecodeUtils.h"
 #include "flashlight/app/asr/decoder/Defines.h"
@@ -305,14 +306,9 @@ int main(int argc, char** argv) {
   featParams.useEnergy = false;
   featParams.usePower = false;
   featParams.zeroMeanFrame = false;
-  FeatureType featType = FeatureType::NONE;
-  if (FLAGS_pow) {
-    featType = FeatureType::POW_SPECTRUM;
-  } else if (FLAGS_mfsc) {
-    featType = FeatureType::MFSC;
-  } else if (FLAGS_mfcc) {
-    featType = FeatureType::MFCC;
-  }
+  FeatureType featType =
+      getFeaturesType(FLAGS_features_type, FLAGS_channels, featParams).second;
+
   TargetGenerationConfig targetGenConfig(
       FLAGS_wordseparator,
       FLAGS_sampletarget,
@@ -422,9 +418,8 @@ int main(int argc, char** argv) {
         fl::Variable rawEmission;
         if (usePlugin) {
           rawEmission = localNetwork
-                            ->forward(
-                                {fl::input(sample[kInputIdx]),
-                                 fl::noGrad(sample[kDurationIdx])})
+                            ->forward({fl::input(sample[kInputIdx]),
+                                       fl::noGrad(sample[kDurationIdx])})
                             .front();
         } else {
           rawEmission = fl::ext::forwardSequentialModuleWithPadMask(

--- a/flashlight/app/asr/Test.cpp
+++ b/flashlight/app/asr/Test.cpp
@@ -20,6 +20,7 @@
 #include "flashlight/app/asr/common/Flags.h"
 #include "flashlight/app/asr/criterion/criterion.h"
 #include "flashlight/app/asr/data/FeatureTransforms.h"
+#include "flashlight/app/asr/data/Utils.h"
 #include "flashlight/app/asr/decoder/Defines.h"
 #include "flashlight/app/asr/decoder/TranscriptionUtils.h"
 #include "flashlight/app/asr/runtime/runtime.h"
@@ -138,8 +139,8 @@ int main(int argc, char** argv) {
     LOG(INFO) << "Number of words: " << wordDict.indexSize();
   }
 
-  fl::lib::text::DictionaryMap dicts = {
-      {kTargetIdx, tokenDict}, {kWordIdx, wordDict}};
+  fl::lib::text::DictionaryMap dicts = {{kTargetIdx, tokenDict},
+                                        {kWordIdx, wordDict}};
 
   /* ===================== Create Dataset ===================== */
   fl::lib::audio::FeatureParams featParams(
@@ -156,14 +157,9 @@ int main(int argc, char** argv) {
   featParams.useEnergy = false;
   featParams.usePower = false;
   featParams.zeroMeanFrame = false;
-  FeatureType featType = FeatureType::NONE;
-  if (FLAGS_pow) {
-    featType = FeatureType::POW_SPECTRUM;
-  } else if (FLAGS_mfsc) {
-    featType = FeatureType::MFSC;
-  } else if (FLAGS_mfcc) {
-    featType = FeatureType::MFCC;
-  }
+  FeatureType featType =
+      getFeaturesType(FLAGS_features_type, FLAGS_channels, featParams).second;
+
   TargetGenerationConfig targetGenConfig(
       FLAGS_wordseparator,
       FLAGS_sampletarget,
@@ -291,9 +287,8 @@ int main(int argc, char** argv) {
       fl::Variable rawEmission;
       if (usePlugin) {
         rawEmission = localNetwork
-                          ->forward(
-                              {fl::input(sample[kInputIdx]),
-                               fl::noGrad(sample[kDurationIdx])})
+                          ->forward({fl::input(sample[kInputIdx]),
+                                     fl::noGrad(sample[kDurationIdx])})
                           .front();
       } else {
         rawEmission = fl::ext::forwardSequentialModuleWithPadMask(

--- a/flashlight/app/asr/Train.cpp
+++ b/flashlight/app/asr/Train.cpp
@@ -22,6 +22,7 @@
 #include "flashlight/app/asr/common/Flags.h"
 #include "flashlight/app/asr/criterion/criterion.h"
 #include "flashlight/app/asr/data/FeatureTransforms.h"
+#include "flashlight/app/asr/data/Utils.h"
 #include "flashlight/app/asr/decoder/DecodeMaster.h"
 #include "flashlight/app/asr/decoder/PlGenerator.h"
 #include "flashlight/app/asr/decoder/TranscriptionUtils.h"
@@ -268,18 +269,11 @@ int main(int argc, char** argv) {
   featParams.useEnergy = false;
   featParams.usePower = false;
   featParams.zeroMeanFrame = false;
-  int numFeatures = FLAGS_channels;
-  FeatureType featType = FeatureType::NONE;
-  if (FLAGS_pow) {
-    featType = FeatureType::POW_SPECTRUM;
-    numFeatures = featParams.powSpecFeatSz();
-  } else if (FLAGS_mfsc) {
-    featType = FeatureType::MFSC;
-    numFeatures = featParams.mfscFeatSz();
-  } else if (FLAGS_mfcc) {
-    featType = FeatureType::MFCC;
-    numFeatures = featParams.mfccFeatSz();
-  }
+  auto featureRes =
+      getFeaturesType(FLAGS_features_type, FLAGS_channels, featParams);
+  int numFeatures = featureRes.first;
+  FeatureType featType = featureRes.second;
+
   TargetGenerationConfig targetGenConfig(
       FLAGS_wordseparator,
       FLAGS_sampletarget,
@@ -419,12 +413,11 @@ int main(int argc, char** argv) {
           usePlugin,
           tokenDict,
           wordDict,
-          DecodeMasterTrainOptions{
-              .repLabel = int32_t(FLAGS_replabel),
-              .wordSepIsPartOfToken = FLAGS_usewordpiece,
-              .surround = FLAGS_surround,
-              .wordSep = FLAGS_wordseparator,
-              .targetPadIdx = targetpadVal});
+          DecodeMasterTrainOptions{.repLabel = int32_t(FLAGS_replabel),
+                                   .wordSepIsPartOfToken = FLAGS_usewordpiece,
+                                   .surround = FLAGS_surround,
+                                   .wordSep = FLAGS_wordseparator,
+                                   .targetPadIdx = targetpadVal});
     } else {
       throw std::runtime_error(
           "Other decoders are not supported yet during training");
@@ -807,9 +800,8 @@ int main(int argc, char** argv) {
       fl::Variable output;
       if (usePlugin) {
         output = ntwrk
-                     ->forward(
-                         {fl::input(batch[kInputIdx]),
-                          fl::noGrad(batch[kDurationIdx])})
+                     ->forward({fl::input(batch[kInputIdx]),
+                                fl::noGrad(batch[kDurationIdx])})
                      .front();
       } else {
         output = fl::ext::forwardSequentialModuleWithPadMask(
@@ -873,7 +865,7 @@ int main(int argc, char** argv) {
 
     std::shared_ptr<fl::Module> saug;
     if (FLAGS_saug_start_update >= 0) {
-      if (!(FLAGS_pow || FLAGS_mfsc || FLAGS_mfcc)) {
+      if (FLAGS_features_type == kFeaturesRaw) {
         saug = std::make_shared<fl::RawWavSpecAugment>(
             FLAGS_filterbanks,
             FLAGS_saug_fmaskf,

--- a/flashlight/app/asr/common/Defines.h
+++ b/flashlight/app/asr/common/Defines.h
@@ -54,6 +54,10 @@ constexpr const char* kSeq2SeqCriterion = "seq2seq";
 constexpr const char* kTransformerCriterion = "transformer";
 constexpr const char* kBatchStrategyNone = "none";
 constexpr const char* kBatchStrategyDynamic = "dynamic";
+constexpr const char* kFeaturesMFSC = "mfsc";
+constexpr const char* kFeaturesMFCC = "mfcc";
+constexpr const char* kFeaturesPow = "pow";
+constexpr const char* kFeaturesRaw = "raw";
 constexpr int kTargetPadValue = -1;
 
 // Feature params

--- a/flashlight/app/asr/common/Flags.cpp
+++ b/flashlight/app/asr/common/Flags.cpp
@@ -209,22 +209,13 @@ DEFINE_string(
     "supported ones 'sgd', 'adam', 'rmsprop', 'adadelta', 'adagrad', 'amsgrad', 'novograd'");
 
 // MFCC OPTIONS
-DEFINE_bool(
-    mfcc,
-    false,
-    "Use standard htk mfcc features as input by processing audio "
-    "(if 'mfcc', 'pow', 'mfsc' all false raw wave will be used as input)");
+DEFINE_string(
+    features_type,
+    "mfsc",
+    "Features type to compute input by processing audio. Could be "
+    "mfcc: standard htk mfcc features; mfsc: standard mfsc features; "
+    "pow: standard power spectrum; raw: raw wave");
 DEFINE_int64(mfcccoeffs, 13, "Number of mfcc coefficients");
-DEFINE_bool(
-    pow,
-    false,
-    "Use standard power spectrum as input by processing audio "
-    "(if 'mfcc', 'pow', 'mfsc' all false raw wave will be used as input)");
-DEFINE_bool(
-    mfsc,
-    false,
-    "Use standard mfsc features as input "
-    "(if 'mfcc', 'pow', 'mfsc' all false raw wave will be used as input)");
 DEFINE_double(melfloor, 1.0, "Specify optional mel floor for mfcc/mfsc/pow");
 DEFINE_int64(
     filterbanks,

--- a/flashlight/app/asr/common/Flags.h
+++ b/flashlight/app/asr/common/Flags.h
@@ -122,10 +122,8 @@ DECLARE_string(critoptim);
 
 /* ========== MFCC OPTIONS ========== */
 
-DECLARE_bool(mfcc);
-DECLARE_bool(pow);
+DECLARE_string(features_type);
 DECLARE_int64(mfcccoeffs);
-DECLARE_bool(mfsc);
 DECLARE_double(melfloor);
 DECLARE_int64(filterbanks);
 DECLARE_int64(devwin);

--- a/flashlight/app/asr/data/Utils.cpp
+++ b/flashlight/app/asr/data/Utils.cpp
@@ -77,16 +77,15 @@ std::vector<std::string> wrd2Target(
     bool skipUnk /* = false */) {
   std::vector<std::string> res;
   for (auto w : words) {
-    auto w2tokens =
-        wrd2Target(
-          w,
-          lexicon,
-          dict,
-          wordSeparator,
-          targetSamplePct,
-          fallback2LtrWordSepLeft,
-          fallback2LtrWordSepRight,
-          skipUnk);
+    auto w2tokens = wrd2Target(
+        w,
+        lexicon,
+        dict,
+        wordSeparator,
+        targetSamplePct,
+        fallback2LtrWordSepLeft,
+        fallback2LtrWordSepRight,
+        skipUnk);
 
     if (w2tokens.size() == 0) {
       continue;
@@ -95,6 +94,27 @@ std::vector<std::string> wrd2Target(
   }
   return res;
 }
+
+std::pair<int, FeatureType> getFeaturesType(
+    const std::string& featuresType,
+    int channels,
+    const fl::lib::audio::FeatureParams& featParams) {
+  if (featuresType == kFeaturesPow) {
+    return std::make_pair(
+        featParams.powSpecFeatSz(), FeatureType::POW_SPECTRUM);
+  } else if (featuresType == kFeaturesMFSC) {
+    return std::make_pair(featParams.mfscFeatSz(), FeatureType::MFSC);
+  } else if (featuresType == kFeaturesMFSC) {
+    return std::make_pair(featParams.mfccFeatSz(), FeatureType::MFCC);
+  } else if (featuresType == kFeaturesRaw) {
+    return std::make_pair(channels, FeatureType::NONE);
+  } else {
+    throw std::runtime_error(
+        "Unsupported feature type for audio preprocessing '" + featuresType +
+        "'");
+  }
+}
+
 } // namespace asr
 } // namespace app
 } // namespace fl

--- a/flashlight/app/asr/data/Utils.h
+++ b/flashlight/app/asr/data/Utils.h
@@ -10,6 +10,8 @@
 #include <string>
 #include <vector>
 
+#include "flashlight/app/asr/data/FeatureTransforms.h"
+#include "flashlight/lib/audio/feature/FeatureParams.h"
 #include "flashlight/lib/text/dictionary/Dictionary.h"
 #include "flashlight/lib/text/dictionary/Utils.h"
 
@@ -36,6 +38,12 @@ std::vector<std::string> wrd2Target(
     bool fallback2LtrWordSepLeft = false,
     bool fallback2LtrWordSepRight = false,
     bool skipUnk = false);
+
+std::pair<int, FeatureType> getFeaturesType(
+    const std::string& featuresType,
+    int channels,
+    const fl::lib::audio::FeatureParams& featParams);
+
 } // namespace asr
 } // namespace app
 } // namespace fl

--- a/flashlight/app/asr/runtime/Logger.cpp
+++ b/flashlight/app/asr/runtime/Logger.cpp
@@ -78,7 +78,7 @@ std::string getLogString(
   auto tsztotal = stats[1];
   auto tszmax = stats[3];
   auto iszAvrFrames = isztotal / numsamples;
-  if (FLAGS_pow || FLAGS_mfcc || FLAGS_mfsc) {
+  if (FLAGS_features_type != kFeaturesRaw) {
     iszAvrFrames = iszAvrFrames / FLAGS_framestridems;
   } else {
     iszAvrFrames = iszAvrFrames / 1000 * FLAGS_samplerate;

--- a/flashlight/app/asr/runtime/Logger.h
+++ b/flashlight/app/asr/runtime/Logger.h
@@ -46,7 +46,7 @@ struct TestMeters {
 
 /*
  * Utility function to log results (learning rate, WER, TER, epoch, timing)
- * From gflags it uses FLAGS_batchsize, FLAGS_pow, FLAGS_mfcc, FLAGS_mfsc
+ * From gflags it uses FLAGS_batchsize, FLAGS_features_type
  * FLAGS_framestridems, FLAGS_samplerate
  */
 std::string getLogString(

--- a/flashlight/app/asr/tools/VoiceActivityDetection-CTC.cpp
+++ b/flashlight/app/asr/tools/VoiceActivityDetection-CTC.cpp
@@ -36,6 +36,7 @@
 #include "flashlight/app/asr/common/Defines.h"
 #include "flashlight/app/asr/criterion/criterion.h"
 #include "flashlight/app/asr/data/FeatureTransforms.h"
+#include "flashlight/app/asr/data/Utils.h"
 #include "flashlight/app/asr/decoder/TranscriptionUtils.h"
 #include "flashlight/app/asr/runtime/runtime.h"
 #include "flashlight/ext/common/SequentialBuilder.h"
@@ -163,18 +164,9 @@ int main(int argc, char** argv) {
   featParams.useEnergy = false;
   featParams.usePower = false;
   featParams.zeroMeanFrame = false;
-  int numFeatures = FLAGS_channels;
-  FeatureType featType = FeatureType::NONE;
-  if (FLAGS_pow) {
-    featType = FeatureType::POW_SPECTRUM;
-    numFeatures = featParams.powSpecFeatSz();
-  } else if (FLAGS_mfsc) {
-    featType = FeatureType::MFSC;
-    numFeatures = featParams.mfscFeatSz();
-  } else if (FLAGS_mfcc) {
-    featType = FeatureType::MFCC;
-    numFeatures = featParams.mfccFeatSz();
-  }
+  FeatureType featType =
+      getFeaturesType(FLAGS_features_type, FLAGS_channels, featParams).second;
+
   TargetGenerationConfig targetGenConfig(
       FLAGS_wordseparator,
       FLAGS_sampletarget,

--- a/flashlight/app/asr/tools/alignment/Align.cpp
+++ b/flashlight/app/asr/tools/alignment/Align.cpp
@@ -11,6 +11,7 @@
 #include "flashlight/app/asr/common/Defines.h"
 #include "flashlight/app/asr/criterion/criterion.h"
 #include "flashlight/app/asr/data/FeatureTransforms.h"
+#include "flashlight/app/asr/data/Utils.h"
 #include "flashlight/app/asr/runtime/runtime.h"
 #include "flashlight/app/asr/tools/alignment/Utils.h"
 #include "flashlight/ext/common/SequentialBuilder.h"
@@ -141,18 +142,9 @@ int main(int argc, char** argv) {
   featParams.useEnergy = false;
   featParams.usePower = false;
   featParams.zeroMeanFrame = false;
-  int numFeatures = FLAGS_channels;
-  FeatureType featType = FeatureType::NONE;
-  if (FLAGS_pow) {
-    featType = FeatureType::POW_SPECTRUM;
-    numFeatures = featParams.powSpecFeatSz();
-  } else if (FLAGS_mfsc) {
-    featType = FeatureType::MFSC;
-    numFeatures = featParams.mfscFeatSz();
-  } else if (FLAGS_mfcc) {
-    featType = FeatureType::MFCC;
-    numFeatures = featParams.mfccFeatSz();
-  }
+  FeatureType featType =
+      getFeaturesType(FLAGS_features_type, FLAGS_channels, featParams).second;
+
   TargetGenerationConfig targetGenConfig(
       FLAGS_wordseparator,
       FLAGS_sampletarget,

--- a/flashlight/app/asr/tutorial/FinetuneCTC.cpp
+++ b/flashlight/app/asr/tutorial/FinetuneCTC.cpp
@@ -21,6 +21,7 @@
 #include "flashlight/app/asr/common/Defines.h"
 #include "flashlight/app/asr/criterion/criterion.h"
 #include "flashlight/app/asr/data/FeatureTransforms.h"
+#include "flashlight/app/asr/data/Utils.h"
 #include "flashlight/app/asr/decoder/TranscriptionUtils.h"
 #include "flashlight/app/asr/runtime/runtime.h"
 #include "flashlight/ext/common/DistributedUtils.h"
@@ -177,18 +178,11 @@ int main(int argc, char** argv) {
   featParams.useEnergy = false;
   featParams.usePower = false;
   featParams.zeroMeanFrame = false;
-  int numFeatures = FLAGS_channels;
-  FeatureType featType = FeatureType::NONE;
-  if (FLAGS_pow) {
-    featType = FeatureType::POW_SPECTRUM;
-    numFeatures = featParams.powSpecFeatSz();
-  } else if (FLAGS_mfsc) {
-    featType = FeatureType::MFSC;
-    numFeatures = featParams.mfscFeatSz();
-  } else if (FLAGS_mfcc) {
-    featType = FeatureType::MFCC;
-    numFeatures = featParams.mfccFeatSz();
-  }
+  auto featureRes =
+      getFeaturesType(FLAGS_features_type, FLAGS_channels, featParams);
+  int numFeatures = featureRes.first;
+  FeatureType featType = featureRes.second;
+
   TargetGenerationConfig targetGenConfig(
       FLAGS_wordseparator,
       FLAGS_sampletarget,

--- a/flashlight/app/asr/tutorial/InferenceCTC.cpp
+++ b/flashlight/app/asr/tutorial/InferenceCTC.cpp
@@ -16,6 +16,7 @@
 #include "flashlight/app/asr/common/Defines.h"
 #include "flashlight/app/asr/data/FeatureTransforms.h"
 #include "flashlight/app/asr/data/Sound.h"
+#include "flashlight/app/asr/data/Utils.h"
 #include "flashlight/app/asr/decoder/DecodeUtils.h"
 #include "flashlight/app/asr/decoder/Defines.h"
 #include "flashlight/app/asr/decoder/TranscriptionUtils.h"
@@ -208,13 +209,23 @@ int main(int argc, char** argv) {
   featParams.useEnergy = false;
   featParams.usePower = false;
   featParams.zeroMeanFrame = false;
-  fl::app::asr::FeatureType featType = fl::app::asr::FeatureType::NONE;
-  if (networkFlags["pow"] == "true") {
-    featType = fl::app::asr::FeatureType::POW_SPECTRUM;
-  } else if (networkFlags["mfsc"] == "true") {
-    featType = fl::app::asr::FeatureType::MFSC;
-  } else if (networkFlags["mfcc"] == "true") {
-    featType = fl::app::asr::FeatureType::MFCC;
+  fl::app::asr::FeatureType featType;
+  if (networkFlags.find("features_type") != networkFlags.end()) {
+    featType = fl::app::asr::getFeaturesType(
+                   networkFlags["features_type"], 1, featParams)
+                   .second;
+  } else {
+    // old models
+    if (networkFlags["pow"] == "true") {
+      featType = fl::app::asr::FeatureType::POW_SPECTRUM;
+    } else if (networkFlags["mfsc"] == "true") {
+      featType = fl::app::asr::FeatureType::MFSC;
+    } else if (networkFlags["mfcc"] == "true") {
+      featType = fl::app::asr::FeatureType::MFCC;
+    } else {
+      // raw wave
+      featType = fl::app::asr::FeatureType::NONE;
+    }
   }
   auto inputTransform = fl::app::asr::inputFeatures(
       featParams,


### PR DESCRIPTION
Summary:
- Remove flags `mfsc`, `mfcc` and `pow`
- add new string flag `features_type` which can be now any of above + `raw`

Differential Revision: D25852019

