### PR TITLE
fix pre-training window for encoder-decoder by adding support of input sizes/target sizes

### DIFF
--- a/flashlight/app/asr/Decode.cpp
+++ b/flashlight/app/asr/Decode.cpp
@@ -23,6 +23,7 @@
 #include "flashlight/app/asr/common/Flags.h"
 #include "flashlight/app/asr/criterion/criterion.h"
 #include "flashlight/app/asr/data/FeatureTransforms.h"
+#include "flashlight/app/asr/data/Utils.h"
 #include "flashlight/app/asr/decoder/ConvLmModule.h"
 #include "flashlight/app/asr/decoder/DecodeUtils.h"
 #include "flashlight/app/asr/decoder/Defines.h"
@@ -305,14 +306,9 @@ int main(int argc, char** argv) {
   featParams.useEnergy = false;
   featParams.usePower = false;
   featParams.zeroMeanFrame = false;
-  FeatureType featType = FeatureType::NONE;
-  if (FLAGS_pow) {
-    featType = FeatureType::POW_SPECTRUM;
-  } else if (FLAGS_mfsc) {
-    featType = FeatureType::MFSC;
-  } else if (FLAGS_mfcc) {
-    featType = FeatureType::MFCC;
-  }
+  FeatureType featType =
+      getFeaturesType(FLAGS_features_type, FLAGS_channels, featParams).second;
+
   TargetGenerationConfig targetGenConfig(
       FLAGS_wordseparator,
       FLAGS_sampletarget,
@@ -422,9 +418,8 @@ int main(int argc, char** argv) {
         fl::Variable rawEmission;
         if (usePlugin) {
           rawEmission = localNetwork
-                            ->forward(
-                                {fl::input(sample[kInputIdx]),
-                                 fl::noGrad(sample[kDurationIdx])})
+                            ->forward({fl::input(sample[kInputIdx]),
+                                       fl::noGrad(sample[kDurationIdx])})
                             .front();
         } else {
           rawEmission = fl::ext::forwardSequentialModuleWithPadMask(

--- a/flashlight/app/asr/Test.cpp
+++ b/flashlight/app/asr/Test.cpp
@@ -20,6 +20,7 @@
 #include "flashlight/app/asr/common/Flags.h"
 #include "flashlight/app/asr/criterion/criterion.h"
 #include "flashlight/app/asr/data/FeatureTransforms.h"
+#include "flashlight/app/asr/data/Utils.h"
 #include "flashlight/app/asr/decoder/Defines.h"
 #include "flashlight/app/asr/decoder/TranscriptionUtils.h"
 #include "flashlight/app/asr/runtime/runtime.h"
@@ -138,8 +139,8 @@ int main(int argc, char** argv) {
     LOG(INFO) << "Number of words: " << wordDict.indexSize();
   }
 
-  fl::lib::text::DictionaryMap dicts = {
-      {kTargetIdx, tokenDict}, {kWordIdx, wordDict}};
+  fl::lib::text::DictionaryMap dicts = {{kTargetIdx, tokenDict},
+                                        {kWordIdx, wordDict}};
 
   /* ===================== Create Dataset ===================== */
   fl::lib::audio::FeatureParams featParams(
@@ -156,14 +157,9 @@ int main(int argc, char** argv) {
   featParams.useEnergy = false;
   featParams.usePower = false;
   featParams.zeroMeanFrame = false;
-  FeatureType featType = FeatureType::NONE;
-  if (FLAGS_pow) {
-    featType = FeatureType::POW_SPECTRUM;
-  } else if (FLAGS_mfsc) {
-    featType = FeatureType::MFSC;
-  } else if (FLAGS_mfcc) {
-    featType = FeatureType::MFCC;
-  }
+  FeatureType featType =
+      getFeaturesType(FLAGS_features_type, FLAGS_channels, featParams).second;
+
   TargetGenerationConfig targetGenConfig(
       FLAGS_wordseparator,
       FLAGS_sampletarget,
@@ -291,9 +287,8 @@ int main(int argc, char** argv) {
       fl::Variable rawEmission;
       if (usePlugin) {
         rawEmission = localNetwork
-                          ->forward(
-                              {fl::input(sample[kInputIdx]),
-                               fl::noGrad(sample[kDurationIdx])})
+                          ->forward({fl::input(sample[kInputIdx]),
+                                     fl::noGrad(sample[kDurationIdx])})
                           .front();
       } else {
         rawEmission = fl::ext::forwardSequentialModuleWithPadMask(

--- a/flashlight/app/asr/Train.cpp
+++ b/flashlight/app/asr/Train.cpp
@@ -22,6 +22,7 @@
 #include "flashlight/app/asr/common/Flags.h"
 #include "flashlight/app/asr/criterion/criterion.h"
 #include "flashlight/app/asr/data/FeatureTransforms.h"
+#include "flashlight/app/asr/data/Utils.h"
 #include "flashlight/app/asr/decoder/DecodeMaster.h"
 #include "flashlight/app/asr/decoder/PlGenerator.h"
 #include "flashlight/app/asr/decoder/TranscriptionUtils.h"
@@ -268,18 +269,11 @@ int main(int argc, char** argv) {
   featParams.useEnergy = false;
   featParams.usePower = false;
   featParams.zeroMeanFrame = false;
-  int numFeatures = FLAGS_channels;
-  FeatureType featType = FeatureType::NONE;
-  if (FLAGS_pow) {
-    featType = FeatureType::POW_SPECTRUM;
-    numFeatures = featParams.powSpecFeatSz();
-  } else if (FLAGS_mfsc) {
-    featType = FeatureType::MFSC;
-    numFeatures = featParams.mfscFeatSz();
-  } else if (FLAGS_mfcc) {
-    featType = FeatureType::MFCC;
-    numFeatures = featParams.mfccFeatSz();
-  }
+  auto featureRes =
+      getFeaturesType(FLAGS_features_type, FLAGS_channels, featParams);
+  int numFeatures = featureRes.first;
+  FeatureType featType = featureRes.second;
+
   TargetGenerationConfig targetGenConfig(
       FLAGS_wordseparator,
       FLAGS_sampletarget,
@@ -419,12 +413,11 @@ int main(int argc, char** argv) {
           usePlugin,
           tokenDict,
           wordDict,
-          DecodeMasterTrainOptions{
-              .repLabel = int32_t(FLAGS_replabel),
-              .wordSepIsPartOfToken = FLAGS_usewordpiece,
-              .surround = FLAGS_surround,
-              .wordSep = FLAGS_wordseparator,
-              .targetPadIdx = targetpadVal});
+          DecodeMasterTrainOptions{.repLabel = int32_t(FLAGS_replabel),
+                                   .wordSepIsPartOfToken = FLAGS_usewordpiece,
+                                   .surround = FLAGS_surround,
+                                   .wordSep = FLAGS_wordseparator,
+                                   .targetPadIdx = targetpadVal});
     } else {
       throw std::runtime_error(
           "Other decoders are not supported yet during training");
@@ -807,9 +800,8 @@ int main(int argc, char** argv) {
       fl::Variable output;
       if (usePlugin) {
         output = ntwrk
-                     ->forward(
-                         {fl::input(batch[kInputIdx]),
-                          fl::noGrad(batch[kDurationIdx])})
+                     ->forward({fl::input(batch[kInputIdx]),
+                                fl::noGrad(batch[kDurationIdx])})
                      .front();
       } else {
         output = fl::ext::forwardSequentialModuleWithPadMask(
@@ -873,7 +865,7 @@ int main(int argc, char** argv) {
 
     std::shared_ptr<fl::Module> saug;
     if (FLAGS_saug_start_update >= 0) {
-      if (!(FLAGS_pow || FLAGS_mfsc || FLAGS_mfcc)) {
+      if (FLAGS_features_type == kFeaturesRaw) {
         saug = std::make_shared<fl::RawWavSpecAugment>(
             FLAGS_filterbanks,
             FLAGS_saug_fmaskf,

--- a/flashlight/app/asr/common/Defines.h
+++ b/flashlight/app/asr/common/Defines.h
@@ -54,6 +54,10 @@ constexpr const char* kSeq2SeqCriterion = "seq2seq";
 constexpr const char* kTransformerCriterion = "transformer";
 constexpr const char* kBatchStrategyNone = "none";
 constexpr const char* kBatchStrategyDynamic = "dynamic";
+constexpr const char* kFeaturesMFSC = "mfsc";
+constexpr const char* kFeaturesMFCC = "mfcc";
+constexpr const char* kFeaturesPow = "pow";
+constexpr const char* kFeaturesRaw = "raw";
 constexpr int kTargetPadValue = -1;
 
 // Feature params

--- a/flashlight/app/asr/common/Flags.cpp
+++ b/flashlight/app/asr/common/Flags.cpp
@@ -209,22 +209,13 @@ DEFINE_string(
     "supported ones 'sgd', 'adam', 'rmsprop', 'adadelta', 'adagrad', 'amsgrad', 'novograd'");
 
 // MFCC OPTIONS
-DEFINE_bool(
-    mfcc,
-    false,
-    "Use standard htk mfcc features as input by processing audio "
-    "(if 'mfcc', 'pow', 'mfsc' all false raw wave will be used as input)");
+DEFINE_string(
+    features_type,
+    "mfsc",
+    "Features type to compute input by processing audio. Could be "
+    "mfcc: standard htk mfcc features; mfsc: standard mfsc features; "
+    "pow: standard power spectrum; raw: raw wave");
 DEFINE_int64(mfcccoeffs, 13, "Number of mfcc coefficients");
-DEFINE_bool(
-    pow,
-    false,
-    "Use standard power spectrum as input by processing audio "
-    "(if 'mfcc', 'pow', 'mfsc' all false raw wave will be used as input)");
-DEFINE_bool(
-    mfsc,
-    false,
-    "Use standard mfsc features as input "
-    "(if 'mfcc', 'pow', 'mfsc' all false raw wave will be used as input)");
 DEFINE_double(melfloor, 1.0, "Specify optional mel floor for mfcc/mfsc/pow");
 DEFINE_int64(
     filterbanks,

--- a/flashlight/app/asr/common/Flags.h
+++ b/flashlight/app/asr/common/Flags.h
@@ -122,10 +122,8 @@ DECLARE_string(critoptim);
 
 /* ========== MFCC OPTIONS ========== */
 
-DECLARE_bool(mfcc);
-DECLARE_bool(pow);
+DECLARE_string(features_type);
 DECLARE_int64(mfcccoeffs);
-DECLARE_bool(mfsc);
 DECLARE_double(melfloor);
 DECLARE_int64(filterbanks);
 DECLARE_int64(devwin);

--- a/flashlight/app/asr/criterion/CMakeLists.txt
+++ b/flashlight/app/asr/criterion/CMakeLists.txt
@@ -79,4 +79,5 @@ target_sources(
   ${CMAKE_CURRENT_LIST_DIR}/attention/SoftPretrainWindow.cpp
   ${CMAKE_CURRENT_LIST_DIR}/attention/SoftWindow.cpp
   ${CMAKE_CURRENT_LIST_DIR}/attention/StepWindow.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/attention/WindowBase.cpp
   )

--- a/flashlight/app/asr/criterion/CMakeLists.txt
+++ b/flashlight/app/asr/criterion/CMakeLists.txt
@@ -73,6 +73,7 @@ target_sources(
   ${CMAKE_CURRENT_LIST_DIR}/attention/ContentAttention.cpp
   ${CMAKE_CURRENT_LIST_DIR}/attention/LocationAttention.cpp
   ${CMAKE_CURRENT_LIST_DIR}/attention/MultiHeadAttention.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/attention/Utils.cpp
   # Window
   ${CMAKE_CURRENT_LIST_DIR}/attention/MedianWindow.cpp
   ${CMAKE_CURRENT_LIST_DIR}/attention/SoftPretrainWindow.cpp

--- a/flashlight/app/asr/criterion/Seq2SeqCriterion.h
+++ b/flashlight/app/asr/criterion/Seq2SeqCriterion.h
@@ -127,7 +127,8 @@ class Seq2SeqCriterion : public SequenceCriterion {
   std::pair<fl::Variable, Seq2SeqState> decodeStep(
       const fl::Variable& xEncoded,
       const fl::Variable& y,
-      const Seq2SeqState& instate) const;
+      const Seq2SeqState& instate,
+      int targetLen = -1) const;
 
   void clearWindow() {
     trainWithWindow_ = false;

--- a/flashlight/app/asr/criterion/TransformerCriterion.cpp
+++ b/flashlight/app/asr/criterion/TransformerCriterion.cpp
@@ -181,7 +181,7 @@ std::pair<Variable, Variable> TransformerCriterion::vectorizedDecoder(
   if (!input.isempty()) {
     Variable windowWeight;
     if (window_ && (!train_ || trainWithWindow_)) {
-      windowWeight = window_->computeWindowMask(U, T, B);
+      windowWeight = window_->computeVectorizedWindow(U, T, B);
     }
 
     std::tie(alpha, summaries) =
@@ -262,8 +262,10 @@ std::pair<Variable, TS2SState> TransformerCriterion::decodeStep(
 
   Variable windowWeight, alpha, summary;
   if (window_ && (!train_ || trainWithWindow_)) {
-    windowWeight = window_->computeSingleStepWindow(
-        Variable(), xEncoded.dims(1), xEncoded.dims(2), inState.step);
+    // TODO fix for softpretrain where target size is used
+    // for now force to xEncoded.dims(1)
+    windowWeight = window_->computeWindow(
+        Variable(), inState.step, xEncoded.dims(1), xEncoded.dims(1), xEncoded.dims(2));
   }
 
   std::tie(alpha, summary) =

--- a/flashlight/app/asr/criterion/attention/AttentionBase.h
+++ b/flashlight/app/asr/criterion/attention/AttentionBase.h
@@ -13,48 +13,80 @@ namespace fl {
 namespace app {
 namespace asr {
 
+/**
+ * Attention base class for encoder-decoder: decoder attends to particular
+ * encoder part
+ */
 class AttentionBase : public fl::Container {
  public:
   AttentionBase() {}
 
-  std::vector<fl::Variable> forward(
-      const std::vector<fl::Variable>& inputs) override {
-    if (inputs.size() != 3 && inputs.size() != 4) {
-      throw std::invalid_argument("Invalid inputs size");
+  std::vector<Variable> forward(const std::vector<Variable>& inputs) override {
+    if (inputs.size() != 3 && inputs.size() != 4 && inputs.size() != 5) {
+      throw std::invalid_argument(
+          "Attention encoder-decoder: Invalid inputs size, should be 3, 4, or 5 arguments");
     }
 
-    auto attnWeight = inputs.size() == 4 ? inputs[3] : fl::Variable();
-    auto res = forward(inputs[0], inputs[1], inputs[2], attnWeight);
+    auto logAttnWeight = inputs.size() == 4 ? inputs[3] : Variable();
+    auto xEncodedSizes = inputs.size() == 5 ? inputs[4] : Variable();
+    auto res = forwardBase(
+        inputs[0], inputs[1], inputs[2], logAttnWeight, xEncodedSizes);
     return {res.first, res.second};
   }
 
-  std::pair<fl::Variable, fl::Variable> operator()(
-      const fl::Variable& state,
-      const fl::Variable& xEncoded,
-      const fl::Variable& prevAttn) {
-    return forward(state, xEncoded, prevAttn);
+  std::pair<Variable, Variable> forward(
+      const Variable& state,
+      const Variable& xEncoded,
+      const Variable& prevAttn) {
+    return forward(
+        state,
+        xEncoded,
+        prevAttn,
+        Variable() /* logAttnWeight */,
+        Variable() /* xEncodedSizes */);
   }
 
-  std::pair<fl::Variable, fl::Variable> forward(
-      const fl::Variable& state,
-      const fl::Variable& xEncoded,
-      const fl::Variable& prevAttn) {
-    return forward(state, xEncoded, prevAttn, fl::Variable() /* attnWeight */);
+  std::pair<Variable, Variable> forward(
+      const Variable& state,
+      const Variable& xEncoded,
+      const Variable& prevAttn,
+      const Variable& logAttnWeight) {
+    return forwardBase(
+        state,
+        xEncoded,
+        prevAttn,
+        logAttnWeight,
+        Variable() /* xEncodedSizes */);
   }
 
-  std::pair<fl::Variable, fl::Variable> operator()(
-      const fl::Variable& state,
-      const fl::Variable& xEncoded,
-      const fl::Variable& prevAttn,
-      const fl::Variable& attnWeight) {
-    return forward(state, xEncoded, prevAttn, attnWeight);
+  virtual std::pair<Variable, Variable> forward(
+      const Variable& state,
+      const Variable& xEncoded,
+      const Variable& prevAttn,
+      const Variable& logAttnWeight,
+      const Variable& xEncodedSizes) {
+    return forwardBase(state, xEncoded, prevAttn, logAttnWeight, xEncodedSizes);
   }
 
-  virtual std::pair<fl::Variable, fl::Variable> forward(
-      const fl::Variable& state,
-      const fl::Variable& xEncoded,
-      const fl::Variable& prevAttn,
-      const fl::Variable& attnWeight) = 0;
+ protected:
+  /**
+   * Forward pass
+   * @param state current decoder state
+   * @param xEncoded encoder output = decoder input
+   * @param prevAttn previous attention vector
+   * @param logAttnWeight attention weights to add: finalAttn =
+   * exp(logAttnWeight + logComputedAttn)
+   * @param xEncodedSizes encoder output actual sizes has (1, B) dims
+   * Returns <attention vector (sum = 1), summary> of sizes
+   * [targetlen, seqlen, batchsize] for attention,
+   * [hiddendim, targetlen, batchsize] for summary
+   */
+  virtual std::pair<Variable, Variable> forwardBase(
+      const Variable& state,
+      const Variable& xEncoded,
+      const Variable& prevAttn,
+      const Variable& logAttnWeight,
+      const Variable& xEncodedSizes) = 0;
 
  private:
   FL_SAVE_LOAD_WITH_BASE(fl::Container)

--- a/flashlight/app/asr/criterion/attention/ContentAttention.cpp
+++ b/flashlight/app/asr/criterion/attention/ContentAttention.cpp
@@ -7,37 +7,42 @@
 
 #include "flashlight/app/asr/criterion/attention/ContentAttention.h"
 #include <cmath>
+#include "flashlight/app/asr/criterion/attention/Utils.h"
 
 namespace fl {
 namespace app {
 namespace asr {
 
-std::pair<Variable, Variable> ContentAttention::forward(
+std::pair<Variable, Variable> ContentAttention::forwardBase(
     const Variable& state,
     const Variable& xEncoded,
     const Variable& /* unused */,
-    const Variable& attnWeight) {
+    const Variable& logAttnWeight,
+    const Variable& xEncodedSizes) {
   int dim = xEncoded.dims(0);
   if (dim != (1 + ((keyValue_) ? 1 : 0)) * state.dims(0)) {
-    throw std::invalid_argument("Invalid dimension for content attention");
+    throw std::invalid_argument(
+        "ContentAttention: Invalid dimension for content attention");
   }
-
   auto keys = keyValue_ ? xEncoded(af::seq(0, dim / 2 - 1)) : xEncoded;
   auto values = keyValue_ ? xEncoded(af::seq(dim / 2, dim - 1)) : xEncoded;
-
   // [targetlen, seqlen, batchsize]
   auto innerProd = matmulTN(state, keys) / std::sqrt(state.dims(0));
-
-  if (!attnWeight.isempty()) {
-    innerProd = innerProd + log(attnWeight);
+  if (!logAttnWeight.isempty()) {
+    if (logAttnWeight.dims() != innerProd.dims()) {
+      throw std::invalid_argument(
+          "ContentAttention: logAttnWeight has wong dimentions");
+    }
+    innerProd = innerProd + logAttnWeight;
   }
-
+  af::array padMask;
+  if (!xEncodedSizes.isempty()) {
+    innerProd = maskAttention(innerProd, xEncodedSizes);
+  }
   // [targetlen, seqlen, batchsize]
   auto attention = softmax(innerProd, 1);
-
   // [hiddendim, targetlen, batchsize]
   auto summaries = matmulNT(values, attention);
-
   return std::make_pair(attention, summaries);
 }
 
@@ -56,11 +61,12 @@ NeuralContentAttention::NeuralContentAttention(int dim, int layers /* = 1 */) {
   add(net);
 }
 
-std::pair<Variable, Variable> NeuralContentAttention::forward(
+std::pair<Variable, Variable> NeuralContentAttention::forwardBase(
     const Variable& state,
     const Variable& xEncoded,
     const Variable& /* unused */,
-    const Variable& attnWeight) {
+    const Variable& logAttnWeight,
+    const Variable& xEncodedSizes) {
   int U = state.dims(1);
   int H = xEncoded.dims(0);
   int T = xEncoded.dims(1);
@@ -68,23 +74,26 @@ std::pair<Variable, Variable> NeuralContentAttention::forward(
 
   auto tileHx = tile(moddims(xEncoded, {H, 1, T, B}), {1, U, 1, 1});
   auto tileHy = tile(moddims(state, {H, U, 1, B}), {1, 1, T, 1});
-
   // [hiddendim, targetlen, seqlen, batchsize]
   auto hidden = tileHx + tileHy;
-
   // [targetlen, seqlen, batchsize]
   auto nnOut = moddims(module(0)->forward({hidden}).front(), {U, T, B});
 
-  if (!attnWeight.isempty()) {
-    nnOut = nnOut + log(attnWeight);
+  if (!logAttnWeight.isempty()) {
+    if (logAttnWeight.dims() != nnOut.dims()) {
+      throw std::invalid_argument(
+          "ContentAttention: logAttnWeight has wong dimentions");
+    }
+    nnOut = nnOut + logAttnWeight;
   }
 
+  if (!xEncodedSizes.isempty()) {
+    nnOut = maskAttention(nnOut, xEncodedSizes);
+  }
   // [targetlen, seqlen, batchsize]
   auto attention = softmax(nnOut, 1);
-
   // [hiddendim, targetlen, batchsize]
   auto summaries = matmulNT(xEncoded, attention);
-
   return std::make_pair(attention, summaries);
 }
 

--- a/flashlight/app/asr/criterion/attention/ContentAttention.h
+++ b/flashlight/app/asr/criterion/attention/ContentAttention.h
@@ -17,11 +17,12 @@ class ContentAttention : public AttentionBase {
  public:
   ContentAttention(bool keyValue = false) : keyValue_(keyValue) {}
 
-  std::pair<fl::Variable, fl::Variable> forward(
-      const fl::Variable& state,
-      const fl::Variable& xEncoded,
-      const fl::Variable& prevAttn,
-      const fl::Variable& attnWeight) override;
+  std::pair<Variable, Variable> forwardBase(
+      const Variable& state,
+      const Variable& xEncoded,
+      const Variable& prevAttn,
+      const Variable& logAttnWeight,
+      const Variable& xEncodedSizes) override;
 
   std::string prettyString() const override;
 
@@ -36,11 +37,12 @@ class NeuralContentAttention : public AttentionBase {
   NeuralContentAttention() {}
   explicit NeuralContentAttention(int dim, int layers = 1);
 
-  std::pair<fl::Variable, fl::Variable> forward(
-      const fl::Variable& state,
-      const fl::Variable& xEncoded,
-      const fl::Variable& prevAttn,
-      const fl::Variable& attnWeight) override;
+  std::pair<Variable, Variable> forwardBase(
+      const Variable& state,
+      const Variable& xEncoded,
+      const Variable& prevAttn,
+      const Variable& logAttnWeight,
+      const Variable& xEncodedSizes) override;
 
   std::string prettyString() const override;
 

--- a/flashlight/app/asr/criterion/attention/Defines.h
+++ b/flashlight/app/asr/criterion/attention/Defines.h
@@ -31,6 +31,11 @@ const std::string kNoWindow = "no";
 const std::string kSoftWindow = "soft";
 const std::string kSoftPretrainWindow = "softPretrain";
 const std::string kStepWindow = "step";
+
+// to avoid nans when apply log to these var
+// which cannot be propagated correctly if we set -inf
+constexpr float kAttentionMaskValue = -10000;
+
 } // namespace asr
 } // namespace app
 } // namespace fl

--- a/flashlight/app/asr/criterion/attention/LocationAttention.h
+++ b/flashlight/app/asr/criterion/attention/LocationAttention.h
@@ -17,11 +17,12 @@ class SimpleLocationAttention : public AttentionBase {
  public:
   explicit SimpleLocationAttention(int convKernel);
 
-  std::pair<fl::Variable, fl::Variable> forward(
-      const fl::Variable& state,
-      const fl::Variable& xEncoded,
-      const fl::Variable& prevAttn,
-      const fl::Variable& attnWeight) override;
+  std::pair<Variable, Variable> forwardBase(
+      const Variable& state,
+      const Variable& xEncoded,
+      const Variable& prevAttn,
+      const Variable& logAttnWeight,
+      const Variable& xEncodedSizes) override;
 
   std::string prettyString() const override;
 
@@ -35,11 +36,12 @@ class LocationAttention : public AttentionBase {
  public:
   LocationAttention(int encDim, int convKernel);
 
-  std::pair<fl::Variable, fl::Variable> forward(
-      const fl::Variable& state,
-      const fl::Variable& xEncoded,
-      const fl::Variable& prevAttn,
-      const fl::Variable& attnWeight) override;
+  std::pair<Variable, Variable> forwardBase(
+      const Variable& state,
+      const Variable& xEncoded,
+      const Variable& prevAttn,
+      const Variable& logAttnWeight,
+      const Variable& xEncodedSizes) override;
 
   std::string prettyString() const override;
 
@@ -57,11 +59,12 @@ class NeuralLocationAttention : public AttentionBase {
       int convChannel,
       int convKernel);
 
-  std::pair<fl::Variable, fl::Variable> forward(
-      const fl::Variable& state,
-      const fl::Variable& xEncoded,
-      const fl::Variable& prevAttn,
-      const fl::Variable& attnWeight) override;
+  std::pair<Variable, Variable> forwardBase(
+      const Variable& state,
+      const Variable& xEncoded,
+      const Variable& prevAttn,
+      const Variable& logAttnWeight,
+      const Variable& xEncodedSizes) override;
 
   std::string prettyString() const override;
 

--- a/flashlight/app/asr/criterion/attention/MedianWindow.cpp
+++ b/flashlight/app/asr/criterion/attention/MedianWindow.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "flashlight/app/asr/criterion/attention/MedianWindow.h"
+#include "flashlight/app/asr/criterion/attention/Defines.h"
 
 namespace fl {
 namespace app {
@@ -14,61 +15,76 @@ namespace asr {
 MedianWindow::MedianWindow() {}
 MedianWindow::MedianWindow(int wL, int wR) : wL_(wL), wR_(wR) {}
 
-Variable MedianWindow::initialize(int inputSteps, int batchSize) {
-  int width = std::min(wL_ + wR_, inputSteps);
-
-  // [1, inputSteps]
-  auto maskArray = af::constant(0.0, 1, inputSteps);
-  maskArray(af::span, af::seq(0, width - 1)) = 1.0;
-
-  // [1, inputSteps, batchSize]
-  auto mask = Variable(tile(maskArray, {1, 1, batchSize}), false);
-
-  return mask;
-}
-
-Variable MedianWindow::computeSingleStepWindow(
+Variable MedianWindow::computeWindow(
     const Variable& prevAttn, // [1, windowsize, batchSize]
+    int step,
+    int targetLen,
     int inputSteps,
     int batchSize,
-    int step) {
-  int width = std::min(wL_ + wR_, inputSteps);
-
-  if (step == 0 || width >= inputSteps) {
-    return initialize(inputSteps, batchSize);
-  }
+    const af::array& inputSizes,
+    const af::array& targetSizes) const {
   // Each row of prevAttn is the attention for an input utterance.
   // The attention vector is output from a softmax.
   // The definition of "median" is the point where cdf passes 0.5.
-  auto mIdx = sum(accum(prevAttn.array(), 1) < 0.5, 1).as(af::dtype::s32);
+
+  int width = std::min(wL_ + wR_, inputSteps);
+  af::array inputNotPaddedSize =
+      computeInputNotPaddedSize(inputSizes, inputSteps, batchSize, 0, false);
+
+  if (step == 0 || width == inputSteps) {
+    // [1, inputSteps]
+    auto maskArray = af::constant(0.0, af::dim4(1, inputSteps, batchSize));
+    maskArray(af::span, af::seq(0, width - 1), af::span) = 1.0;
+    auto indicesAdd = af::range(af::dim4(1, inputSteps, batchSize), 1);
+    maskArray(
+        indicesAdd >= af::tile(inputNotPaddedSize, af::dim4(1, inputSteps))) =
+        0.0;
+    // [1, inputSteps, batchSize]
+    return Variable(af::log(maskArray), false);
+  }
+
+  auto mIdx =
+      af::sum(af::accum(prevAttn.array(), 1) < 0.5, 1).as(af::dtype::s32);
   auto startIdx = mIdx - wL_;
 
   // check boundary conditions and adjust the window
-  auto startDiff = af::abs(clamp(startIdx, -wL_, 0));
+  auto startDiff = af::abs(af::clamp(startIdx, -wL_, 0));
   startIdx = startIdx + startDiff;
-  auto endDiff =
-      af::abs(clamp(startIdx + wL_ + wR_ - inputSteps, 0, wL_ + wR_));
+  auto endDiff = af::abs(
+      af::clamp(startIdx + wL_ + wR_ - inputNotPaddedSize, 0, wL_ + wR_));
   startIdx = startIdx - endDiff;
 
   auto maskArray = af::constant(0.0, 1, inputSteps, batchSize, f32);
-  auto indices = range(af::dim4(width, batchSize), 0) +
-      tile(moddims(startIdx, {1, batchSize}), {width, 1}) +
-      tile(moddims(
-               af::seq(0, batchSize * inputSteps - 1, inputSteps),
-               {1, batchSize}),
-           {width, 1});
-  maskArray(flat(indices)) = 1.0;
+  auto indices = af::range(af::dim4(width, batchSize), 0) +
+      af::tile(af::moddims(startIdx, {1, batchSize}), {width, 1}) +
+      af::tile(af::moddims(
+                   af::seq(0, batchSize * inputSteps - 1, inputSteps),
+                   {1, batchSize}),
+               {width, 1});
+  maskArray(af::flat(indices)) = 1.0;
+  auto indicesAdd = af::range(af::dim4(1, inputSteps, batchSize), 1);
+  maskArray(
+      indicesAdd >= af::tile(inputNotPaddedSize, af::dim4(1, inputSteps))) =
+      0.0;
 
+  if (!targetSizes.isempty()) {
+    af::array targetNotPaddedSize = computeTargetNotPaddedSize(
+        targetSizes, inputSteps, targetLen, batchSize, 1);
+    maskArray(step >= targetNotPaddedSize) = 0.0;
+  }
+  maskArray = af::log(maskArray);
+  // force all -inf values to be kAttentionMaskValue to avoid nan in softmax
+  maskArray(maskArray < kAttentionMaskValue) = kAttentionMaskValue;
   // [1, inputSteps, batchSize]
-  auto mask = Variable(maskArray, false);
-
-  return mask;
+  return Variable(maskArray, false);
 }
 
-Variable MedianWindow::computeWindowMask(
+Variable MedianWindow::computeVectorizedWindow(
     int /* unused */,
     int /* unused */,
-    int /* unused */) {
+    int /* unused */,
+    const af::array& /* unused */,
+    const af::array& /* unused */) const {
   throw af::exception("MedianWindow does not support vectorized window mask");
 }
 } // namespace asr

--- a/flashlight/app/asr/criterion/attention/MedianWindow.h
+++ b/flashlight/app/asr/criterion/attention/MedianWindow.h
@@ -18,16 +18,21 @@ class MedianWindow : public WindowBase {
   MedianWindow();
   MedianWindow(int wL, int wR);
 
-  fl::Variable initialize(int inputSteps, int batchSize);
-
-  fl::Variable computeSingleStepWindow(
-      const fl::Variable& prevAttn,
+  Variable computeWindow(
+      const Variable& prevAttn,
+      int step,
+      int targetLen,
       int inputSteps,
       int batchSize,
-      int step) override;
+      const af::array& inputSizes = af::array(),
+      const af::array& targetSizes = af::array()) const override;
 
-  fl::Variable computeWindowMask(int targetLen, int inputSteps, int batchSize)
-      override;
+  Variable computeVectorizedWindow(
+      int targetLen,
+      int inputSteps,
+      int batchSize,
+      const af::array& inputSizes = af::array(),
+      const af::array& targetSizes = af::array()) const override;
 
  private:
   int wL_;

--- a/flashlight/app/asr/criterion/attention/MultiHeadAttention.h
+++ b/flashlight/app/asr/criterion/attention/MultiHeadAttention.h
@@ -22,11 +22,12 @@ class MultiHeadContentAttention : public AttentionBase {
       bool keyValue = false,
       bool splitInput = false);
 
-  std::pair<fl::Variable, fl::Variable> forward(
-      const fl::Variable& state,
-      const fl::Variable& xEncoded,
-      const fl::Variable& prevAttn,
-      const fl::Variable& attnWeight) override;
+  std::pair<Variable, Variable> forwardBase(
+      const Variable& state,
+      const Variable& xEncoded,
+      const Variable& prevAttn,
+      const Variable& logAttnWeight,
+      const Variable& xEncodedSizes) override;
 
   std::string prettyString() const override;
 

--- a/flashlight/app/asr/criterion/attention/SoftPretrainWindow.cpp
+++ b/flashlight/app/asr/criterion/attention/SoftPretrainWindow.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "flashlight/app/asr/criterion/attention/SoftPretrainWindow.h"
+#include "flashlight/app/asr/criterion/attention/Defines.h"
 
 namespace fl {
 namespace app {
@@ -13,32 +14,63 @@ namespace asr {
 
 SoftPretrainWindow::SoftPretrainWindow(double std) : std_(std) {}
 
-/* The pretrain window should only be used during training, since it requires
- * users set the length of the targets using setBatchStat() in advance.*/
-Variable SoftPretrainWindow::computeSingleStepWindow(
-    const Variable& /* unused */,
-    int inputSteps,
-    int batchSize,
-    int step) {
-  auto ts = af::range(af::dim4(1, inputSteps), 1);
-  double vratio = (double)inputSteps / (double)targetLen_;
-  auto maskArray = exp(-pow(ts - vratio * step, 2) / (2 * std_ * std_));
-
-  // [1, inputSteps, batchSize]
-  return Variable(tile(maskArray, {1, 1, batchSize}), false);
-}
-
-Variable SoftPretrainWindow::computeWindowMask(
+Variable SoftPretrainWindow::compute(
     int targetLen,
     int inputSteps,
-    int batchSize) {
-  auto ts = af::range(af::dim4(targetLen, inputSteps), 1);
-  auto us = af::range(af::dim4(targetLen, inputSteps));
-  double vratio = (double)inputSteps / (double)targetLen;
-  auto maskArray = exp(-pow(ts - vratio * us, 2) / (2 * std_ * std_));
+    int batchSize,
+    const af::array& inputSizes,
+    const af::array& targetSizes,
+    af::array& decoderSteps) const {
+  int decoderStepsDim = decoderSteps.dims(0);
+  auto ts = af::range(af::dim4(decoderStepsDim, inputSteps, batchSize), 1);
+  if (inputSizes.isempty() && targetSizes.isempty()) {
+    return Variable(
+        -af::pow(ts - inputSteps / targetLen * decoderSteps, 2) /
+            (2 * std_ * std_),
+        false);
+  }
 
-  // [targetLen, inputSteps, batchSize]
-  return Variable(tile(maskArray, {1, 1, batchSize}), false);
+  af::array inputNotPaddedSize = computeInputNotPaddedSize(
+      inputSizes, inputSteps, batchSize, decoderStepsDim, true);
+  af::array targetNotPaddedSize = computeTargetNotPaddedSize(
+      targetSizes, inputSteps, targetLen, batchSize, decoderStepsDim);
+
+  auto maskArray =
+      -pow(ts - inputNotPaddedSize / targetNotPaddedSize * decoderSteps, 2) /
+      (2 * std_ * std_);
+  maskArray(ts >= inputNotPaddedSize) = -std::numeric_limits<float>::infinity();
+  maskArray(decoderSteps >= targetNotPaddedSize) =
+      -std::numeric_limits<float>::infinity();
+  // force all -inf values to be kAttentionMaskValue to avoid nan in softmax
+  maskArray(maskArray < kAttentionMaskValue) = kAttentionMaskValue;
+  // [decoderStepsDim, inputSteps, batchSize]
+  return Variable(maskArray, false);
+}
+
+Variable SoftPretrainWindow::computeWindow(
+    const Variable& /* unused */,
+    int step,
+    int targetLen,
+    int inputSteps,
+    int batchSize,
+    const af::array& inputSizes,
+    const af::array& targetSizes) const {
+  af::array decoderSteps =
+      af::constant(step, af::dim4(1, inputSteps, batchSize));
+  return compute(
+      targetLen, inputSteps, batchSize, inputSizes, targetSizes, decoderSteps);
+}
+
+Variable SoftPretrainWindow::computeVectorizedWindow(
+    int targetLen,
+    int inputSteps,
+    int batchSize,
+    const af::array& inputSizes,
+    const af::array& targetSizes) const {
+  af::array decoderSteps =
+      af::range(af::dim4(targetLen, inputSteps, batchSize), 0);
+  return compute(
+      targetLen, inputSteps, batchSize, inputSizes, targetSizes, decoderSteps);
 }
 } // namespace asr
 } // namespace app

--- a/flashlight/app/asr/criterion/attention/SoftPretrainWindow.h
+++ b/flashlight/app/asr/criterion/attention/SoftPretrainWindow.h
@@ -17,19 +17,34 @@ class SoftPretrainWindow : public WindowBase {
  public:
   explicit SoftPretrainWindow(double std);
 
-  fl::Variable computeSingleStepWindow(
-      const fl::Variable& prevAttn,
+  Variable computeWindow(
+      const Variable& prevAttn,
+      int step,
+      int targetLen,
       int inputSteps,
       int batchSize,
-      int step) override;
+      const af::array& inputSizes = af::array(),
+      const af::array& targetSizes = af::array()) const override;
 
-  fl::Variable computeWindowMask(int targetLen, int inputSteps, int batchSize)
-      override;
+  Variable computeVectorizedWindow(
+      int targetLen,
+      int inputSteps,
+      int batchSize,
+      const af::array& inputSizes = af::array(),
+      const af::array& targetSizes = af::array()) const override;
 
  private:
   SoftPretrainWindow() = default;
 
   double std_;
+
+  Variable compute(
+      int targetLen,
+      int inputSteps,
+      int batchSize,
+      const af::array& inputSizes,
+      const af::array& targetSizes,
+      af::array& decoderSteps) const;
 
   FL_SAVE_LOAD_WITH_BASE(WindowBase, std_)
 };

--- a/flashlight/app/asr/criterion/attention/SoftWindow.h
+++ b/flashlight/app/asr/criterion/attention/SoftWindow.h
@@ -18,17 +18,30 @@ class SoftWindow : public WindowBase {
   SoftWindow();
   SoftWindow(double std, double avgRate, int offset);
 
-  fl::Variable computeSingleStepWindow(
-      const fl::Variable& prevAttn,
+  Variable computeWindow(
+      const Variable& prevAttn,
+      int step,
+      int targetLen,
       int inputSteps,
       int batchSize,
-      int step) override;
+      const af::array& inputSizes = af::array(),
+      const af::array& targetSizes = af::array()) const override;
 
-  fl::Variable computeWindowMask(int targetLen, int inputSteps, int batchSize)
-      override;
+  Variable computeVectorizedWindow(
+      int targetLen,
+      int inputSteps,
+      int batchSize,
+      const af::array& inputSizes = af::array(),
+      const af::array& targetSizes = af::array()) const override;
 
  private:
-  int getCenter(int step, int inputSteps);
+  Variable compute(
+      int targetLen,
+      int inputSteps,
+      int batchSize,
+      const af::array& inputSizes,
+      const af::array& targetSizes,
+      af::array& decoderSteps) const;
 
   double std_;
   double avgRate_;

--- a/flashlight/app/asr/criterion/attention/StepWindow.h
+++ b/flashlight/app/asr/criterion/attention/StepWindow.h
@@ -18,20 +18,35 @@ class StepWindow : public WindowBase {
   StepWindow();
   StepWindow(int sMin, int sMax, double vMin, double vMax);
 
-  fl::Variable computeSingleStepWindow(
-      const fl::Variable& prevAttn,
+  Variable computeWindow(
+      const Variable& prevAttn,
+      int step,
+      int targetLen,
       int inputSteps,
       int batchSize,
-      int step) override;
+      const af::array& inputSizes = af::array(),
+      const af::array& targetSizes = af::array()) const override;
 
-  fl::Variable computeWindowMask(int targetLen, int inputSteps, int batchSize)
-      override;
+  Variable computeVectorizedWindow(
+      int targetLen,
+      int inputSteps,
+      int batchSize,
+      const af::array& inputSizes = af::array(),
+      const af::array& targetSizes = af::array()) const override;
 
  private:
   int sMin_;
   int sMax_;
   double vMin_;
   double vMax_;
+
+  Variable compute(
+      int targetLen,
+      int inputSteps,
+      int batchSize,
+      const af::array& inputSizes,
+      const af::array& targetSizes,
+      af::array& decoderSteps) const;
 
   FL_SAVE_LOAD_WITH_BASE(WindowBase, sMin_, sMax_, vMin_, vMax_)
 };

--- a/flashlight/app/asr/criterion/attention/Utils.cpp
+++ b/flashlight/app/asr/criterion/attention/Utils.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "flashlight/app/asr/criterion/attention/Utils.h"
+#include "flashlight/app/asr/criterion/attention/Defines.h"
 
 #include "flashlight/fl/flashlight.h"
 

--- a/flashlight/app/asr/criterion/attention/Utils.cpp
+++ b/flashlight/app/asr/criterion/attention/Utils.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "flashlight/app/asr/criterion/attention/Utils.h"
+
+#include "flashlight/fl/flashlight.h"
+
+namespace fl {
+namespace app {
+namespace asr {
+
+Variable maskAttention(const Variable& input, const Variable& sizes) {
+  int B = input.dims(2);
+  int T = input.dims(1);
+  // xEncodedSizes is (1, B) size
+  af::array inputNotPaddedSize =
+      af::ceil(sizes.array() / af::max<float>(sizes.array()) * T);
+  auto padMask = af::iota(af::dim4(T, 1), af::dim4(1, B)) >=
+      af::tile(inputNotPaddedSize, T, 1);
+  padMask =
+      af::tile(af::moddims(padMask, af::dim4(1, T, B)), input.dims(0), 1, 1);
+
+  af::array output = af::flat(input.array());
+  af::array flatPadMask = af::flat(padMask);
+  auto inputDims = input.dims();
+
+  output(flatPadMask) = kAttentionMaskValue;
+  output = af::moddims(output, inputDims);
+
+  auto gradFunc = [flatPadMask, inputDims](
+                      std::vector<Variable>& inputs,
+                      const Variable& gradOutput) {
+    af::array gradArray = af::flat(gradOutput.array());
+    gradArray(flatPadMask) = 0.;
+    auto grad = Variable(af::moddims(gradArray, inputDims), false);
+    inputs[0].addGrad(grad);
+  };
+  return Variable(output, {input.withoutData()}, gradFunc);
+}
+} // namespace asr
+} // namespace app
+} // namespace fl

--- a/flashlight/app/asr/criterion/attention/Utils.h
+++ b/flashlight/app/asr/criterion/attention/Utils.h
@@ -7,17 +7,11 @@
 
 #pragma once
 
-#include "flashlight/app/asr/criterion/attention/Utils.h"
-
 #include "flashlight/fl/flashlight.h"
 
 namespace fl {
 namespace app {
 namespace asr {
-
-// to avoid nans when apply log to these var
-// which cannot be propagated correctly if we set -inf
-constexpr float kAttentionMaskValue = -10000;
 
 fl::Variable maskAttention(
     const fl::Variable& input,

--- a/flashlight/app/asr/criterion/attention/Utils.h
+++ b/flashlight/app/asr/criterion/attention/Utils.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "flashlight/app/asr/criterion/attention/Utils.h"
+
+#include "flashlight/fl/flashlight.h"
+
+namespace fl {
+namespace app {
+namespace asr {
+
+// to avoid nans when apply log to these var
+// which cannot be propagated correctly if we set -inf
+constexpr float kAttentionMaskValue = -10000;
+
+fl::Variable maskAttention(
+    const fl::Variable& input,
+    const fl::Variable& sizes);
+} // namespace asr
+} // namespace app
+} // namespace fl

--- a/flashlight/app/asr/criterion/attention/WindowBase.cpp
+++ b/flashlight/app/asr/criterion/attention/WindowBase.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "flashlight/app/asr/criterion/attention/WindowBase.h"
+
+namespace fl {
+namespace app {
+namespace asr {
+
+af::array WindowBase::computeInputNotPaddedSize(
+    const af::array& inputSizes,
+    int inputSteps,
+    int batchSize,
+    int decoderStepsDim,
+    int doTile) const {
+  if (inputSizes.isempty()) {
+    if (doTile) {
+      return af::constant(
+          static_cast<float>(inputSteps),
+          af::dim4(decoderStepsDim, inputSteps, batchSize));
+    } else {
+      return af::constant(
+          static_cast<float>(inputSteps), af::dim4(1, 1, batchSize));
+    }
+  }
+  if (inputSizes.elements() != batchSize) {
+    throw std::runtime_error(
+        "Attention Window: wrong size of the input sizes vector, doesn't match with batchsize");
+  }
+  af::array inputNotPaddedSize =
+      af::ceil(inputSizes / af::max<float>(inputSizes) * inputSteps);
+  inputNotPaddedSize =
+      af::moddims(inputNotPaddedSize, af::dim4(1, 1, batchSize));
+  if (doTile) {
+    inputNotPaddedSize =
+        af::tile(inputNotPaddedSize, decoderStepsDim, inputSteps, 1);
+  }
+  return inputNotPaddedSize;
+}
+
+af::array WindowBase::computeTargetNotPaddedSize(
+    const af::array& targetSizes,
+    int inputSteps,
+    int targetLen,
+    int batchSize,
+    int decoderStepsDim) const {
+  if (targetSizes.isempty()) {
+    return af::constant(
+        static_cast<float>(targetLen),
+        af::dim4(decoderStepsDim, inputSteps, batchSize));
+  }
+  if (targetSizes.elements() != batchSize) {
+    throw std::runtime_error(
+        "Window Attention: wrong size of the target sizes vector, doesn't match with batchsize");
+  }
+  af::array targetNotPaddedSize = af::moddims(
+      af::ceil(targetSizes / af::max<float>(targetSizes) * targetLen),
+      1,
+      1,
+      batchSize);
+  targetNotPaddedSize =
+      af::tile(targetNotPaddedSize, af::dim4(decoderStepsDim, inputSteps, 1));
+  return targetNotPaddedSize;
+}
+
+} // namespace asr
+} // namespace app
+} // namespace fl

--- a/flashlight/app/asr/criterion/attention/WindowBase.h
+++ b/flashlight/app/asr/criterion/attention/WindowBase.h
@@ -13,31 +13,91 @@ namespace fl {
 namespace app {
 namespace asr {
 
+/**
+ * Pretraining window class which defines attention mask
+ * while attention is not trained yet, so it force aligning attention
+ * thus we can have good proxy for attention between encoder-decoder
+ * right at the beginning
+ */
 class WindowBase {
  public:
   WindowBase() {}
 
-  virtual fl::Variable computeSingleStepWindow(
-      const fl::Variable& prevAttn,
+  /**
+   * Compute window for the data for particular output step using
+   * @param prevAttn previous step attention
+   * @param step decoder step
+   * @param inputSteps encoder output / decoder input length (max in the batch)
+   * @param batchSize batch size
+   * @param inputSizes actual encoder output / decoder input sizes (even before
+   * the encoder, we need only the proportions); can be empty which means all
+   * are treated to be the same size, size is 1xB
+   * @param targetSizes actual decoder target output sizes (excluding padding);
+   * can be empty
+   */
+  virtual Variable computeWindow(
+      const Variable& prevAttn,
+      int step,
+      int targetLen,
       int inputSteps,
       int batchSize,
-      int step) = 0;
+      const af::array& inputSizes = af::array(),
+      const af::array& targetSizes = af::array()) const = 0;
 
-  virtual fl::Variable
-  computeWindowMask(int targetLen, int inputSteps, int batchSize) = 0;
+  /**
+   * Compute window for the data for entire decoder known target size
+   * @param targetLen target size (max in the batch)
+   * @param inputSteps encoder output / decoder input length (max in the batch)
+   * @param batchSize batch size
+   * @param inputSizes actual encoder output / decoder input sizes (even before
+   * the encoder, we need only the proportions); can be empty which means all
+   * are treated to be the same size, size is 1xB
+   * @param targetSizes actual decoder target output sizes (excluding padding);
+   * can be empty
+   */
+  virtual Variable computeVectorizedWindow(
+      int targetLen,
+      int inputSteps,
+      int batchSize,
+      const af::array& inputSizes = af::array(),
+      const af::array& targetSizes = af::array()) const = 0;
 
   virtual ~WindowBase() {}
 
-  void setBatchStat(int seqLen, int targetLen, int batchSize) {
-    inputLen_ = seqLen;
-    targetLen_ = targetLen;
-    batchSize_ = batchSize;
-  }
-
  protected:
-  int inputLen_;
-  int targetLen_;
-  int batchSize_;
+  /**
+   * Compute necessary matrix to process the padding later from the input sizes
+   * @param inputSizes actual encoder output / decoder input sizes (even before
+   * the encoder, we need only the proportions); can be empty which means all
+   * are treated to be the same size, size is 1xB
+   * @param inputSteps encoder output / decoder input length (max in the batch)
+   * @param batchSize batch size
+   * @param decoderStepsDim max decoder steps
+   * @param doTile Do necessary tile to (decoderStepsDim, inputSteps, BatchSize)
+   * or return (1, 1, BatchSize) vector (depends on the window we need to use)
+   */
+  af::array computeInputNotPaddedSize(
+      const af::array& inputSizes,
+      int inputSteps,
+      int batchSize,
+      int decoderStepsDim,
+      int doTile) const;
+
+  /**
+   * Compute necessary matrix to process the padding later from the target sizes
+   * @param targetSizes actual decoder target output sizes (excluding padding);
+   * can be empty
+   * @param inputSteps encoder output / decoder input length (max in the batch)
+   * @param targetLen target size (max in the batch)
+   * @param batchSize batch size
+   * @param decoderStepsDim max decoder steps
+   */
+  af::array computeTargetNotPaddedSize(
+      const af::array& targetSizes,
+      int inputSteps,
+      int targetLen,
+      int batchSize,
+      int decoderStepsDim) const;
 
  private:
   FL_SAVE_LOAD()

--- a/flashlight/app/asr/data/Utils.cpp
+++ b/flashlight/app/asr/data/Utils.cpp
@@ -77,16 +77,15 @@ std::vector<std::string> wrd2Target(
     bool skipUnk /* = false */) {
   std::vector<std::string> res;
   for (auto w : words) {
-    auto w2tokens =
-        wrd2Target(
-          w,
-          lexicon,
-          dict,
-          wordSeparator,
-          targetSamplePct,
-          fallback2LtrWordSepLeft,
-          fallback2LtrWordSepRight,
-          skipUnk);
+    auto w2tokens = wrd2Target(
+        w,
+        lexicon,
+        dict,
+        wordSeparator,
+        targetSamplePct,
+        fallback2LtrWordSepLeft,
+        fallback2LtrWordSepRight,
+        skipUnk);
 
     if (w2tokens.size() == 0) {
       continue;
@@ -95,6 +94,27 @@ std::vector<std::string> wrd2Target(
   }
   return res;
 }
+
+std::pair<int, FeatureType> getFeaturesType(
+    const std::string& featuresType,
+    int channels,
+    const fl::lib::audio::FeatureParams& featParams) {
+  if (featuresType == kFeaturesPow) {
+    return std::make_pair(
+        featParams.powSpecFeatSz(), FeatureType::POW_SPECTRUM);
+  } else if (featuresType == kFeaturesMFSC) {
+    return std::make_pair(featParams.mfscFeatSz(), FeatureType::MFSC);
+  } else if (featuresType == kFeaturesMFSC) {
+    return std::make_pair(featParams.mfccFeatSz(), FeatureType::MFCC);
+  } else if (featuresType == kFeaturesRaw) {
+    return std::make_pair(channels, FeatureType::NONE);
+  } else {
+    throw std::runtime_error(
+        "Unsupported feature type for audio preprocessing '" + featuresType +
+        "'");
+  }
+}
+
 } // namespace asr
 } // namespace app
 } // namespace fl

--- a/flashlight/app/asr/data/Utils.h
+++ b/flashlight/app/asr/data/Utils.h
@@ -10,6 +10,8 @@
 #include <string>
 #include <vector>
 
+#include "flashlight/app/asr/data/FeatureTransforms.h"
+#include "flashlight/lib/audio/feature/FeatureParams.h"
 #include "flashlight/lib/text/dictionary/Dictionary.h"
 #include "flashlight/lib/text/dictionary/Utils.h"
 
@@ -36,6 +38,12 @@ std::vector<std::string> wrd2Target(
     bool fallback2LtrWordSepLeft = false,
     bool fallback2LtrWordSepRight = false,
     bool skipUnk = false);
+
+std::pair<int, FeatureType> getFeaturesType(
+    const std::string& featuresType,
+    int channels,
+    const fl::lib::audio::FeatureParams& featParams);
+
 } // namespace asr
 } // namespace app
 } // namespace fl

--- a/flashlight/app/asr/runtime/Logger.cpp
+++ b/flashlight/app/asr/runtime/Logger.cpp
@@ -78,7 +78,7 @@ std::string getLogString(
   auto tsztotal = stats[1];
   auto tszmax = stats[3];
   auto iszAvrFrames = isztotal / numsamples;
-  if (FLAGS_pow || FLAGS_mfcc || FLAGS_mfsc) {
+  if (FLAGS_features_type != kFeaturesRaw) {
     iszAvrFrames = iszAvrFrames / FLAGS_framestridems;
   } else {
     iszAvrFrames = iszAvrFrames / 1000 * FLAGS_samplerate;

--- a/flashlight/app/asr/runtime/Logger.h
+++ b/flashlight/app/asr/runtime/Logger.h
@@ -46,7 +46,7 @@ struct TestMeters {
 
 /*
  * Utility function to log results (learning rate, WER, TER, epoch, timing)
- * From gflags it uses FLAGS_batchsize, FLAGS_pow, FLAGS_mfcc, FLAGS_mfsc
+ * From gflags it uses FLAGS_batchsize, FLAGS_features_type
  * FLAGS_framestridems, FLAGS_samplerate
  */
 std::string getLogString(

--- a/flashlight/app/asr/test/criterion/attention/AttentionTest.cpp
+++ b/flashlight/app/asr/test/criterion/attention/AttentionTest.cpp
@@ -10,13 +10,52 @@
 #include <arrayfire.h>
 #include "flashlight/fl/flashlight.h"
 
+#include "flashlight/app/asr/criterion/attention/Utils.h"
 #include "flashlight/app/asr/criterion/attention/attention.h"
 
 using namespace fl;
 using namespace fl::app::asr;
 
 namespace {
-void sequential_test(std::shared_ptr<AttentionBase> attention, int H) {
+using JacobianFunc = std::function<Variable(Variable&)>;
+bool jacobianTestImpl(
+    const JacobianFunc& func,
+    Variable& input,
+    float precision = 1E-5,
+    float perturbation = 1E-4) {
+  auto fwdJacobian =
+      af::array(func(input).elements(), input.elements(), af::dtype::f32);
+
+  for (int i = 0; i < input.elements(); ++i) {
+    af::array orig = input.array()(i);
+    input.array()(i) = orig - perturbation;
+    auto outa = func(input).array();
+
+    input.array()(i) = orig + perturbation;
+    auto outb = func(input).array();
+    input.array()(i) = orig;
+
+    fwdJacobian(af::span, i) =
+        af::moddims((outb - outa), outa.elements()) * 0.5 / perturbation;
+  }
+
+  auto bwdJacobian =
+      af::array(func(input).elements(), input.elements(), af::dtype::f32);
+  auto dout =
+      Variable(af::constant(0, func(input).dims(), func(input).type()), false);
+  for (int i = 0; i < dout.elements(); ++i) {
+    dout.array()(i) = 1; // element in 1D view
+    input.zeroGrad();
+    auto out = func(input);
+    out.backward(dout);
+    bwdJacobian(i, af::span) =
+        af::moddims(input.grad().array(), input.elements());
+    dout.array()(i) = 0;
+  }
+  return allClose(fwdJacobian, bwdJacobian, precision);
+}
+
+void sequentialTest(std::shared_ptr<AttentionBase> attention, int H) {
   int B = 2, T = 10;
 
   Variable encodedx(af::randn(H, T, B), true);
@@ -29,20 +68,57 @@ void sequential_test(std::shared_ptr<AttentionBase> attention, int H) {
     ASSERT_EQ(alphas.dims(), af::dim4(1, T, B));
     ASSERT_EQ(summaries.dims(), af::dim4(H, 1, B));
 
-    auto alphasum = sum(alphas.array(), 1);
+    auto alphasum = af::sum(alphas.array(), 1);
     auto ones = af::constant(1.0, alphasum.dims(), alphasum.type());
     ASSERT_TRUE(allClose(alphasum, ones, 1e-5));
   }
 
-  Variable window_mask = Variable(af::constant(1.0, 1, T, B), false);
+  Variable windowMask = Variable(af::constant(0.0, 1, T, B), false);
   auto alphas1 =
-      std::get<0>(attention->forward(encodedy, encodedx, alphas, window_mask));
+      std::get<0>(attention->forward(encodedy, encodedx, alphas, windowMask));
   auto alphas2 = std::get<0>(attention->forward(encodedy, encodedx, alphas));
   ASSERT_TRUE(allClose(alphas1, alphas2, 1e-6));
 
-  Variable encodedy_invalid(af::randn(H, 10, B), true);
+  Variable encodedyInvalid(af::randn(H, 10, B), true);
   EXPECT_THROW(
-      attention->forward(encodedy_invalid, encodedx, alphas),
+      attention->forward(encodedyInvalid, encodedx, alphas),
+      std::invalid_argument);
+}
+
+void sequentialTestWithPad(std::shared_ptr<AttentionBase> attention, int H) {
+  int B = 2, T = 10;
+
+  Variable encodedx(af::randn(H, T, B), true);
+  std::vector<int> padRaw = {T / 2, T};
+  Variable pad = Variable(af::array(af::dim4(1, B), padRaw.data()), false);
+  Variable encodedy(af::randn(H, 1, B), true);
+
+  Variable alphas, summaries;
+  for (int step = 0; step < 3; ++step) {
+    std::tie(alphas, summaries) =
+        attention->forward(encodedy, encodedx, alphas, Variable(), pad);
+    ASSERT_EQ(alphas.dims(), af::dim4(1, T, B));
+    ASSERT_EQ(summaries.dims(), af::dim4(H, 1, B));
+
+    auto alphasum = af::sum(alphas.array(), 1);
+    auto ones = af::constant(1.0, alphasum.dims(), alphasum.type());
+    ASSERT_TRUE(allClose(alphasum, ones, 1e-5));
+    ASSERT_TRUE(
+        af::count<int>(
+            alphas.array()(af::span, af::seq(T - T / 2, T - 1), 0) == 0) ==
+        T / 2);
+  }
+
+  Variable windowMask = Variable(af::constant(0.0, 1, T, B), false);
+  auto alphas1 = std::get<0>(
+      attention->forward(encodedy, encodedx, alphas, windowMask, pad));
+  auto alphas2 = std::get<0>(
+      attention->forward(encodedy, encodedx, alphas, Variable{}, pad));
+  ASSERT_TRUE(allClose(alphas1, alphas2, 1e-6));
+
+  Variable encodedyInvalid(af::randn(H, 10, B), true);
+  EXPECT_THROW(
+      attention->forward(encodedyInvalid, encodedx, alphas),
       std::invalid_argument);
 }
 
@@ -55,57 +131,97 @@ TEST(AttentionTest, NeuralContentAttention) {
   Variable encodedx(af::randn(H, T, B), true);
   Variable encodedy(af::randn(H, U, B), true);
 
-  Variable alphas, summaries;
-  std::tie(alphas, summaries) = attention(encodedy, encodedx, Variable{});
-  ASSERT_EQ(alphas.dims(), af::dim4(U, T, B));
-  ASSERT_EQ(summaries.dims(), af::dim4(H, U, B));
+  std::vector<int> padRaw = {T / 2, T};
+  Variable pad = Variable(af::array(af::dim4(1, B), padRaw.data()), false);
 
-  auto alphasum = sum(alphas.array(), 1);
-  auto ones = af::constant(1.0, alphasum.dims(), alphasum.type());
-  ASSERT_TRUE(allClose(alphasum, ones, 1e-5));
+  std::vector<Variable> padV = {Variable(), pad};
+  for (auto currentPad : padV) {
+    Variable alphas, summaries;
+    std::tie(alphas, summaries) = attention.forward(
+        encodedy, encodedx, Variable{}, Variable{}, currentPad);
+    ASSERT_EQ(alphas.dims(), af::dim4(U, T, B));
+    ASSERT_EQ(summaries.dims(), af::dim4(H, U, B));
+    if (!currentPad.isempty()) {
+      ASSERT_TRUE(
+          af::count<int>(
+              alphas.array()(af::span, af::seq(T - T / 2, T - 1), 0) == 0) ==
+          T / 2 * U);
+    }
+    auto alphasum = sum(alphas.array(), 1);
+    auto ones = af::constant(1.0, alphasum.dims(), alphasum.type());
+    ASSERT_TRUE(allClose(alphasum, ones, 1e-5));
 
-  Variable window_mask = Variable(af::constant(1.0, U, T, B), false);
-  auto alphas1 = std::get<0>(
-      attention.forward(encodedy, encodedx, Variable{}, window_mask));
-  ASSERT_TRUE(allClose(alphas, alphas1, 1e-6));
+    Variable windowMask = Variable(af::constant(0.0, U, T, B), false);
+    auto alphas1 = std::get<0>(attention.forward(
+        encodedy, encodedx, Variable{}, windowMask, currentPad));
+    ASSERT_TRUE(allClose(alphas, alphas1, 1e-6));
+  }
 }
 
 TEST(AttentionTest, SimpleLocationAttention) {
   int H = 8, K = 5;
-  sequential_test(std::make_shared<SimpleLocationAttention>(K), H);
+  sequentialTest(std::make_shared<SimpleLocationAttention>(K), H);
+  sequentialTestWithPad(std::make_shared<SimpleLocationAttention>(K), H);
 }
 
 TEST(AttentionTest, LocationAttention) {
   int H = 8, K = 5;
-  sequential_test(std::make_shared<LocationAttention>(H, K), H);
+  sequentialTest(std::make_shared<LocationAttention>(H, K), H);
+  sequentialTestWithPad(std::make_shared<LocationAttention>(H, K), H);
 }
 
 TEST(AttentionTest, NeuralLocationAttention) {
   int H = 8, A = 8, C = 5, K = 3;
-  sequential_test(std::make_shared<NeuralLocationAttention>(H, A, C, K), H);
+  sequentialTest(std::make_shared<NeuralLocationAttention>(H, A, C, K), H);
+  sequentialTestWithPad(
+      std::make_shared<NeuralLocationAttention>(H, A, C, K), H);
 }
 
 TEST(AttentionTest, MultiHeadContentAttention) {
   int H = 512, B = 2, T = 10, U = 5, NH = 8;
 
-  for (bool keyValue : {true, false}) {
-    for (bool splitInput : {true, false}) {
-      MultiHeadContentAttention attention(H, NH, keyValue, splitInput);
+  std::vector<int> padRaw = {T / 2, T};
+  Variable pad = Variable(af::array(af::dim4(1, B), padRaw.data()), false);
 
-      auto Hencode = keyValue ? H * 2 : H;
-      Variable encodedx(af::randn(Hencode, T, B), true);
-      Variable encodedy(af::randn(H, U, B), true);
+  std::vector<Variable> padV = {Variable(), pad};
+  for (auto currentPad : padV) {
+    for (bool keyValue : {true, false}) {
+      for (bool splitInput : {true, false}) {
+        MultiHeadContentAttention attention(H, NH, keyValue, splitInput);
 
-      Variable alphas, summaries;
-      std::tie(alphas, summaries) = attention(encodedy, encodedx, Variable{});
-      ASSERT_EQ(alphas.dims(), af::dim4(U * NH, T, B));
-      ASSERT_EQ(summaries.dims(), af::dim4(H, U, B));
+        auto hEncode = keyValue ? H * 2 : H;
+        Variable encodedx(af::randn(hEncode, T, B), true);
+        Variable encodedy(af::randn(H, U, B), true);
 
-      auto alphasum = sum(alphas.array(), 1);
-      auto ones = af::constant(1.0, alphasum.dims(), alphasum.type());
-      ASSERT_TRUE(allClose(alphasum, ones, 1e-5));
+        Variable alphas, summaries;
+        std::tie(alphas, summaries) = attention.forward(
+            encodedy, encodedx, Variable{}, Variable{}, currentPad);
+        ASSERT_EQ(alphas.dims(), af::dim4(U * NH, T, B));
+        ASSERT_EQ(summaries.dims(), af::dim4(H, U, B));
+        if (!currentPad.isempty()) {
+          ASSERT_TRUE(
+              af::count<int>(
+                  alphas.array()(af::span, af::seq(T - T / 2, T - 1), 0) ==
+                  0) == T / 2 * U * NH);
+        }
+
+        auto alphasum = sum(alphas.array(), 1);
+        auto ones = af::constant(1.0, alphasum.dims(), alphasum.type());
+        ASSERT_TRUE(allClose(alphasum, ones, 1e-5));
+      }
     }
   }
+}
+
+TEST(AttentionTest, JacobianMaskAttention) {
+  // CxTxB
+  auto in = Variable(af::randu(10, 9, 5, af::dtype::f32), true);
+  std::vector<int> inpSzRaw = {1, 2, 4, 8, 16};
+  af::array inpSz = af::array(af::dim4(1, inpSzRaw.size()), inpSzRaw.data());
+  auto func_in = [&](Variable& input) {
+    return fl::app::asr::maskAttention(input, fl::Variable(inpSz, false));
+  };
+  ASSERT_TRUE(jacobianTestImpl(func_in, in, 2e-4));
 }
 
 int main(int argc, char** argv) {

--- a/flashlight/app/asr/tools/VoiceActivityDetection-CTC.cpp
+++ b/flashlight/app/asr/tools/VoiceActivityDetection-CTC.cpp
@@ -36,6 +36,7 @@
 #include "flashlight/app/asr/common/Defines.h"
 #include "flashlight/app/asr/criterion/criterion.h"
 #include "flashlight/app/asr/data/FeatureTransforms.h"
+#include "flashlight/app/asr/data/Utils.h"
 #include "flashlight/app/asr/decoder/TranscriptionUtils.h"
 #include "flashlight/app/asr/runtime/runtime.h"
 #include "flashlight/ext/common/SequentialBuilder.h"
@@ -163,18 +164,9 @@ int main(int argc, char** argv) {
   featParams.useEnergy = false;
   featParams.usePower = false;
   featParams.zeroMeanFrame = false;
-  int numFeatures = FLAGS_channels;
-  FeatureType featType = FeatureType::NONE;
-  if (FLAGS_pow) {
-    featType = FeatureType::POW_SPECTRUM;
-    numFeatures = featParams.powSpecFeatSz();
-  } else if (FLAGS_mfsc) {
-    featType = FeatureType::MFSC;
-    numFeatures = featParams.mfscFeatSz();
-  } else if (FLAGS_mfcc) {
-    featType = FeatureType::MFCC;
-    numFeatures = featParams.mfccFeatSz();
-  }
+  FeatureType featType =
+      getFeaturesType(FLAGS_features_type, FLAGS_channels, featParams).second;
+
   TargetGenerationConfig targetGenConfig(
       FLAGS_wordseparator,
       FLAGS_sampletarget,

--- a/flashlight/app/asr/tools/alignment/Align.cpp
+++ b/flashlight/app/asr/tools/alignment/Align.cpp
@@ -11,6 +11,7 @@
 #include "flashlight/app/asr/common/Defines.h"
 #include "flashlight/app/asr/criterion/criterion.h"
 #include "flashlight/app/asr/data/FeatureTransforms.h"
+#include "flashlight/app/asr/data/Utils.h"
 #include "flashlight/app/asr/runtime/runtime.h"
 #include "flashlight/app/asr/tools/alignment/Utils.h"
 #include "flashlight/ext/common/SequentialBuilder.h"
@@ -141,18 +142,9 @@ int main(int argc, char** argv) {
   featParams.useEnergy = false;
   featParams.usePower = false;
   featParams.zeroMeanFrame = false;
-  int numFeatures = FLAGS_channels;
-  FeatureType featType = FeatureType::NONE;
-  if (FLAGS_pow) {
-    featType = FeatureType::POW_SPECTRUM;
-    numFeatures = featParams.powSpecFeatSz();
-  } else if (FLAGS_mfsc) {
-    featType = FeatureType::MFSC;
-    numFeatures = featParams.mfscFeatSz();
-  } else if (FLAGS_mfcc) {
-    featType = FeatureType::MFCC;
-    numFeatures = featParams.mfccFeatSz();
-  }
+  FeatureType featType =
+      getFeaturesType(FLAGS_features_type, FLAGS_channels, featParams).second;
+
   TargetGenerationConfig targetGenConfig(
       FLAGS_wordseparator,
       FLAGS_sampletarget,

--- a/flashlight/app/asr/tutorial/FinetuneCTC.cpp
+++ b/flashlight/app/asr/tutorial/FinetuneCTC.cpp
@@ -21,6 +21,7 @@
 #include "flashlight/app/asr/common/Defines.h"
 #include "flashlight/app/asr/criterion/criterion.h"
 #include "flashlight/app/asr/data/FeatureTransforms.h"
+#include "flashlight/app/asr/data/Utils.h"
 #include "flashlight/app/asr/decoder/TranscriptionUtils.h"
 #include "flashlight/app/asr/runtime/runtime.h"
 #include "flashlight/ext/common/DistributedUtils.h"
@@ -177,18 +178,11 @@ int main(int argc, char** argv) {
   featParams.useEnergy = false;
   featParams.usePower = false;
   featParams.zeroMeanFrame = false;
-  int numFeatures = FLAGS_channels;
-  FeatureType featType = FeatureType::NONE;
-  if (FLAGS_pow) {
-    featType = FeatureType::POW_SPECTRUM;
-    numFeatures = featParams.powSpecFeatSz();
-  } else if (FLAGS_mfsc) {
-    featType = FeatureType::MFSC;
-    numFeatures = featParams.mfscFeatSz();
-  } else if (FLAGS_mfcc) {
-    featType = FeatureType::MFCC;
-    numFeatures = featParams.mfccFeatSz();
-  }
+  auto featureRes =
+      getFeaturesType(FLAGS_features_type, FLAGS_channels, featParams);
+  int numFeatures = featureRes.first;
+  FeatureType featType = featureRes.second;
+
   TargetGenerationConfig targetGenConfig(
       FLAGS_wordseparator,
       FLAGS_sampletarget,

--- a/flashlight/app/asr/tutorial/InferenceCTC.cpp
+++ b/flashlight/app/asr/tutorial/InferenceCTC.cpp
@@ -16,6 +16,7 @@
 #include "flashlight/app/asr/common/Defines.h"
 #include "flashlight/app/asr/data/FeatureTransforms.h"
 #include "flashlight/app/asr/data/Sound.h"
+#include "flashlight/app/asr/data/Utils.h"
 #include "flashlight/app/asr/decoder/DecodeUtils.h"
 #include "flashlight/app/asr/decoder/Defines.h"
 #include "flashlight/app/asr/decoder/TranscriptionUtils.h"
@@ -208,13 +209,23 @@ int main(int argc, char** argv) {
   featParams.useEnergy = false;
   featParams.usePower = false;
   featParams.zeroMeanFrame = false;
-  fl::app::asr::FeatureType featType = fl::app::asr::FeatureType::NONE;
-  if (networkFlags["pow"] == "true") {
-    featType = fl::app::asr::FeatureType::POW_SPECTRUM;
-  } else if (networkFlags["mfsc"] == "true") {
-    featType = fl::app::asr::FeatureType::MFSC;
-  } else if (networkFlags["mfcc"] == "true") {
-    featType = fl::app::asr::FeatureType::MFCC;
+  fl::app::asr::FeatureType featType;
+  if (networkFlags.find("features_type") != networkFlags.end()) {
+    featType = fl::app::asr::getFeaturesType(
+                   networkFlags["features_type"], 1, featParams)
+                   .second;
+  } else {
+    // old models
+    if (networkFlags["pow"] == "true") {
+      featType = fl::app::asr::FeatureType::POW_SPECTRUM;
+    } else if (networkFlags["mfsc"] == "true") {
+      featType = fl::app::asr::FeatureType::MFSC;
+    } else if (networkFlags["mfcc"] == "true") {
+      featType = fl::app::asr::FeatureType::MFCC;
+    } else {
+      // raw wave
+      featType = fl::app::asr::FeatureType::NONE;
+    }
   }
   auto inputTransform = fl::app::asr::inputFeatures(
       featParams,


### PR DESCRIPTION
Summary:
Implement proper pre-training window with respect to padded input and padded target (so part on pre-trained window can provide 0-attention weight as it is padded position).
- revisit API for window.
- remove setBatchStat as a error-prone part (right now transformer criterion ignores this function). Provide input size in case target is not available, so that median window can be computed for Viterbi.
- add extra arguments with input sizes proportions and with target sizes proportions (so that actual current sizes for input and target can be computed)
- return window in log scale to avoid
  - log(exp(x)) operation later in full attention computation
  - errors which will occur due to softmax normalization in case all input is padded for particular decoder step.
- rewrite all window logic with af and in vectorized form with proper reusing of the same part of code for one decoder step or for vectorized all decoders steps
- For now this fix doesn't change s2s models criteria, use the old behaviour for now.
- Fix camelCase
- Add a bit of docs

Differential Revision: D25141129

