### PR TITLE
Support AMP in LM training

### DIFF
--- a/flashlight/app/lm/Trainer.cpp
+++ b/flashlight/app/lm/Trainer.cpp
@@ -191,6 +191,33 @@ DEFINE_int64(
     1,
     "[mask lm task] Min number of masked tokens in each sample.");
 
+/* AMP OPTIONS */
+DEFINE_bool(
+    fl_amp_use_mixed_precision,
+    false,
+    "[train] Use mixed precision for training - scale loss and gradients up and down "
+    "by a scale factor that changes over time. If no fl optim mode is "
+    "specified with --fl_optim_mode when passing this flag, automatically "
+    "sets the optim mode to O1.");
+DEFINE_double(
+    fl_amp_scale_factor,
+    65536.,
+    "[train] Starting scale factor to use for loss scaling "
+    " with mixed precision training");
+DEFINE_uint64(
+    fl_amp_scale_factor_update_interval,
+    2000,
+    "[train] Update interval for adjusting loss scaling in mixed precision training");
+DEFINE_double(
+    fl_amp_max_scale_factor,
+    65536.,
+    "[train] Maximum value for the loss scale factor in mixed precision training");
+DEFINE_string(
+    fl_optim_mode,
+    "",
+    "[train] Sets the flashlight optimization mode. "
+    "Optim modes can be O1, O2, or O3.");
+
 /* ================================ Trainer ================================ */
 
 /* ============= Public functions ============= */
@@ -209,12 +236,21 @@ Trainer::Trainer(const std::string& mode) {
     throw std::invalid_argument("Trainer doesn't support mode: " + mode);
   }
   checkArgs();
-  gflagsStr_ = fl::ext::serializeGflags();
+  gflagsStr_ = serializeGflags();
   FL_LOG_MASTER(INFO) << "Gflags after parsing \n" << serializeGflags("; ");
 
   initArrayFire();
   if (FLAGS_distributed_enable) {
     reducer_ = std::make_shared<fl::CoalescingReducer>(1.0, true, true);
+  }
+
+  if (FLAGS_fl_amp_use_mixed_precision) {
+    FL_LOG_MASTER(INFO)
+        << "Mixed precision training enabled. Will perform loss scaling.";
+    auto flOptimLevel = FLAGS_fl_optim_mode.empty()
+        ? fl::OptimLevel::DEFAULT
+        : fl::OptimMode::toOptimLevel(FLAGS_fl_optim_mode);
+    fl::OptimMode::get().setOptimLevel(flOptimLevel);
   }
 
   FL_LOG_MASTER(INFO) << "network (" << fl::numTotalParams(network_)
@@ -287,6 +323,7 @@ void Trainer::trainStep() {
   network_->train();
   criterion_->train();
   setLr();
+  bool skipBatch = false;
 
   // 1. Sample
   fl::Variable input, target;
@@ -301,15 +338,37 @@ void Trainer::trainStep() {
   af::sync();
   critFwdTimeMeter_.resume();
   auto loss = criterion_->forward({output, target}).front();
+
+  if (FLAGS_fl_amp_use_mixed_precision) {
+    ++scaleCounter_;
+    loss = loss * scaleFactor_;
+
+    auto scaledLoss = loss.array() / fl::getWorldSize();
+    if (FLAGS_distributed_enable) {
+      fl::allReduce(scaledLoss);
+    }
+    if (isInvalidArray(scaledLoss)) {
+      FL_LOG_MASTER(INFO) << "AMP: Loss has NaN values";
+      scaleFactor_ = scaleFactor_ / 2.0f;
+      FL_LOG_MASTER(INFO)
+          << "AMP: Scale factor decreased (loss). New value :\t "
+          << scaleFactor_;
+      skipBatch = true;
+    }
+  }
   af::sync();
   fwdTimeMeter_.stopAndIncUnit();
   critFwdTimeMeter_.stopAndIncUnit();
+  if (skipBatch) {
+    return;
+  }
 
   float numTokens = af::count<float>(target.array() != kPadIdx_);
   if (numTokens > 0) {
     auto weight =
         numTokens / (FLAGS_data_tokens_per_sample * FLAGS_data_batch_size);
-    trainLossMeter_.add(af::mean<float>(loss.array()) / numTokens, weight);
+    trainLossMeter_.add(
+        af::mean<float>(loss.array()) / (numTokens * scaleFactor_), weight);
     tokenCountMeter_.add(numTokens);
   }
 
@@ -323,8 +382,36 @@ void Trainer::trainStep() {
   loss = loss / fl::Variable(numTokensArr, false);
   loss.backward();
   reduceGrads();
+
+  if (FLAGS_fl_amp_use_mixed_precision) {
+    for (auto& p : parameters_) {
+      p.grad() = p.grad() / scaleFactor_;
+      if (isInvalidArray(p.grad().array())) {
+        FL_LOG_MASTER(INFO) << "AMP: Grad has NaN values in 3";
+        if (scaleFactor_ >= fl::kAmpMinimumScaleFactorValue) {
+          scaleFactor_ = scaleFactor_ / 2.0f;
+          FL_LOG_MASTER(INFO)
+              << "AMP: Scale factor decreased (grad). New value:\t"
+              << scaleFactor_;
+          skipBatch = true;
+        } else {
+          FL_LOG(FATAL) << "Minimum loss scale reached: "
+                        << fl::kAmpMinimumScaleFactorValue
+                        << " with over/underflowing gradients. Lowering the "
+                        << "learning rate, using gradient clipping, or "
+                        << "increasing the batch size can help resolve "
+                        << "loss explosion.";
+        }
+        scaleCounter_ = 1;
+        break;
+      }
+    }
+  }
   af::sync();
   bwdTimeMeter_.stopAndIncUnit();
+  if (skipBatch) {
+    return;
+  }
 
   // 4. Optimization
   optimTimeMeter_.resume();
@@ -332,6 +419,18 @@ void Trainer::trainStep() {
   optimizer_->step();
   af::sync();
   optimTimeMeter_.stopAndIncUnit();
+
+  if (FLAGS_fl_amp_use_mixed_precision &&
+      scaleFactor_ < FLAGS_fl_amp_max_scale_factor) {
+    if (scaleCounter_ % FLAGS_fl_amp_scale_factor_update_interval == 0) {
+      scaleFactor_ *= 2;
+      FL_VLOG(2) << "AMP: Scale factor doubled. New value:\t" << scaleFactor_;
+    } else {
+      scaleFactor_ += 2;
+      FL_VLOG(3) << "AMP: Scale factor incremented. New value\t"
+                 << scaleFactor_;
+    }
+  }
 }
 
 void Trainer::evalStep() {
@@ -372,6 +471,10 @@ void Trainer::initTrain() {
 
   createTrainDatasets();
   createValidDatasets();
+
+  scaleCounter_ = 1;
+  scaleFactor_ =
+      FLAGS_fl_amp_use_mixed_precision ? FLAGS_fl_amp_scale_factor : 1.;
 }
 
 void Trainer::initContinue() {
@@ -390,7 +493,9 @@ void Trainer::initContinue() {
       optimizer_,
       epoch_,
       batchIdx_,
-      gflagsStr_);
+      gflagsStr_,
+      scaleCounter_,
+      scaleFactor_);
 
   // overwrite flags using the ones from command line
   gflags::ReadFlagsFromString(gflagsStr_, gflags::GetArgv0(), true);
@@ -418,7 +523,9 @@ void Trainer::initFork() {
       criterion_,
       dummyOptimizer,
       epoch_,
-      batchIdx_);
+      batchIdx_,
+      scaleCounter_,
+      scaleFactor_);
 
   createDictionary();
   createOptimizer();
@@ -766,7 +873,9 @@ void Trainer::saveCheckpoint(const std::string& path, const std::string& suffix)
       optimizer_,
       epoch_,
       batchIdx_,
-      gflagsStr_);
+      gflagsStr_,
+      scaleCounter_,
+      scaleFactor_);
 
   if (!suffix.empty()) {
     Serializer::save(
@@ -777,7 +886,9 @@ void Trainer::saveCheckpoint(const std::string& path, const std::string& suffix)
         optimizer_,
         epoch_,
         batchIdx_,
-        gflagsStr_);
+        gflagsStr_,
+        scaleCounter_,
+        scaleFactor_);
   }
 }
 
@@ -819,6 +930,7 @@ std::string Trainer::getProgress() const {
              tokenCountMeter_.value()[0] * fl::getWorldSize() /
                  batchTimerMeter_.value());
   oss << " | Learning Rate " << format("%.6f", optimizer_->getLr());
+  oss << " | Scale factor " << format("%.6f", scaleFactor_);
   // Losses
   double loss = trainLossMeter_.value()[0];
   oss << " | Loss: " << format("%.2f", loss)

--- a/flashlight/app/lm/Trainer.h
+++ b/flashlight/app/lm/Trainer.h
@@ -87,6 +87,13 @@ DECLARE_double(mask_rand_token_prob);
 DECLARE_double(mask_same_token_prob);
 DECLARE_int64(mask_min_length);
 
+/* AMP OPTIONS */
+DECLARE_bool(fl_amp_use_mixed_precision);
+DECLARE_double(fl_amp_scale_factor);
+DECLARE_uint64(fl_amp_scale_factor_update_interval);
+DECLARE_double(fl_amp_max_scale_factor);
+DECLARE_string(fl_optim_mode);
+
 class Trainer {
  public:
   explicit Trainer(const std::string& mode);
@@ -111,6 +118,8 @@ class Trainer {
   int kPadIdx_, kEosIdx_, kUnkIdx_, kMaskIdx_;
   std::string gflagsStr_;
   std::string version_{FL_APP_LM_VERSION};
+  unsigned short scaleCounter_;
+  double scaleFactor_;
 
   fl::lib::text::Dictionary dictionary_;
   std::shared_ptr<TextDataset> trainDataset_;

--- a/flashlight/app/lm/plugins/LMAdae1024SinposL16H8Fc4096Dp01Ldp0Amp.cpp
+++ b/flashlight/app/lm/plugins/LMAdae1024SinposL16H8Fc4096Dp01Ldp0Amp.cpp
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "flashlight/fl/contrib/modules/modules.h"
+#include "flashlight/fl/flashlight.h"
+#include "flashlight/fl/nn/modules/modules.h"
+
+/**
+ * This is example of plugin for language model architecture which is expected
+ * the input with size Time x Batch x 1 x 1 and used with the adaptive softmax
+ * as criterion (so the last linear layer is absent here)
+ * This architecture is using also adaptive embedding and sinusoidal positional
+ * embedding.
+ */
+class LmModel : public fl::Container {
+ public:
+  LmModel(int64_t nLabel) {
+    // Time x B x 1 x 1
+    std::vector<int> cutoffs = {10000, 50000, (int)nLabel};
+    frontend_ = std::make_shared<fl::Sequential>();
+    frontend_->add(std::make_shared<fl::AdaptiveEmbedding>(1024, cutoffs));
+    // nFeature x Time x B x 1
+    frontend_->add(std::make_shared<fl::SinusoidalPositionEmbedding>(1024, 32));
+    frontend_->add(std::make_shared<fl::Dropout>(0.1));
+    // nFeature x Time x Batch x 1
+    add(frontend_);
+    for (int trIdx = 0; trIdx < 16; trIdx++) {
+      auto layer = std::make_shared<fl::Transformer>(
+          1024, 128, 4096, 8, 0, 0.1, 0., true, false);
+      transformers_.push_back(layer);
+      add(layer);
+    }
+  }
+
+  std::vector<fl::Variable> forward(
+      const std::vector<fl::Variable>& input) override {
+    auto out = input[0];
+    // Avoid fp16 usage in any embedding-ralated calls.
+    out = frontend_->forward(out);
+
+    // Run all transformer forward passes in fp16
+    out = out.as(f16);
+    for (int trIdx = 0; trIdx < transformers_.size(); trIdx++) {
+      out = transformers_[trIdx]->forward({out, fl::Variable()}).front();
+    }
+
+    // Make sure passing fp32 tensor to criterion.
+    // Avoid fp16 usage in any embedding-ralated calls.
+    return {out.as(f32)};
+  }
+
+  std::string prettyString() const override {
+    std::ostringstream ss;
+    ss << "LmModel: ";
+    ss << frontend_->prettyString() << "\n";
+    for (int trIdx = 0; trIdx < transformers_.size(); trIdx++) {
+      ss << transformers_[trIdx]->prettyString() << "\n";
+    }
+    return ss.str();
+  }
+
+ private:
+  LmModel() = default;
+
+  std::shared_ptr<fl::Sequential> frontend_;
+  std::vector<std::shared_ptr<fl::Transformer>> transformers_;
+
+  FL_SAVE_LOAD_WITH_BASE(fl::Container, frontend_, transformers_)
+};
+
+extern "C" fl::Module* createModule(int64_t, int64_t nLabel) {
+  auto m = std::make_unique<LmModel>(nLabel);
+  return m.release();
+}
+
+CEREAL_REGISTER_TYPE(LmModel)

--- a/flashlight/ext/common/Runtime.cpp
+++ b/flashlight/ext/common/Runtime.cpp
@@ -36,5 +36,9 @@ std::string serializeGflags(const std::string& separator) {
   return serialized.str();
 }
 
+bool isInvalidArray(const af::array& arr) {
+  return af::anyTrue<bool>(af::isNaN(arr)) || af::anyTrue<bool>(af::isInf(arr));
+}
+
 } // end namespace ext
 } // end namespace fl

--- a/flashlight/ext/common/Runtime.h
+++ b/flashlight/ext/common/Runtime.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include "flashlight/fl/flashlight.h"
+
 namespace fl {
 namespace ext {
 /**
@@ -19,6 +21,11 @@ getRunFile(const std::string& name, int runidx, const std::string& runpath);
  * Serialize gflags into a buffer.
  */
 std::string serializeGflags(const std::string& separator = "\n");
+
+/**
+ * Check if an array contains any NAN or INF.
+ */
+bool isInvalidArray(const af::array& arr);
 
 } // namespace ext
 } // namespace fl


### PR DESCRIPTION
Summary:
As title.

Optimal solution for now is to run all transformer blocks in fp16, but avoid it on any embedding-related stuff (e.g. front-end and adaptive softmax).

Differential Revision: D27712801

