### PR TITLE
Serialize the AMP scale factor

### DIFF
--- a/flashlight/app/asr/Train.cpp
+++ b/flashlight/app/asr/Train.cpp
@@ -150,14 +150,8 @@ int main(int argc, char** argv) {
     } else {
       startUpdate = std::stoi(nbupdates->second);
     }
-    auto scaleFactorI = cfg.find(kScaleFactor);
-    if (scaleFactorI == cfg.end()) {
-      LOG(WARNING) << "Did not find scalefactor, using the flag's value.";
-      scaleFactor =
-          FLAGS_fl_amp_use_mixed_precision ? FLAGS_fl_amp_scale_factor : 1.;
-    } else {
-      scaleFactor = std::stof(scaleFactorI->second);
-    }
+
+    scaleFactor = getScaleFactor(cfg);
   } else if (runStatus == kForkMode) {
     reloadPath = argv[2];
     std::unordered_map<std::string, std::string> cfg;
@@ -174,14 +168,7 @@ int main(int argc, char** argv) {
     parseCmdLineFlagsWrapper(argc, argv);
     runPath = FLAGS_rundir;
 
-    auto scaleFactorI = cfg.find(kScaleFactor);
-    if (scaleFactorI == cfg.end()) {
-      LOG(WARNING) << "Did not find scalefactor, using the flag's value.";
-      scaleFactor =
-          FLAGS_fl_amp_use_mixed_precision ? FLAGS_fl_amp_scale_factor : 1.;
-    } else {
-      scaleFactor = std::stof(scaleFactorI->second);
-    }
+    scaleFactor = getScaleFactor(cfg);
   } else {
     LOG(FATAL) << gflags::ProgramUsage();
   }

--- a/flashlight/app/asr/Train.cpp
+++ b/flashlight/app/asr/Train.cpp
@@ -114,6 +114,7 @@ int main(int argc, char** argv) {
   std::string runStatus = argv[1];
   int64_t startEpoch = 0;
   int64_t startUpdate = 0;
+  double scaleFactor = 1.; // for AMP
   if (argc <= 1) {
     LOG(FATAL) << gflags::ProgramUsage();
   }
@@ -149,6 +150,14 @@ int main(int argc, char** argv) {
     } else {
       startUpdate = std::stoi(nbupdates->second);
     }
+    auto scaleFactorI = cfg.find(kScaleFactor);
+    if (scaleFactorI == cfg.end()) {
+      LOG(WARNING) << "Did not find scalefactor, using the flag's value.";
+      scaleFactor =
+          FLAGS_fl_amp_use_mixed_precision ? FLAGS_fl_amp_scale_factor : 1.;
+    } else {
+      scaleFactor = std::stof(scaleFactorI->second);
+    }
   } else if (runStatus == kForkMode) {
     reloadPath = argv[2];
     std::unordered_map<std::string, std::string> cfg;
@@ -164,6 +173,15 @@ int main(int argc, char** argv) {
 
     parseCmdLineFlagsWrapper(argc, argv);
     runPath = FLAGS_rundir;
+
+    auto scaleFactorI = cfg.find(kScaleFactor);
+    if (scaleFactorI == cfg.end()) {
+      LOG(WARNING) << "Did not find scalefactor, using the flag's value.";
+      scaleFactor =
+          FLAGS_fl_amp_use_mixed_precision ? FLAGS_fl_amp_scale_factor : 1.;
+    } else {
+      scaleFactor = std::stof(scaleFactorI->second);
+    }
   } else {
     LOG(FATAL) << gflags::ProgramUsage();
   }
@@ -460,11 +478,12 @@ int main(int argc, char** argv) {
           usePlugin,
           tokenDict,
           wordDict,
-          DecodeMasterTrainOptions{.repLabel = int32_t(FLAGS_replabel),
-                                   .wordSepIsPartOfToken = FLAGS_usewordpiece,
-                                   .surround = FLAGS_surround,
-                                   .wordSep = FLAGS_wordseparator,
-                                   .targetPadIdx = targetpadVal});
+          DecodeMasterTrainOptions{
+              .repLabel = int32_t(FLAGS_replabel),
+              .wordSepIsPartOfToken = FLAGS_usewordpiece,
+              .surround = FLAGS_surround,
+              .wordSep = FLAGS_wordseparator,
+              .targetPadIdx = targetpadVal});
     } else {
       throw std::runtime_error(
           "Other decoders are not supported yet during training");
@@ -605,31 +624,33 @@ int main(int argc, char** argv) {
       tokenToWord);
 
   /* ===================== Hooks ===================== */
-  auto logStatus =
-      [&logFile, &validTagSets, &plGenerator, isMaster](
-          TrainMeters& mtrs,
-          std::unordered_map<std::string, double>& validWerWithDecoder,
-          int64_t epoch,
-          int64_t nupdates,
-          double lr,
-          double lrcrit) {
-        syncMeter(mtrs);
-        plGenerator.setModelWER(
-            mtrs.valid[validTagSets.front().first].wrdEdit.errorRate()[0]);
+  auto logStatus = [&logFile, &validTagSets, &plGenerator, isMaster](
+                       TrainMeters& mtrs,
+                       std::unordered_map<std::string, double>&
+                           validWerWithDecoder,
+                       int64_t epoch,
+                       int64_t nupdates,
+                       double lr,
+                       double lrcrit,
+                       double scaleFactor) {
+    syncMeter(mtrs);
+    plGenerator.setModelWER(
+        mtrs.valid[validTagSets.front().first].wrdEdit.errorRate()[0]);
 
-        if (isMaster) {
-          auto logMsg = getLogString(
-              mtrs, validWerWithDecoder, epoch, nupdates, lr, lrcrit);
-          FL_LOG_MASTER(INFO) << logMsg;
-          appendToLog(logFile, logMsg);
-        }
-      };
+    if (isMaster) {
+      auto logMsg = getLogString(
+          mtrs, validWerWithDecoder, epoch, nupdates, lr, lrcrit, scaleFactor);
+      FL_LOG_MASTER(INFO) << logMsg;
+      appendToLog(logFile, logMsg);
+    }
+  };
 
-  auto saveModels = [&](int iter, int totalUpdates) {
+  auto saveModels = [&](int iter, int totalUpdates, double scaleFactor) {
     if (isMaster) {
       // Save last epoch
       config[kEpoch] = std::to_string(iter);
       config[kUpdates] = std::to_string(totalUpdates);
+      config[kScaleFactor] = std::to_string(scaleFactor);
 
       std::string filename;
       if (FLAGS_itersave) {
@@ -833,8 +854,9 @@ int main(int argc, char** argv) {
       fl::Variable output;
       if (usePlugin) {
         output = ntwrk
-                     ->forward({fl::input(batch[kInputIdx]),
-                                fl::noGrad(batch[kDurationIdx])})
+                     ->forward(
+                         {fl::input(batch[kInputIdx]),
+                          fl::noGrad(batch[kDurationIdx])})
                      .front();
       } else {
         output = fl::ext::forwardSequentialModuleWithPadMask(
@@ -879,6 +901,7 @@ int main(int argc, char** argv) {
                 &validds,
                 &curEpoch,
                 &startUpdate,
+                &scaleFactor,
                 &plGenerator,
                 &usePlugin,
                 &isSeq2seqCrit,
@@ -942,7 +965,8 @@ int main(int argc, char** argv) {
     auto runValAndSaveModel = [&](int64_t totalEpochs,
                                   int64_t totalUpdates,
                                   double lr,
-                                  double lrcrit) {
+                                  double lrcrit,
+                                  double saveScaleFactor) {
       meters.runtime.stop();
       meters.timer.stop();
       meters.sampletimer.stop();
@@ -963,13 +987,19 @@ int main(int argc, char** argv) {
       // print status
       try {
         logStatus(
-            meters, validWerWithDecoder, totalEpochs, totalUpdates, lr, lrcrit);
+            meters,
+            validWerWithDecoder,
+            totalEpochs,
+            totalUpdates,
+            lr,
+            lrcrit,
+            saveScaleFactor);
       } catch (const std::exception& ex) {
         LOG(ERROR) << "Error while writing logs: " << ex.what();
       }
       // save last and best models
       try {
-        saveModels(totalEpochs, totalUpdates);
+        saveModels(totalEpochs, totalUpdates, saveScaleFactor);
       } catch (const std::exception& ex) {
         LOG(FATAL) << "Error while saving models: " << ex.what();
       }
@@ -980,8 +1010,6 @@ int main(int argc, char** argv) {
     };
 
     int64_t curBatch = startUpdate;
-    double scaleFactor =
-        FLAGS_fl_amp_use_mixed_precision ? FLAGS_fl_amp_scale_factor : 1.;
     unsigned int kScaleFactorUpdateInterval =
         FLAGS_fl_amp_scale_factor_update_interval;
     unsigned int kMaxScaleFactor = FLAGS_fl_amp_max_scale_factor;
@@ -1191,7 +1219,11 @@ int main(int argc, char** argv) {
 
         if (FLAGS_reportiters > 0 && curBatch % FLAGS_reportiters == 0) {
           runValAndSaveModel(
-              curEpoch, curBatch, netopt->getLr(), critopt->getLr());
+              curEpoch,
+              curBatch,
+              netopt->getLr(),
+              critopt->getLr(),
+              scaleFactor);
           resetTimeStatMeters();
           ntwrk->train();
           crit->train();
@@ -1206,7 +1238,7 @@ int main(int argc, char** argv) {
       af::sync();
       if (FLAGS_reportiters == 0) {
         runValAndSaveModel(
-            curEpoch, curBatch, netopt->getLr(), critopt->getLr());
+            curEpoch, curBatch, netopt->getLr(), critopt->getLr(), scaleFactor);
       }
 
       // Try regenerate PL

--- a/flashlight/app/asr/common/Defines.h
+++ b/flashlight/app/asr/common/Defines.h
@@ -41,6 +41,7 @@ constexpr const char* kRunPath = "runPath";
 constexpr const char* kProgramName = "programname";
 constexpr const char* kEpoch = "epoch";
 constexpr const char* kUpdates = "updates";
+constexpr const char* kScaleFactor = "scalefactor";
 constexpr const char* kSGDOptimizer = "sgd";
 constexpr const char* kAdamOptimizer = "adam";
 constexpr const char* kRMSPropOptimizer = "rmsprop";

--- a/flashlight/app/asr/runtime/Helpers.cpp
+++ b/flashlight/app/asr/runtime/Helpers.cpp
@@ -83,6 +83,21 @@ std::string serializeGflags(const std::string& separator /* = "\n" */) {
   return serialized.str();
 }
 
+float getScaleFactor(const std::unordered_map<std::string, std::string>& cfg) {
+  float scaleFactor;
+  // Check gflags for the scale factor; if not present, use the default
+  auto scaleFactorI = cfg.find(kScaleFactor);
+  if (scaleFactorI == cfg.end()) {
+    LOG(WARNING) << "Did not find scalefactor, using the flag's value.";
+    scaleFactor =
+        FLAGS_fl_amp_use_mixed_precision ? FLAGS_fl_amp_scale_factor : 1.;
+  } else {
+    scaleFactor = std::stof(scaleFactorI->second);
+  }
+  LOG(INFO) << "Using initial scale factor " << scaleFactor;
+  return scaleFactor;
+}
+
 std::unordered_set<int64_t>
 getTrainEvalIds(int64_t dsSize, double pctTrainEval, int64_t seed) {
   std::mt19937_64 rng(seed);

--- a/flashlight/app/asr/runtime/Helpers.h
+++ b/flashlight/app/asr/runtime/Helpers.h
@@ -22,8 +22,8 @@
 
 #include "flashlight/app/asr/common/Defines.h"
 #include "flashlight/app/asr/common/Flags.h"
-#include "flashlight/app/asr/data/ListFileDataset.h"
 #include "flashlight/app/asr/criterion/criterion.h"
+#include "flashlight/app/asr/data/ListFileDataset.h"
 
 #include "flashlight/lib/common/String.h"
 #include "flashlight/lib/text/dictionary/Utils.h"
@@ -52,6 +52,14 @@ std::string cleanFilepath(const std::string& inputFileName);
 std::string serializeGflags(const std::string& separator = "\n");
 
 /**
+ * Gets the initial scale factor to be used by the model. Checks for a value
+ * serialized in a config; if not found, uses a default value.
+ *
+ * @param[in] cfg - the configuration map loaded from the serializer
+ */
+float getScaleFactor(const std::unordered_map<std::string, std::string>& cfg);
+
+/**
  * Sample indices for the `--pcttraineval` flag.
  */
 std::unordered_set<int64_t>
@@ -71,8 +79,8 @@ std::vector<std::string> readSampleIds(const af::array& arr);
  * @param padVal - a tuple of padding values when batching input, target, word
  * @param batchingStrategy - batching strategy for the data, for now "none" and
  * "dynamic"
- * @param maxDurationPerBatch - is used for batchingStrategy="dynamic", max total
- * duration in a batch
+ * @param maxDurationPerBatch - is used for batchingStrategy="dynamic", max
+ * total duration in a batch
  */
 std::shared_ptr<fl::Dataset> createDataset(
     const std::vector<std::string>& paths,
@@ -81,9 +89,8 @@ std::shared_ptr<fl::Dataset> createDataset(
     const fl::Dataset::DataTransformFunction& inputTransform = nullptr,
     const fl::Dataset::DataTransformFunction& targetTransform = nullptr,
     const fl::Dataset::DataTransformFunction& wordTransform = nullptr,
-    const std::tuple<int, int, int>& padVal = std::tuple<int, int, int>{0,
-                                                                        -1,
-                                                                        -1},
+    const std::tuple<int, int, int>& padVal =
+        std::tuple<int, int, int>{0, -1, -1},
     int worldRank = 0,
     int worldSize = 1,
     const bool allowEmpty = false,

--- a/flashlight/app/asr/runtime/Logger.cpp
+++ b/flashlight/app/asr/runtime/Logger.cpp
@@ -32,6 +32,7 @@ std::string getLogString(
     int64_t nupdates,
     double lr,
     double lrcrit,
+    double scaleFactor,
     const std::string& separator /* = " | " */) {
   std::string status;
   auto insertItem = [&](std::string key, std::string val) {
@@ -42,6 +43,7 @@ std::string getLogString(
   insertItem("nupdates", format("%12d", nupdates));
   insertItem("lr", format("%4.6lf", lr));
   insertItem("lrcriterion", format("%4.6lf", lrcrit));
+  insertItem("scale-factor", format("%4.6lf", scaleFactor));
 
   int rt = meters.runtime.value();
   insertItem(

--- a/flashlight/app/asr/runtime/Logger.h
+++ b/flashlight/app/asr/runtime/Logger.h
@@ -56,6 +56,7 @@ std::string getLogString(
     int64_t nupdates,
     double lr,
     double lrcrit,
+    double scaleFactor,
     const std::string& separator = " | ");
 
 void appendToLog(std::ofstream& logfile, const std::string& logstr);

--- a/flashlight/app/asr/tutorial/FinetuneCTC.cpp
+++ b/flashlight/app/asr/tutorial/FinetuneCTC.cpp
@@ -310,18 +310,20 @@ int main(int argc, char** argv) {
     ar(CEREAL_NVP(config));
   }
 
-  auto logStatus =
-      [&logFile, isMaster](
-          TrainMeters& mtrs, int64_t epoch, int64_t nupdates, double lr) {
-        syncMeter(mtrs);
+  auto logStatus = [&logFile, isMaster](
+                       TrainMeters& mtrs,
+                       int64_t epoch,
+                       int64_t nupdates,
+                       double lr) {
+    syncMeter(mtrs);
 
-        if (isMaster) {
-          auto logMsg =
-              getLogString(mtrs, {}, epoch, nupdates, lr, 0 /* lrcrit */);
-          FL_LOG_MASTER(INFO) << logMsg;
-          appendToLog(logFile, logMsg);
-        }
-      };
+    if (isMaster) {
+      auto logMsg = getLogString(
+          mtrs, {}, epoch, nupdates, lr, 0 /* lrcrit */, 1 /* scaleFactor */);
+      FL_LOG_MASTER(INFO) << logMsg;
+      appendToLog(logFile, logMsg);
+    }
+  };
 
   auto saveModels = [&](int iter, int totalUpdates) {
     if (isMaster) {


### PR DESCRIPTION
See title.

Make sure that `continue` and `fork` modes use the previously-saved scale factor from training.

Also log the scale factor when printing output per-update for better diagnostics.

[A chunk of this is clang-format, ignore]

Test plan:
[thanks @tlikhomanenko]

tested on baseline 100h model

![image](https://user-images.githubusercontent.com/7871817/106813766-8bc19c80-6615-11eb-9c85-d0724e911c7f.png)
