### PR TITLE
Support repeated augmentation

### DIFF
--- a/flashlight/app/imgclass/examples/ImageNetEval.cpp
+++ b/flashlight/app/imgclass/examples/ImageNetEval.cpp
@@ -96,8 +96,10 @@ int main(int argc, char** argv) {
       worldRank,
       worldSize,
       FLAGS_data_batch_size,
-      10,
-      FLAGS_data_batch_size);
+      1, // train_n_repeatedaug
+      10, // prefetch threads
+      FLAGS_data_batch_size,
+      fl::BatchDatasetPolicy::INCLUDE_LAST);
   FL_LOG_MASTER(INFO) << "[testDataset size] " << testDataset.size();
 
   // The main evaluation loop

--- a/flashlight/app/imgclass/examples/ImageNetResnet34.cpp
+++ b/flashlight/app/imgclass/examples/ImageNetResnet34.cpp
@@ -155,16 +155,20 @@ int main(int argc, char** argv) {
       worldRank,
       worldSize,
       batchSizePerGpu,
+      1, // train_n_repeatedaug
       prefetchThreads,
-      prefetchSize);
+      prefetchSize,
+      fl::BatchDatasetPolicy::SKIP_LAST);
 
   auto valDataset = fl::ext::image::DistributedDataset(
       imagenetDataset(valList, labelMap, {valTransforms}),
       worldRank,
       worldSize,
       batchSizePerGpu,
+      1, // train_n_repeatedaug
       prefetchThreads,
-      prefetchSize);
+      prefetchSize,
+      fl::BatchDatasetPolicy::INCLUDE_LAST);
 
   //////////////////////////
   //  Load model and optimizer
@@ -215,7 +219,7 @@ int main(int argc, char** argv) {
   AverageValueMeter trainLossMeter;
   for (int epoch = (FLAGS_exp_checkpoint_epoch + 1); epoch < FLAGS_train_epochs;
        epoch++) {
-    trainDataset.resample();
+    trainDataset.resample(epoch);
     lrScheduler(epoch);
 
     // Get an iterator over the data

--- a/flashlight/app/objdet/examples/ImageNetResnet50Backbone.cpp
+++ b/flashlight/app/objdet/examples/ImageNetResnet50Backbone.cpp
@@ -12,10 +12,10 @@
 #include <glog/logging.h>
 
 #include "flashlight/app/imgclass/dataset/Imagenet.h"
+#include "flashlight/app/objdet/models/Resnet50Backbone.h"
 #include "flashlight/ext/common/DistributedUtils.h"
 #include "flashlight/ext/image/af/Transforms.h"
 #include "flashlight/ext/image/fl/dataset/DistributedDataset.h"
-#include "flashlight/app/objdet/models/Resnet50Backbone.h"
 #include "flashlight/fl/dataset/datasets.h"
 #include "flashlight/fl/meter/meters.h"
 #include "flashlight/fl/optim/optim.h"
@@ -154,16 +154,20 @@ int main(int argc, char** argv) {
       worldRank,
       worldSize,
       batchSizePerGpu,
+      1, // train_n_repeatedaug
       prefetchThreads,
-      prefetchSize);
+      prefetchSize,
+      fl::BatchDatasetPolicy::INCLUDE_LAST);
 
   auto valDataset = fl::ext::image::DistributedDataset(
       imagenetDataset(valList, labelMap, {valTransforms}),
       worldRank,
       worldSize,
       batchSizePerGpu,
+      1, // train_n_repeatedaug
       prefetchThreads,
-      prefetchSize);
+      prefetchSize,
+      fl::BatchDatasetPolicy::INCLUDE_LAST);
 
   //////////////////////////
   //  Load model and optimizer

--- a/flashlight/ext/image/fl/dataset/DistributedDataset.h
+++ b/flashlight/ext/image/fl/dataset/DistributedDataset.h
@@ -20,12 +20,14 @@ class DistributedDataset : public Dataset {
       int64_t worldRank,
       int64_t worldSize,
       int64_t batchSize,
+      int64_t nRepeated,
       int64_t numThreads,
-      int64_t prefetchSize);
+      int64_t prefetchSize,
+      BatchDatasetPolicy batchpolicy = fl::BatchDatasetPolicy::INCLUDE_LAST);
 
   std::vector<af::array> get(const int64_t idx) const override;
 
-  void resample();
+  void resample(const int seed = 0);
 
   int64_t size() const override;
 

--- a/flashlight/fl/dataset/ShuffleDataset.cpp
+++ b/flashlight/fl/dataset/ShuffleDataset.cpp
@@ -21,9 +21,13 @@ ShuffleDataset::ShuffleDataset(
 void ShuffleDataset::resample() {
   std::iota(resampleVec_.begin(), resampleVec_.end(), 0);
   auto n = resampleVec_.size();
-  // custom implementation of shuffle - https://stackoverflow.com/a/51931164
-  for (auto i = n; i >= 1; --i) {
-    std::swap(resampleVec_[i - 1], resampleVec_[rng_() % n]);
+  // custom implementation of shuffle -
+  // en.cppreference.com/w/cpp/algorithm/random_shuffle#Possible_implementation
+  using distr_t = std::uniform_int_distribution<unsigned int>;
+  distr_t D;
+  for (int i = n - 1; i > 0; --i) {
+    std::swap(
+        resampleVec_[i], resampleVec_[D(rng_, distr_t::param_type(0, i))]);
   }
 }
 


### PR DESCRIPTION
Summary:
- In each epoch using only `1/nRepeated` data from the whole dataset
- Keeping `nRepeated` repetitions of each sample in the same batch. (Note: this is done approximately)

- PT impl: https://github.com/facebookresearch/deit/blob/38fcfbd8635f356a476e337c5983f4d3556b01c4/samplers.py

Reviewed By: tlikhomanenko

Differential Revision: D27380612

