### PR TITLE
Added variables to build bindings when using VCPKG

### DIFF
--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -55,6 +55,12 @@ cd bindings/python
 python3 setup.py install
 ```
 
+In case you used VCPKG to build flashlight, you also need to declare these variables before running setup.py:
+```
+export CMAKE_LIBRARY_PATH=[vcpkg_installation_location]/installed/x64-linux/lib
+export CMAKE_INCLUDE_PATH=[vcpkg_installation_location]/installed/x64-linux/include
+```
+
 with `pip` either install from `pypi` (coming soon)
 ```
 pip3 install pyflashlight


### PR DESCRIPTION
**Original Issue**: #437 


### Summary
Missing documentation for building python bindings when using VCPKG to build flashlight

### Test Plan (required)
None, documentation change only
