### PR TITLE
[cpp17] Upgrade - C++ 17 and gcc 7 minimum

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ commands:
             sudo docker exec -it flashlight bash -c "\
             echo 'deb http://archive.ubuntu.com/ubuntu xenial main' | tee /etc/apt/sources.list.d/xenial.list && \
             apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends software-properties-common && \
-            apt-add-repository -r universe apt-add-repository 'deb http://dk.archive.ubuntu.com/ubuntu/ bionic main' && apt-add-repository 'deb http://dk.archive.ubuntu.com/ubuntu/ bionic universe' && apt-get update && \
+            apt-add-repository -r universe && apt-add-repository 'deb http://dk.archive.ubuntu.com/ubuntu/ bionic main' && apt-add-repository 'deb http://dk.archive.ubuntu.com/ubuntu/ bionic universe' && apt-get update && \
             DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gcc-7 g++-7 && \
             export CC=/usr/bin/gcc-7 && export CXX=/usr/bin/g++-7 && \
             wget https://cmake.org/files/v<< parameters.version >>/cmake-<< parameters.version >>.<< parameters.version_build >>-Linux-x86_64.sh && \
@@ -101,10 +101,10 @@ commands:
           command: |
             sudo add-apt-repository ppa:ubuntu-toolchain-r/test
             sudo apt update || true
-            sudo apt install gcc-5 g++-5 -y --no-install-recommends
+            sudo apt install gcc-7 g++-7 -y --no-install-recommends
             sudo rm /usr/bin/gcc /usr/bin/g++
-            sudo ln -s /usr/bin/gcc-5 /usr/bin/gcc
-            sudo ln -s /usr/bin/g++-5 /usr/bin/g++
+            sudo ln -s /usr/bin/gcc-7 /usr/bin/gcc
+            sudo ln -s /usr/bin/g++-7 /usr/bin/g++
   build_vcpkg:
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,8 +67,8 @@ commands:
             echo 'deb http://archive.ubuntu.com/ubuntu xenial main' | tee /etc/apt/sources.list.d/xenial.list && \
             apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends software-properties-common && \
             apt-add-repository -r universe && apt-get update && \
-            DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gcc-5 g++-5 && \
-            export CC=/usr/bin/gcc-5 && export CXX=/usr/bin/g++-5 && \
+            DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gcc-7 g++-7 && \
+            export CC=/usr/bin/gcc-7 && export CXX=/usr/bin/g++-7 && \
             wget https://cmake.org/files/v<< parameters.version >>/cmake-<< parameters.version >>.<< parameters.version_build >>-Linux-x86_64.sh && \
             mkdir /opt/cmake && \
             sh cmake-<< parameters.version >>.<< parameters.version_build >>-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && \
@@ -164,8 +164,8 @@ commands:
             echo "deb http://archive.ubuntu.com/ubuntu xenial main" | tee /etc/apt/sources.list.d/xenial.list
             apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends software-properties-common
             apt-add-repository -r universe && apt-get update
-            DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gcc-5 g++-5
-            export CC=/usr/bin/gcc-5 && export CXX=/usr/bin/g++-5
+            DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gcc-7 g++-7
+            export CC=/usr/bin/gcc-7 && export CXX=/usr/bin/g++-7
             export MKLROOT=/opt/intel/mkl
             cd flashlight && mkdir -p build && cd build
             cmake .. -DFL_BACKEND=CPU -DDNNL_DIR=/opt/onednn/lib/cmake/dnnl -DGloo_DIR=/opt/gloo/share/cmake
@@ -188,7 +188,7 @@ commands:
             set +H
             echo "printf '#include <flashlight/fl/flashlight.h>\nint main() { auto x = fl::constant(1.0, 1); auto y = x + 1; return !fl::allClose(y, x + x); }\n' > main.cpp" >> flashlight_compile_and_link_external_project.sh
             echo "printf 'cmake_minimum_required(VERSION 3.10)\nset(CMAKE_CXX_STANDARD 14)\nset(CMAKE_CXX_STANDARD_REQUIRED ON)\nfind_package(flashlight CONFIG REQUIRED)\nadd_executable(main main.cpp)\ntarget_link_libraries(main PRIVATE flashlight::flashlight)\n' > CMakeLists.txt" >> flashlight_compile_and_link_external_project.sh
-            echo "export CC=/usr/bin/gcc-5 && export CXX=/usr/bin/g++-5 && export MKLROOT=/opt/intel/mkl" >> flashlight_compile_and_link_external_project.sh
+            echo "export CC=/usr/bin/gcc-7 && export CXX=/usr/bin/g++-7 && export MKLROOT=/opt/intel/mkl" >> flashlight_compile_and_link_external_project.sh
             echo "mkdir -p build && cd build && cmake .. -DDNNL_DIR=/opt/onednn/lib/cmake/dnnl && make" >> flashlight_compile_and_link_external_project.sh
             echo "./main" >> flashlight_compile_and_link_external_project.sh
   ############################ Dependency Commands ############################
@@ -264,7 +264,7 @@ commands:
 
 ############################ Jobs ############################
 jobs:
-  ubuntu1604_gcc5_cuda_11_1_vcpkg_flashlight_lib:
+  ubuntu1604_gcc7_cuda_11_1_vcpkg_flashlight_lib:
     <<: *gpu
     steps:
       - checkout
@@ -474,7 +474,7 @@ workflows:
   version: 2
   vcpkg_cuda_test_source_build_and_test:
     jobs:
-      - ubuntu1604_gcc5_cuda_11_1_vcpkg_flashlight_lib
+      - ubuntu1604_gcc7_cuda_11_1_vcpkg_flashlight_lib
   docker_cuda_build_test_and_install:
     jobs:
       - ubuntu2004_cuda11_1_docker_flashlight_lib

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ commands:
             sudo docker exec -it flashlight bash -c "\
             echo 'deb http://archive.ubuntu.com/ubuntu xenial main' | tee /etc/apt/sources.list.d/xenial.list && \
             apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends software-properties-common && \
-            apt-add-repository -r universe && apt-get update && \
+            apt-add-repository -r universe apt-add-repository 'deb http://dk.archive.ubuntu.com/ubuntu/ bionic main' && apt-add-repository 'deb http://dk.archive.ubuntu.com/ubuntu/ bionic universe' && apt-get update && \
             DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gcc-7 g++-7 && \
             export CC=/usr/bin/gcc-7 && export CXX=/usr/bin/g++-7 && \
             wget https://cmake.org/files/v<< parameters.version >>/cmake-<< parameters.version >>.<< parameters.version_build >>-Linux-x86_64.sh && \
@@ -101,10 +101,10 @@ commands:
           command: |
             sudo add-apt-repository ppa:ubuntu-toolchain-r/test
             sudo apt update || true
-            sudo apt install gcc-7 g++-7 -y --no-install-recommends
+            sudo apt install gcc-5 g++-5 -y --no-install-recommends
             sudo rm /usr/bin/gcc /usr/bin/g++
-            sudo ln -s /usr/bin/gcc-7 /usr/bin/gcc
-            sudo ln -s /usr/bin/g++-7 /usr/bin/g++
+            sudo ln -s /usr/bin/gcc-5 /usr/bin/gcc
+            sudo ln -s /usr/bin/g++-5 /usr/bin/g++
   build_vcpkg:
     steps:
       - run:
@@ -163,7 +163,7 @@ commands:
           command: |
             echo "deb http://archive.ubuntu.com/ubuntu xenial main" | tee /etc/apt/sources.list.d/xenial.list
             apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends software-properties-common
-            apt-add-repository -r universe && apt-get update
+            apt-add-repository -r universe && apt-add-repository "deb http://dk.archive.ubuntu.com/ubuntu/ bionic main" && apt-add-repository "deb http://dk.archive.ubuntu.com/ubuntu/ bionic universe" && apt-get update
             DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gcc-7 g++-7
             export CC=/usr/bin/gcc-7 && export CXX=/usr/bin/g++-7
             export MKLROOT=/opt/intel/mkl

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,10 @@ set(FL_BUILD_BINARY_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/bin")
 # CUDA/nvcc setup
 if (FL_USE_CUDA)
   enable_language(CUDA)
-  set(CMAKE_CUDA_STANDARD 17)
+  # The CUDA standard is still C++14 to enable interopability with
+  # slightly older and still well-supported versions of CUDA/nvcc
+  # (e.g. CUDA < 11).
+  set(CMAKE_CUDA_STANDARD 14)
   set(CMAKE_CUDA_STANDARD_REQUIRED ON)
   include(${CMAKE_MODULE_PATH}/CUDAUtils.cmake)
   set_cuda_arch_nvcc_flags()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ if(CCACHE_PROGRAM)
 endif()
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Default directories for installation
@@ -93,7 +93,7 @@ set(FL_BUILD_BINARY_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/bin")
 # CUDA/nvcc setup
 if (FL_USE_CUDA)
   enable_language(CUDA)
-  set(CMAKE_CUDA_STANDARD 14)
+  set(CMAKE_CUDA_STANDARD 17)
   set(CMAKE_CUDA_STANDARD_REQUIRED ON)
   include(${CMAKE_MODULE_PATH}/CUDAUtils.cmake)
   set_cuda_arch_nvcc_flags()

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ D.backward(); // populates A.grad() along with gradients for B, C, and D.
 
 ### Requirements
 At minimum, compilation requires:
-- A C++ compiler with good C++14 support (e.g. gcc/g++ >= 5)
+- A C++ compiler with good C++17 support (e.g. gcc/g++ >= 7)
 - [CMake](https://cmake.org/) — version 3.10 or later, and ``make``
 - A Linux-based operating system.
 
@@ -432,7 +432,7 @@ The following CMake configuration links Flashlight and sets include directories:
 
 ```cmake
 cmake_minimum_required(VERSION 3.10)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_executable(myProject project.cpp)

--- a/flashlight/fl/common/Defines.cpp
+++ b/flashlight/fl/common/Defines.cpp
@@ -13,11 +13,6 @@
 
 namespace fl {
 
-// ODR
-constexpr const char* DistributedConstants::kMaxDevicePerNode;
-constexpr const char* DistributedConstants::kFilePath;
-constexpr const std::size_t DistributedConstants::kCoalesceCacheSize;
-
 OptimLevel OptimMode::getOptimLevel() {
   return optimLevel_;
 }

--- a/flashlight/fl/common/Defines.h
+++ b/flashlight/fl/common/Defines.h
@@ -70,12 +70,12 @@ enum class DistributedInit {
   FILE_SYSTEM = 1,
 };
 
-struct DistributedConstants {
-  static constexpr const char* kMaxDevicePerNode = "MAX_DEVICE_PER_NODE";
-  static constexpr const char* kFilePath = "FILE_PATH";
-  static constexpr const std::size_t kCoalesceCacheSize =
+namespace DistributedConstants {
+  constexpr const char* kMaxDevicePerNode = "MAX_DEVICE_PER_NODE";
+  constexpr const char* kFilePath = "FILE_PATH";
+  constexpr const std::size_t kCoalesceCacheSize =
       ((size_t)(20) << 20); // 20 MB
-};
+}
 
 constexpr std::size_t kDynamicBenchmarkDefaultCount = 10;
 constexpr double kAmpMinimumScaleFactorValue = 1e-4;

--- a/flashlight/fl/examples/CMakeLists.txt
+++ b/flashlight/fl/examples/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(flashlight-examples)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # If building in source, we already have these targets.


### PR DESCRIPTION
Move to C++ 17. Require gcc >= 7. Upgrade CI baselines to use gcc-7.

Test plan:
Manual build and test + CI
