### PR TITLE
[fl][opencl] DNNL OpenCL GPU support

### DIFF
--- a/flashlight/fl/autograd/CMakeLists.txt
+++ b/flashlight/fl/autograd/CMakeLists.txt
@@ -16,7 +16,7 @@ target_sources(
 
 # ----------------------------- Autograd Backends -----------------------------
 # CPU
-if (FL_USE_CPU OR FL_USE_OPENCL)
+if (FL_USE_CPU)
   find_package(DNNL 2.0 CONFIG REQUIRED)
 
   set(
@@ -96,19 +96,19 @@ endif ()
 # OpenCL
 # TODO(jacobkahn): enable, with dependencies, when needed
 if (FL_USE_OPENCL)
-  # set(
-  #   AUTOGRAD_OPENCL_SOURCES
-  #   ${CMAKE_CURRENT_LIST_DIR}/backend/opencl/Conv2D.cpp
-  #   ${CMAKE_CURRENT_LIST_DIR}/backend/opencl/Pool2D.cpp
-  #   ${CMAKE_CURRENT_LIST_DIR}/backend/opencl/RNN.cpp
-  #   ${CMAKE_CURRENT_LIST_DIR}/backend/generic/BatchNorm.cpp # generic
-  #   )
+  set(
+    AUTOGRAD_OPENCL_SOURCES
+    ${CMAKE_CURRENT_LIST_DIR}/backend/opencl/Conv2D.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/backend/opencl/Pool2D.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/backend/opencl/RNN.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/backend/generic/BatchNorm.cpp # generic
+    )
 
-  # target_sources(
-  #   flashlight
-  #   PRIVATE
-  #   ${AUTOGRAD_OPENCL_SOURCES}
-  #   )
+  target_sources(
+    flashlight
+    PRIVATE
+    ${AUTOGRAD_OPENCL_SOURCES}
+    )
 
   target_link_libraries(
     flashlight

--- a/flashlight/fl/autograd/CMakeLists.txt
+++ b/flashlight/fl/autograd/CMakeLists.txt
@@ -16,7 +16,7 @@ target_sources(
 
 # ----------------------------- Autograd Backends -----------------------------
 # CPU
-if (FL_USE_CPU)
+if (FL_USE_CPU OR FL_USE_OPENCL)
   find_package(DNNL 2.0 CONFIG REQUIRED)
 
   set(
@@ -96,19 +96,19 @@ endif ()
 # OpenCL
 # TODO(jacobkahn): enable, with dependencies, when needed
 if (FL_USE_OPENCL)
-  set(
-    AUTOGRAD_OPENCL_SOURCES
-    ${CMAKE_CURRENT_LIST_DIR}/backend/opencl/Conv2D.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/backend/opencl/Pool2D.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/backend/opencl/RNN.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/backend/generic/BatchNorm.cpp # generic
-    )
+  # set(
+  #   AUTOGRAD_OPENCL_SOURCES
+  #   ${CMAKE_CURRENT_LIST_DIR}/backend/opencl/Conv2D.cpp
+  #   ${CMAKE_CURRENT_LIST_DIR}/backend/opencl/Pool2D.cpp
+  #   ${CMAKE_CURRENT_LIST_DIR}/backend/opencl/RNN.cpp
+  #   ${CMAKE_CURRENT_LIST_DIR}/backend/generic/BatchNorm.cpp # generic
+  #   )
 
-  target_sources(
-    flashlight
-    PRIVATE
-    ${AUTOGRAD_OPENCL_SOURCES}
-    )
+  # target_sources(
+  #   flashlight
+  #   PRIVATE
+  #   ${AUTOGRAD_OPENCL_SOURCES}
+  #   )
 
   target_link_libraries(
     flashlight

--- a/flashlight/fl/autograd/backend/cpu/BatchNorm.cpp
+++ b/flashlight/fl/autograd/backend/cpu/BatchNorm.cpp
@@ -15,7 +15,6 @@
 #include "flashlight/fl/autograd/Functions.h"
 #include "flashlight/fl/autograd/Variable.h"
 #include "flashlight/fl/autograd/backend/cpu/DnnlUtils.h"
-#include "flashlight/fl/common/DevicePtr.h"
 
 namespace fl {
 

--- a/flashlight/fl/autograd/backend/cpu/Conv2D.cpp
+++ b/flashlight/fl/autograd/backend/cpu/Conv2D.cpp
@@ -16,7 +16,6 @@
 #include "flashlight/fl/autograd/Functions.h"
 #include "flashlight/fl/autograd/Variable.h"
 #include "flashlight/fl/autograd/backend/cpu/DnnlUtils.h"
-#include "flashlight/fl/common/DevicePtr.h"
 
 using namespace dnnl;
 
@@ -105,18 +104,18 @@ Variable conv2d(
 
   /********************************* Forward *******************************/
   // Create memory dims
-  memory::dims mInputDims =
-      detail::convertAfToDnnlDims({input.dims(kIOBatchSizeIdx),
-                                   input.dims(kIOChannelSizeIdx),
-                                   input.dims(kHIdx),
-                                   input.dims(kWIdx)});
+  memory::dims mInputDims = detail::convertAfToDnnlDims(
+      {input.dims(kIOBatchSizeIdx),
+       input.dims(kIOChannelSizeIdx),
+       input.dims(kHIdx),
+       input.dims(kWIdx)});
   memory::dims mWeightDims;
   if (groups == 1) {
-    mWeightDims =
-        detail::convertAfToDnnlDims({weights.dims(kWeightOutputChannelSizeIdx),
-                                     input.dims(kIOChannelSizeIdx),
-                                     weights.dims(kHIdx),
-                                     weights.dims(kWIdx)});
+    mWeightDims = detail::convertAfToDnnlDims(
+        {weights.dims(kWeightOutputChannelSizeIdx),
+         input.dims(kIOChannelSizeIdx),
+         weights.dims(kHIdx),
+         weights.dims(kWIdx)});
   } else {
     mWeightDims = detail::convertAfToDnnlDims(
         {groups,
@@ -125,11 +124,11 @@ Variable conv2d(
          weights.dims(kHIdx),
          weights.dims(kWIdx)});
   }
-  memory::dims mOutputDims =
-      detail::convertAfToDnnlDims({input.dims(kIOBatchSizeIdx),
-                                   weights.dims(kWeightOutputChannelSizeIdx),
-                                   output.dims(kHIdx),
-                                   output.dims(kWIdx)});
+  memory::dims mOutputDims = detail::convertAfToDnnlDims(
+      {input.dims(kIOBatchSizeIdx),
+       weights.dims(kWeightOutputChannelSizeIdx),
+       output.dims(kHIdx),
+       output.dims(kWIdx)});
   memory::dims mBiasDims =
       detail::convertAfToDnnlDims({weights.dims(kWeightOutputChannelSizeIdx)});
   memory::dims mStrideDims = {sy, sx};
@@ -183,18 +182,12 @@ Variable conv2d(
       *fwdDescriptor, dnnlEngine);
 
   // Create memory
-  DevicePtr inputRaw(input.array());
-  auto inputMemoryInit =
-      memory({{{mInputDims}, dataType, formatNCHW}, dnnlEngine});
-  inputMemoryInit.set_data_handle(inputRaw.get());
-  DevicePtr outputRaw(output);
-  auto outputMemoryInit =
-      memory({{{mOutputDims}, dataType, formatNCHW}, dnnlEngine});
-  outputMemoryInit.set_data_handle(outputRaw.get());
-  DevicePtr weightsRaw(weights.array());
-  auto weightsMemoryInit =
-      memory({{{mWeightDims}, dataType, formatWeight}, dnnlEngine});
-  weightsMemoryInit.set_data_handle(weightsRaw.get());
+  const detail::DnnlMemoryWrapper inputMemInit(
+      input.array(), {mInputDims}, formatNCHW);
+  const detail::DnnlMemoryWrapper outputMemInit(
+      output, {mOutputDims}, formatNCHW);
+  const detail::DnnlMemoryWrapper weightsMem(
+      weights.array(), {mWeightDims}, formatWeight);
 
   // Network for execution
   std::vector<primitive> network;
@@ -208,22 +201,21 @@ Variable conv2d(
   auto weightsDesc = fwdPrimDesc->weights_desc();
   auto outputDesc = fwdPrimDesc->dst_desc();
   // Input
-  auto inputMemory =
-      detail::dnnlAlignOrdering(network, fwdArgs, inputMemoryInit, inputDesc);
+  auto inputMemory = detail::dnnlAlignOrdering(
+      network, fwdArgs, inputMemInit.getMemory(), inputDesc);
   auto weightsMemory = detail::dnnlAlignOrdering(
-      network, fwdArgs, weightsMemoryInit, weightsDesc);
+      network, fwdArgs, weightsMem.getMemory(), weightsDesc);
   // Output - adds a reorder after the conv if needed
-  auto outputMemory = outputMemoryInit;
-  if (outputMemoryInit.get_desc() != outputDesc) {
+  auto outputMemory = outputMemInit.getMemory();
+  if (outputMemInit.getMemory().get_desc() != outputDesc) {
     outputMemory = memory(outputDesc, dnnlEngine);
   }
 
   // Create convolution
   std::shared_ptr<convolution_forward> conv;
-  DevicePtr biasRaw(bias.array());
   auto formatBias = memory::format_tag::x;
-  auto biasMemory = memory({{{mBiasDims}, dataType, formatBias}, dnnlEngine});
-  biasMemory.set_data_handle(biasRaw.get());
+  const detail::DnnlMemoryWrapper biasMemory(
+      bias.array(), mBiasDims, formatBias);
   if (hasBias) {
     conv = std::make_shared<convolution_forward>(*fwdPrimDesc);
   } else {
@@ -237,15 +229,16 @@ Variable conv2d(
       {DNNL_ARG_WEIGHTS, weightsMemory},
       {DNNL_ARG_DST, outputMemory}};
   if (hasBias) {
-    convFwdArgs[DNNL_ARG_BIAS] = biasMemory;
+    convFwdArgs[DNNL_ARG_BIAS] = biasMemory.getMemory();
   }
   fwdArgs.push_back(convFwdArgs);
 
   // Add output reordering if needed
-  if (outputMemory != outputMemoryInit) {
-    network.push_back(dnnl::reorder(outputMemory, outputMemoryInit));
+  if (outputMemory != outputMemInit.getMemory()) {
+    network.push_back(dnnl::reorder(outputMemory, outputMemInit.getMemory()));
     fwdArgs.push_back(
-        {{DNNL_ARG_FROM, outputMemory}, {DNNL_ARG_TO, outputMemoryInit}});
+        {{DNNL_ARG_FROM, outputMemory},
+         {DNNL_ARG_TO, outputMemInit.getMemory()}});
   }
 
   // Run
@@ -299,18 +292,12 @@ Variable conv2d(
               *bwdDataDesc, dnnlEngineBwd, *fwdPrimDesc);
 
       // Create memory
-      DevicePtr gradOutputRaw(grad_output.array());
-      auto gradOutputMemoryInit =
-          memory({{{mOutputDims}, dataType, formatNCHW}, dnnlEngineBwd});
-      gradOutputMemoryInit.set_data_handle(gradOutputRaw.get());
-      DevicePtr gradInputRaw(gradInput.array());
-      auto gradInputMemoryInit =
-          memory({{{mInputDims}, dataType, formatNCHW}, dnnlEngineBwd});
-      gradInputMemoryInit.set_data_handle(gradInputRaw.get());
-      DevicePtr weightRaw(weightRef.array());
-      auto weightsMemoryInitBackwards =
-          memory({{{mWeightDims}, dataType, formatWeight}, dnnlEngineBwd});
-      weightsMemoryInitBackwards.set_data_handle(weightRaw.get());
+      const detail::DnnlMemoryWrapper gradOutputMemInit(
+          grad_output.array(), mOutputDims, formatNCHW);
+      const detail::DnnlMemoryWrapper gradInputMemInit(
+          gradInput.array(), mInputDims, formatNCHW);
+      const detail::DnnlMemoryWrapper weightsMemInitBwd(
+          weightRef.array(), mWeightDims, formatWeight);
 
       std::vector<primitive> networkBackwards;
       std::vector<std::unordered_map<int, dnnl::memory>> bwdDataArgs;
@@ -320,15 +307,18 @@ Variable conv2d(
       auto weightsDesc = bwdDataPrimDesc->weights_desc();
       auto gradInputDesc = bwdDataPrimDesc->diff_src_desc();
       auto gradOutputMemory = detail::dnnlAlignOrdering(
-          networkBackwards, bwdDataArgs, gradOutputMemoryInit, gradOutputDesc);
+          networkBackwards,
+          bwdDataArgs,
+          gradOutputMemInit.getMemory(),
+          gradOutputDesc);
       auto weightsMemoryBackwards = detail::dnnlAlignOrdering(
           networkBackwards,
           bwdDataArgs,
-          weightsMemoryInitBackwards,
+          weightsMemInitBwd.getMemory(),
           weightsDesc);
-      auto gradInputMemory = gradInputMemoryInit;
+      auto gradInputMemory = gradInputMemInit.getMemory();
       // Don't reorder the gradient until after the conv
-      if (gradInputMemoryInit.get_desc() != gradInputDesc) {
+      if (gradInputMemInit.getMemory().get_desc() != gradInputDesc) {
         gradInputMemory = memory(gradInputDesc, dnnlEngineBwd);
       }
 
@@ -336,17 +326,19 @@ Variable conv2d(
       auto convBwdData =
           std::make_shared<convolution_backward_data>(*bwdDataPrimDesc);
 
-      bwdDataArgs.push_back({{DNNL_ARG_DIFF_SRC, gradInputMemory},
-                             {DNNL_ARG_WEIGHTS, weightsMemoryBackwards},
-                             {DNNL_ARG_DIFF_DST, gradOutputMemory}});
+      bwdDataArgs.push_back(
+          {{DNNL_ARG_DIFF_SRC, gradInputMemory},
+           {DNNL_ARG_WEIGHTS, weightsMemoryBackwards},
+           {DNNL_ARG_DIFF_DST, gradOutputMemory}});
       networkBackwards.push_back(*convBwdData);
 
       // Reorder the output (which is gradInput here) if necessary
-      if (gradInputMemory != gradInputMemoryInit) {
+      if (gradInputMemory != gradInputMemInit.getMemory()) {
         networkBackwards.push_back(
-            dnnl::reorder(gradInputMemory, gradInputMemoryInit));
-        bwdDataArgs.push_back({{DNNL_ARG_FROM, gradInputMemory},
-                               {DNNL_ARG_TO, gradInputMemoryInit}});
+            dnnl::reorder(gradInputMemory, gradInputMemInit.getMemory()));
+        bwdDataArgs.push_back(
+            {{DNNL_ARG_FROM, gradInputMemory},
+             {DNNL_ARG_TO, gradInputMemInit.getMemory()}});
       }
 
       detail::executeNetwork(networkBackwards, bwdDataArgs);
@@ -396,18 +388,12 @@ Variable conv2d(
               *bwdWeightDesc, dnnlEngineBwd, *fwdPrimDesc);
 
       // Create memory
-      DevicePtr inputRawBackwards(inputRef.array());
-      auto inputMemoryInitBackwards =
-          memory({{{mInputDims}, dataType, formatNCHW}, dnnlEngineBwd});
-      inputMemoryInitBackwards.set_data_handle(inputRawBackwards.get());
-      DevicePtr gradOutputRaw(grad_output.array());
-      auto gradOutputMemoryInit =
-          memory({{{mOutputDims}, dataType, formatNCHW}, dnnlEngineBwd});
-      gradOutputMemoryInit.set_data_handle(gradOutputRaw.get());
-      DevicePtr gradWeightsRaw(gradWeights.array());
-      auto gradWeightsMemoryInit =
-          memory({{{mWeightDims}, dataType, formatWeight}, dnnlEngineBwd});
-      gradWeightsMemoryInit.set_data_handle(gradWeightsRaw.get());
+      const detail::DnnlMemoryWrapper inputRawMemInitBwd(
+          inputRef.array(), mInputDims, formatNCHW);
+      const detail::DnnlMemoryWrapper gradOutputMemInit(
+          grad_output.array(), mOutputDims, formatNCHW);
+      const detail::DnnlMemoryWrapper gradWeightsMemInit(
+          gradWeights.array(), mWeightDims, formatWeight);
 
       std::vector<primitive> networkBackwards;
       std::vector<std::unordered_map<int, dnnl::memory>> bwdWeightsArgs;
@@ -419,16 +405,16 @@ Variable conv2d(
       auto inputMemoryBackwards = detail::dnnlAlignOrdering(
           networkBackwards,
           bwdWeightsArgs,
-          inputMemoryInitBackwards,
+          inputRawMemInitBwd.getMemory(),
           inputDesc);
       auto gradOutputMemory = detail::dnnlAlignOrdering(
           networkBackwards,
           bwdWeightsArgs,
-          gradOutputMemoryInit,
+          gradOutputMemInit.getMemory(),
           gradOutputDesc);
       // Don't reorder the grads until after the conv bwd
-      auto gradWeightsMemory = gradWeightsMemoryInit;
-      if (gradWeightsMemoryInit.get_desc() != gradWeightsDesc) {
+      auto gradWeightsMemory = gradWeightsMemInit.getMemory();
+      if (gradWeightsMemInit.getMemory().get_desc() != gradWeightsDesc) {
         gradWeightsMemory = memory(gradWeightsDesc, dnnlEngineBwd);
       }
 
@@ -438,15 +424,18 @@ Variable conv2d(
           {DNNL_ARG_SRC, inputMemoryBackwards},
           {DNNL_ARG_DIFF_WEIGHTS, gradWeightsMemory},
           {DNNL_ARG_DIFF_DST, gradOutputMemory}};
-      DevicePtr biasRawBackwards(gradBias.array());
+
       auto formatBias = memory::format_tag::x;
-      auto gradBiasMemory =
-          memory({{{mBiasDims}, dataType, formatBias}, dnnlEngineBwd});
-      gradBiasMemory.set_data_handle(biasRawBackwards.get());
+      const detail::DnnlMemoryWrapper gradBiasMem(
+          gradBias.array(), mBiasDims, formatBias);
+
+      // auto gradBiasMemory =
+      //     memory({{{mBiasDims}, dataType, formatBias}, dnnlEngineBwd});
+      // gradBiasMemory.set_data_handle(biasRawBackwards.get());
       if (hasBias) {
         bwdWeights =
             std::make_shared<convolution_backward_weights>(*bwdWeightPrimDesc);
-        bwdConvWeightsArgs[DNNL_ARG_DIFF_BIAS] = gradBiasMemory;
+        bwdConvWeightsArgs[DNNL_ARG_DIFF_BIAS] = gradBiasMem.getMemory();
       } else {
         bwdWeights =
             std::make_shared<convolution_backward_weights>(*bwdWeightPrimDesc);
@@ -455,11 +444,12 @@ Variable conv2d(
       bwdWeightsArgs.push_back(bwdConvWeightsArgs);
 
       // Reorder weight gradients if necessary
-      if (gradWeightsMemory != gradWeightsMemoryInit) {
+      if (gradWeightsMemory != gradWeightsMemInit.getMemory()) {
         networkBackwards.push_back(
-            dnnl::reorder(gradWeightsMemory, gradWeightsMemoryInit));
-        bwdWeightsArgs.push_back({{DNNL_ARG_FROM, gradWeightsMemory},
-                                  {DNNL_ARG_TO, gradWeightsMemoryInit}});
+            dnnl::reorder(gradWeightsMemory, gradWeightsMemInit.getMemory()));
+        bwdWeightsArgs.push_back(
+            {{DNNL_ARG_FROM, gradWeightsMemory},
+             {DNNL_ARG_TO, gradWeightsMemInit.getMemory()}});
       }
 
       detail::executeNetwork(networkBackwards, bwdWeightsArgs);

--- a/flashlight/fl/autograd/backend/cpu/Conv2D.cpp
+++ b/flashlight/fl/autograd/backend/cpu/Conv2D.cpp
@@ -428,10 +428,6 @@ Variable conv2d(
       auto formatBias = memory::format_tag::x;
       const detail::DnnlMemoryWrapper gradBiasMem(
           gradBias.array(), mBiasDims, formatBias);
-
-      // auto gradBiasMemory =
-      //     memory({{{mBiasDims}, dataType, formatBias}, dnnlEngineBwd});
-      // gradBiasMemory.set_data_handle(biasRawBackwards.get());
       if (hasBias) {
         bwdWeights =
             std::make_shared<convolution_backward_weights>(*bwdWeightPrimDesc);

--- a/flashlight/fl/autograd/backend/cpu/DnnlUtils.cpp
+++ b/flashlight/fl/autograd/backend/cpu/DnnlUtils.cpp
@@ -69,13 +69,17 @@ DnnlMemoryWrapper::DnnlMemoryWrapper(
     const af::array& array,
     dnnl::memory::dims dims,
     dnnl::memory::format_tag format) {
+#ifdef FL_USE_OPENCL
+  devicePtr_ = fl::DevicePtrOpenCl(array);
+  cl_mem* buffer = devicePtr_.getAs<cl_mem>();
+#else
   devicePtr_ = fl::DevicePtr(array);
+  void* buffer = devicePtr_.get();
+#endif
   descriptor_ =
       dnnl::memory::desc({dims}, detail::dnnlMapToType(array.type()), format);
   memory_ = dnnl::memory(
-      descriptor_,
-      detail::DnnlEngine::getInstance().getEngine(),
-      devicePtr_.get());
+      descriptor_, detail::DnnlEngine::getInstance().getEngine(), buffer);
 }
 
 DnnlMemoryWrapper& DnnlMemoryWrapper::operator=(DnnlMemoryWrapper&& other) {

--- a/flashlight/fl/autograd/backend/cpu/DnnlUtils.cpp
+++ b/flashlight/fl/autograd/backend/cpu/DnnlUtils.cpp
@@ -71,7 +71,7 @@ DnnlMemoryWrapper::DnnlMemoryWrapper(
     dnnl::memory::format_tag format) {
 #ifdef FL_USE_OPENCL
   devicePtr_ = fl::DevicePtrOpenCl(array);
-  cl_mem* buffer = devicePtr_.getAs<cl_mem>();
+  cl_mem* buffer = devicePtr_.getAsClMem();
 #else
   devicePtr_ = fl::DevicePtr(array);
   void* buffer = devicePtr_.get();

--- a/flashlight/fl/autograd/backend/cpu/DnnlUtils.cpp
+++ b/flashlight/fl/autograd/backend/cpu/DnnlUtils.cpp
@@ -93,25 +93,6 @@ dnnl::memory::desc DnnlMemoryWrapper::getDescriptor() const {
   return descriptor_;
 }
 
-dnnl::memory afToDnnlMemory(
-    const af::array& array,
-    const fl::DevicePtr& dPtr,
-    dnnl::memory::dims dims,
-    dnnl::memory::format_tag format) {
-  auto inputMemDesc =
-      dnnl::memory::desc(dims, detail::dnnlMapToType(array.type()), format);
-  return dnnl::memory(
-      inputMemDesc, detail::DnnlEngine::getInstance().getEngine(), dPtr.get());
-}
-
-dnnl::memory afToDnnlMemory(
-    const af::array& array,
-    const fl::DevicePtr& dPtr,
-    dnnl::memory::format_tag format) {
-  return afToDnnlMemory(
-      array, dPtr, convertAfDim4ToDnnlDims(array.dims()), format);
-}
-
 dnnl::memory dnnlAlignOrdering(
     std::vector<dnnl::primitive>& net,
     std::vector<std::unordered_map<int, dnnl::memory>>& netArgs,

--- a/flashlight/fl/autograd/backend/cpu/DnnlUtils.h
+++ b/flashlight/fl/autograd/backend/cpu/DnnlUtils.h
@@ -63,12 +63,17 @@ class DnnlEngine {
 dnnl::memory::dims convertAfToDnnlDims(const std::vector<dim_t>& dims);
 dnnl::memory::dims convertAfDim4ToDnnlDims(const af::dim4& afDims);
 
+/**
+ * A light wrapper around dnnl::memory that manages underlying memory lifetime
+ * in accordance with fl::DevicePtr.
+ */
 class DnnlMemoryWrapper {
  public:
   DnnlMemoryWrapper(
       const af::array& array,
       dnnl::memory::dims dims,
       dnnl::memory::format_tag format);
+  DnnlMemoryWrapper() = default;
 
   DnnlMemoryWrapper& operator=(DnnlMemoryWrapper&& other);
 
@@ -81,19 +86,6 @@ class DnnlMemoryWrapper {
   dnnl::memory memory_;
   fl::DevicePtr devicePtr_;
 };
-
-/**
- * Converts an ArrayFire array to a dnnl::memory struct.
- */
-dnnl::memory afToDnnlMemory(
-    const af::array& array,
-    const fl::DevicePtr& dPtr,
-    dnnl::memory::dims dims,
-    dnnl::memory::format_tag format);
-dnnl::memory afToDnnlMemory(
-    const af::array& array,
-    const fl::DevicePtr& dPtr,
-    dnnl::memory::format_tag format);
 
 /**
  * Given some an dnnl network (a ``std::vector<dnnl::primitive>``), a

--- a/flashlight/fl/autograd/backend/cpu/DnnlUtils.h
+++ b/flashlight/fl/autograd/backend/cpu/DnnlUtils.h
@@ -13,6 +13,7 @@
 #include <dnnl.hpp>
 
 #include "flashlight/fl/common/Defines.h"
+#include "flashlight/fl/common/DevicePtr.h"
 
 namespace fl {
 namespace detail {
@@ -60,6 +61,39 @@ class DnnlEngine {
  * for dnnl::memory::dims.
  */
 dnnl::memory::dims convertAfToDnnlDims(const std::vector<dim_t>& dims);
+dnnl::memory::dims convertAfDim4ToDnnlDims(const af::dim4& afDims);
+
+class DnnlMemoryWrapper {
+ public:
+  DnnlMemoryWrapper(
+      const af::array& array,
+      dnnl::memory::dims dims,
+      dnnl::memory::format_tag format);
+
+  DnnlMemoryWrapper& operator=(DnnlMemoryWrapper&& other);
+
+  dnnl::memory getMemory() const;
+
+  dnnl::memory::desc getDescriptor() const;
+
+ private:
+  dnnl::memory::desc descriptor_;
+  dnnl::memory memory_;
+  fl::DevicePtr devicePtr_;
+};
+
+/**
+ * Converts an ArrayFire array to a dnnl::memory struct.
+ */
+dnnl::memory afToDnnlMemory(
+    const af::array& array,
+    const fl::DevicePtr& dPtr,
+    dnnl::memory::dims dims,
+    dnnl::memory::format_tag format);
+dnnl::memory afToDnnlMemory(
+    const af::array& array,
+    const fl::DevicePtr& dPtr,
+    dnnl::memory::format_tag format);
 
 /**
  * Given some an dnnl network (a ``std::vector<dnnl::primitive>``), a
@@ -80,9 +114,9 @@ dnnl::memory dnnlAlignOrdering(
  * Executes a sequence of DNNL primitives in the default execution stream with
  * the default execution engine.
  *
- * For each primitive, passes the corresponding arguments map for that index to
- * the execution stream. The number of primitives and the number of arguments
- * must be equal, else throws.
+ * For each primitive, passes the corresponding arguments map for that index
+ * to the execution stream. The number of primitives and the number of
+ * arguments must be equal, else throws.
  *
  * Blocks calling thread until the enqueued work has been completed.
  */

--- a/flashlight/fl/autograd/backend/cpu/DnnlUtils.h
+++ b/flashlight/fl/autograd/backend/cpu/DnnlUtils.h
@@ -22,7 +22,7 @@ namespace detail {
  */
 class DnnlStream {
  public:
-  DnnlStream(dnnl::engine engine) : stream_(engine) {}
+  DnnlStream(dnnl::engine engine);
   ~DnnlStream() = default;
 
   /// Prohibit assignment
@@ -41,7 +41,7 @@ class DnnlStream {
  */
 class DnnlEngine {
  public:
-  DnnlEngine() : engine_(dnnl::engine::kind::cpu, 0) {}
+  DnnlEngine();
   ~DnnlEngine() = default;
 
   /// Prohibit assignment

--- a/flashlight/fl/common/CMakeLists.txt
+++ b/flashlight/fl/common/CMakeLists.txt
@@ -16,6 +16,9 @@ set(
 if(FL_USE_CUDA)
   set(COMMON_SRCS ${COMMON_SRCS} ${CMAKE_CURRENT_LIST_DIR}/CudaUtils.cpp)
 endif()
+if(FL_USE_OPENCL)
+  set(COMMON_SRCS ${COMMON_SRCS} ${CMAKE_CURRENT_LIST_DIR}/OpenClUtils.cpp)
+endif()
 
 target_sources(
   flashlight
@@ -37,4 +40,7 @@ target_link_libraries(
 if (FL_USE_CUDA)
   target_link_libraries(flashlight PUBLIC ${CUDA_LIBRARIES})
   target_include_directories(flashlight PUBLIC ${CUDA_INCLUDE_DIRS})
+endif()
+if (FL_USE_OPENCL)
+  target_link_libraries(flashlight PUBLIC OpenCL::OpenCL)
 endif()

--- a/flashlight/fl/common/DevicePtr.h
+++ b/flashlight/fl/common/DevicePtr.h
@@ -62,8 +62,15 @@ class DevicePtr {
 
   void* get() const;
 
- private:
+  template <typename T>
+  T* getAs() const {
+    return reinterpret_cast<T*>(ptr_);
+  }
+
+ protected:
   af_array arr_;
+
+ private:
   void* ptr_;
 };
 

--- a/flashlight/fl/common/OpenClUtils.cpp
+++ b/flashlight/fl/common/OpenClUtils.cpp
@@ -11,11 +11,11 @@ namespace fl {
 namespace ocl {
 
 cl_context getContext() {
-  return afcl::getContext(/*retain=*/true);
+  return afcl::getContext();
 }
 
 cl_command_queue getQueue() {
-  return afcl::getQueue(/*retain=*/true);
+  return afcl::getQueue();
 }
 
 cl_device_id getDeviceId() {

--- a/flashlight/fl/common/OpenClUtils.cpp
+++ b/flashlight/fl/common/OpenClUtils.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "flashlight/fl/common/OpenClUtils.h"
+
+namespace fl {
+namespace ocl {
+
+cl_context getContext() {
+  return afcl::getContext(/*retain=*/true);
+}
+
+cl_command_queue getQueue() {
+  return afcl::getQueue(/*retain=*/true);
+}
+
+cl_device_id getDeviceId() {
+  return afcl::getDeviceId();
+}
+
+} // namespace ocl
+} // namespace fl

--- a/flashlight/fl/common/OpenClUtils.h
+++ b/flashlight/fl/common/OpenClUtils.h
@@ -13,13 +13,48 @@
 #include <CL/cl.h>
 #include <af/opencl.h>
 
+#include "flashlight/fl/common/DevicePtr.h"
+
 namespace fl {
 namespace ocl {
 
+/**
+ * A device pointer subclass for the OpenCL backend to handle cl_mem that
+ * follows retain/release OpenCL semantics when using OpenCL objects during
+ * construction.
+ *
+ * Handles the cl_mem provided by ArrayFire that must be explicitly deleted.
+ */
+class DevicePtrOpenCl : public fl::DevicePtr {
+  DevicePtrOpenCl(const af::array& in) : DevicePtr(in) {
+    clMemBuf_ = in.device<cl_mem>();
+  }
+
+  ~DevicePtrOpenCl() {
+    delete clMemBuf_;
+  }
+
+  cl_mem* getAs() const {
+    return clMemBuf_;
+  }
+
+ private:
+  cl_mem* clMemBuf_;
+};
+
+/**
+ * Gets the Arrayfire OpenCL context for the current device
+ */
 cl_context getContext();
 
+/**
+ * Gets the Arrayfire OpenCL queue for the current device.
+ */
 cl_command_queue getQueue();
 
+/**
+ * Gets the Arrayfire OpenCL device ID for the current device.
+ */
 cl_device_id getDeviceId();
 
 } // namespace ocl

--- a/flashlight/fl/common/OpenClUtils.h
+++ b/flashlight/fl/common/OpenClUtils.h
@@ -34,7 +34,7 @@ class DevicePtrOpenCl : public fl::DevicePtr {
     delete clMemBuf_;
   }
 
-  cl_mem* getAs() const {
+  cl_mem* getAsClMem() const {
     return clMemBuf_;
   }
 

--- a/flashlight/fl/common/OpenClUtils.h
+++ b/flashlight/fl/common/OpenClUtils.h
@@ -7,8 +7,10 @@
 
 #pragma once
 
+#ifndef CL_TARGET_OPENCL_VERSION
 // Version 2.2
 #define CL_TARGET_OPENCL_VERSION 220
+#endif
 
 #include <CL/cl.h>
 #include <af/opencl.h>
@@ -26,7 +28,8 @@ namespace ocl {
  * Handles the cl_mem provided by ArrayFire that must be explicitly deleted.
  */
 class DevicePtrOpenCl : public fl::DevicePtr {
-  DevicePtrOpenCl(const af::array& in) : DevicePtr(in) {
+ public:
+  DevicePtrOpenCl(const af::array& in) : fl::DevicePtr(in) {
     clMemBuf_ = in.device<cl_mem>();
   }
 

--- a/flashlight/fl/common/OpenClUtils.h
+++ b/flashlight/fl/common/OpenClUtils.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// Version 2.2
+#define CL_TARGET_OPENCL_VERSION 220
+
+#include <CL/cl.h>
+#include <af/opencl.h>
+
+namespace fl {
+namespace ocl {
+
+cl_context getContext();
+
+cl_command_queue getQueue();
+
+cl_device_id getDeviceId();
+
+} // namespace ocl
+} // namespace fl


### PR DESCRIPTION
Wrapping up oneDNN with OpenCL GPU things. Was sitting on this code for a while but didn't send it in; fixed a few things up.

This makes the tweaks needed to add OpenCL GPU support to OneDNN. Also creates some DNNL memory abstractions which significantly clean up primitive code.

- **Add `DevicePtrOpenCl`** — since the `cl_mem*` returned by `af::array::device<cl_mem>()` needs to be explicitly deleted, creates some additional RAII things on top of it.
- **Adds `OpenClUtils`** (@avidov will likely add this as well — I can easily rebase on top of that one) which exposes general getters for ArrayFire OpenCL computation stream components (command queue, context, etc.)
- Integrates the above into the DNNL engine and compute stream.
- **Adds `DnnlMemoryWrapper`** to wrap `af::array`s in `dnnl::memory` structs with a lot more ease and some RAII-ness that avoids the use of `DevicePtr` and facilitates combining the logic to conditionally grab `cl_mem` buffers if the OpenCL backend is active.

### Test Plan
Changes to CPU backend tested locally with oneDNN 2.0 and AF 3.7.3, all passing.

OpenCL components tested on a friend's personal machine (no joke) with an AMD Radeon device and OpenCL 2.2 - trained Mnist/some small other models to convergence with oneDNN primitives. All tests pass with the OpenCL backend as well.

More work will need to be done to test this and fix other bugs once we have access to the needed machines.