### PR TITLE
fix the stability of multiheadAttention for fp16 computation

### DIFF
--- a/flashlight/fl/autograd/Functions.cpp
+++ b/flashlight/fl/autograd/Functions.cpp
@@ -1201,6 +1201,7 @@ fl::Variable multiheadAttention(
   auto k = moddims(key, af::dim4(-1, headDim, nHeads * bsz));
   auto v = moddims(value, af::dim4(-1, headDim, nHeads * bsz));
 
+  q = q / std::sqrt(float(headDim));
   auto scores = matmulNT(q, k);
   if (!posEmb.isempty()) {
     int n = posEmb.dims(0) / 2 - offset;
@@ -1208,7 +1209,6 @@ fl::Variable multiheadAttention(
         relativePositionEmbeddingRotate(matmulNT(posEmb.as(q.type()), q));
     scores = scores + transpose(pscores.rows(n, n + k.dims(0) - 1));
   }
-  scores = scores / std::sqrt(float(headDim));
   if (!mask.isempty()) {
     scores = scores + tileAs(mask.as(scores.type()), scores);
   }


### PR DESCRIPTION
Summary: For fp16 training at some point (even to at the end of training) loss NaN occurs, which is caused by -inf values for all axis for some Time position in self-attention (after softmax this will give nan for attn weight). This is caused by the overflow of matmulNT(q, k) and the same for rel pos emb, which produce these -inf. The fix is to performs scaling before linear operations.

Differential Revision: D26177968

