### PR TITLE
move the fl_asr_sfx_apply executable to bin/asr

### DIFF
--- a/flashlight/app/asr/augmentation/CMakeLists.txt
+++ b/flashlight/app/asr/augmentation/CMakeLists.txt
@@ -17,6 +17,11 @@ add_executable(
   ${CMAKE_CURRENT_LIST_DIR}/SoundEffectApply.cpp
   )
 
+set_executable_output_directory(
+  fl_asr_sfx_apply 
+  "${FL_BUILD_BINARY_OUTPUT_DIR}/asr"
+  )
+
 target_link_libraries(
   fl_asr_sfx_apply
   flashlight-app-asr


### PR DESCRIPTION

### Summary
Move fl_asr_sfx_apply  executable to the same place as fl_asr_train etc.

### Test Plan (required)
[steps by which you tested that your fix resolves the issue. These might include specific commands and configurations]

    (base) avidov@devfair0325:~/fbcode/deeplearning/projects/flashlight/build$ tree bin
    bin
    ├── asr
    │   ├── fl_asr_align
    │   ├── fl_asr_decode
    │   ├── fl_asr_sfx_apply
    │   ├── fl_asr_test
    │   ├── fl_asr_train
    │   ├── fl_asr_tutorial_finetune_ctc
    │   ├── fl_asr_tutorial_inference_ctc
    │   └── fl_asr_voice_activity_detection_ctc
    ├── imgclass
    │   └── fl_img_imagenet_resnet34
    └── lm
        ├── fl_lm_dictionary_builder
        └── fl_lm_train
