### PR TITLE
remove call_once() initialization from the MemoryManagerInstaller

### DIFF
--- a/flashlight/fl/common/Init.cpp
+++ b/flashlight/fl/common/Init.cpp
@@ -26,7 +26,12 @@ std::once_flag flInitFlag;
 void init() {
   std::call_once(flInitFlag, []() {
     af_init();
-    MemoryManagerInstaller::installDefaultMemoryManager();
+    // TODO: remove this temporary workaround for TextDatasetTest crash on CPU
+    // backend when tearing down the test environment. This is possibly due to
+    // AF race conditions when tearing down our custom memory manager.
+    if (!FL_BACKEND_CPU) {
+      MemoryManagerInstaller::installDefaultMemoryManager();
+    }
   });
 }
 

--- a/flashlight/fl/memory/MemoryManagerInstaller.cpp
+++ b/flashlight/fl/memory/MemoryManagerInstaller.cpp
@@ -17,9 +17,6 @@
 namespace fl {
 
 // Statics from MemoryManagerInstaller
-std::once_flag MemoryManagerInstaller::startupMemoryInitialize_;
-std::shared_ptr<MemoryManagerInstaller>
-    MemoryManagerInstaller::startupMemoryManagerInstaller_;
 std::shared_ptr<MemoryManagerAdapter>
     MemoryManagerInstaller::currentlyInstalledMemoryManager_;
 
@@ -222,15 +219,11 @@ MemoryManagerInstaller::currentlyInstalledMemoryManager() {
 }
 
 void MemoryManagerInstaller::installDefaultMemoryManager() {
-  std::call_once(startupMemoryInitialize_, []() {
-    auto deviceInterface = std::make_shared<MemoryManagerDeviceInterface>();
-    auto adapter = std::make_shared<CachingMemoryManager>(
-        af::getDeviceCount(), deviceInterface);
-    MemoryManagerInstaller::startupMemoryManagerInstaller_ =
-        std::make_shared<MemoryManagerInstaller>(adapter);
-    MemoryManagerInstaller::startupMemoryManagerInstaller_
-        ->setAsMemoryManager();
-  });
+  auto deviceInterface = std::make_shared<MemoryManagerDeviceInterface>();
+  auto adapter = std::make_shared<CachingMemoryManager>(
+      af::getDeviceCount(), deviceInterface);
+  auto installer = MemoryManagerInstaller(adapter);
+  installer.setAsMemoryManager();
 }
 
 void MemoryManagerInstaller::unsetMemoryManager() {

--- a/flashlight/fl/memory/MemoryManagerInstaller.h
+++ b/flashlight/fl/memory/MemoryManagerInstaller.h
@@ -85,9 +85,6 @@ class MemoryManagerInstaller {
    *
    * Uses a `CachingMemoryManager` by default. Only sets the memory manager -
    * doesn't set an AF pinned memory manager.
-   *
-   * @return a pointer to the `MemoryManagerInstaller` for the default memory
-   * manager.
    */
   static void installDefaultMemoryManager();
 
@@ -103,10 +100,6 @@ class MemoryManagerInstaller {
   std::shared_ptr<MemoryManagerAdapter> impl_;
   // Points to the impl_ of the most recently installed manager.
   static std::shared_ptr<MemoryManagerAdapter> currentlyInstalledMemoryManager_;
-  // Used to gate global initialization of the default memory manager
-  static std::once_flag startupMemoryInitialize_;
-  // Installer for the default memory manager installed on startup
-  static std::shared_ptr<MemoryManagerInstaller> startupMemoryManagerInstaller_;
 };
 
 } // namespace fl

--- a/flashlight/fl/test/memory/MemoryInitTest.cpp
+++ b/flashlight/fl/test/memory/MemoryInitTest.cpp
@@ -18,6 +18,9 @@
 using namespace fl;
 
 TEST(MemoryInitTest, DefaultManagerInitializesCorrectType) {
+  if (FL_BACKEND_CPU) {
+    GTEST_SKIP() << "CachingMemoryManager is not used on CPU backend";
+  }
   auto* manager = MemoryManagerInstaller::currentlyInstalledMemoryManager();
   // A non-null value means that a) a custom memory manager has been installed
   // and b) that a CachingMemoryManager has been installed which is the desired


### PR DESCRIPTION
Summary:
CashingMemoryManger installation is now triggered by fl::init().
The call_once() static initialization mechanics in MemoryManagerInstaller
is no longer needed.

Differential Revision: D25855275

